### PR TITLE
update grafana renderer image

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -9,7 +9,7 @@ kubewatch:
       cpu: ~
 
 grafana_renderer:
-  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/grafana-renderer:4
+  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/grafana-renderer:5
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
I've updated the base image for grafana-renderer to a version of alpine with no vulnerabilities.