### PR TITLE
Update kubewatch version to latest

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -1,6 +1,6 @@
 
 kubewatch:
-  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v1.10
+  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v1.11
   pprof: True
   resources:
     requests:


### PR DESCRIPTION
I updated Kubewatch's base image to remove vulnerabilities. We should do some extra testing on this before the next release due to the change.