### PR TITLE
update debug-toolkit to new image

### DIFF
--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -14,7 +14,7 @@ from .templates import get_deployment_yaml
 S = TypeVar("S")
 T = TypeVar("T")
 PYTHON_DEBUGGER_IMAGE = (
-    "us-central1-docker.pkg.dev/genuine-flight-317411/devel/python-tools:v2"
+    "us-central1-docker.pkg.dev/genuine-flight-317411/devel/debug-toolkit:v2"
 )
 
 


### PR DESCRIPTION
This renames the image to something more consistent with the name used elsewhere.

The newer image also contains one minor fix: see
https://github.com/robusta-dev/debug-toolkit/commit/6a267895d561608deffa7f939cb36ad09f6e84e2