### PR TITLE
fix bug with deployment babysitter diffs on creation/deletion events

### DIFF
--- a/playbooks/deployment_babysitter.py
+++ b/playbooks/deployment_babysitter.py
@@ -25,7 +25,7 @@ def babysitter_should_include_diff(diff_detail: DiffDetail, config: BabysitterCo
 def do_babysitter(
     event: K8sBaseEvent, config: BabysitterConfig, resource_type: FindingSubjectType
 ):
-    filtered_diffs = None
+    filtered_diffs = []
     if event.operation == K8sOperationType.UPDATE:
         all_diffs = event.obj.diff(event.old_obj)
         filtered_diffs = list(

--- a/src/robusta/core/reporting/blocks.py
+++ b/src/robusta/core/reporting/blocks.py
@@ -70,8 +70,8 @@ class ListBlock(BaseBlock):
 # TODO: we should add a generalization of this which isn't K8s specific
 class KubernetesDiffBlock(BaseBlock):
     diffs: List[DiffDetail]
-    old: str
-    new: str
+    old: Optional[str]
+    new: Optional[str]
 
     # note that interesting_diffs might be a subset of the full diff between old and new
     def __init__(
@@ -91,7 +91,7 @@ class KubernetesDiffBlock(BaseBlock):
         if obj is None:
             return ""
         else:
-            return hikaru.get_yaml(old)
+            return hikaru.get_yaml(obj)
 
 
 class JsonBlock(BaseBlock):

--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -65,6 +65,10 @@ class SlackSender:
 
     @staticmethod
     def __to_slack_diff(block: KubernetesDiffBlock, sink_name: str) -> List[SlackBlock]:
+        # this can happen when a block.old=None or block.new=None - e.g. the resource was added or deleted
+        if not block.diffs:
+            return []
+
         num_additions = len([d for d in block.diffs if d.diff_type == DiffType.ADDED])
         num_subtractions = len(
             [d for d in block.diffs if d.diff_type == DiffType.REMOVED]


### PR DESCRIPTION
This should fix the bug that we saw in logs earlier today.