### PR TITLE
Fix stop_execution for actions under the same trigger

### DIFF
--- a/src/robusta/core/playbooks/playbooks_event_handler_impl.py
+++ b/src/robusta/core/playbooks/playbooks_event_handler_impl.py
@@ -131,6 +131,9 @@ class PlaybooksEventHandlerImpl(PlaybooksEventHandler):
         self.__prepare_execution_event(execution_event)
         execution_event.response = {"success": True}
         for action in actions:
+            if execution_event.stop_processing:
+                return execution_event.response
+
             registered_action = self.registry.get_actions().get_action(
                 action.action_name
             )


### PR DESCRIPTION
I encountered this when working on the HighCPUThrottling enricher. Its appears in the default list of playbooks as:

```
- triggers:
  - on_prometheus_alert:
      alert_name: CPUThrottlingHigh
  actions:
  - cpu_throttling_analysis_enricher: {}
  - graph_enricher: {}
```

Even when `cpu_throttling_analysis_enricher` attempts to silence an alert by setting `stop_execution`, a finding is still created by `graph_enricher` which runs despite the attempt to stop execution.