### PR TITLE
add `exec_on_node`

### DIFF
--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -134,6 +134,14 @@ class RobustaPod(Pod):
         return debugger
 
     @staticmethod
+    def exec_on_node(pod_name: str, node_name: str, cmd):
+        node_runner = RobustaPod.create_debugger_pod(pod_name, node_name)
+        try:
+            node_runner.exec(f"nsenter -t 1 -a {cmd}")
+        finally:
+            node_runner.delete()
+
+    @staticmethod
     def exec_in_debugger_pod(
         pod_name: str, node_name: str, cmd, debug_image=PYTHON_DEBUGGER_IMAGE
     ) -> str:


### PR DESCRIPTION
This adds a new function to run a command on a node as an alternative to the eixsting `exec_in_debugger_pod`.

Actions like `node_bash_enricher` currently use `exec_in_debugger_pod` which means that they can't access the host filesystem and binaries of the node itself. The new `exec_on_node`  function works around that by using `nsenter`.

This new function was necessary to implement an as-of-now unreleased playbook which needed to run `systemctl` commands on the node.

For reference, please see https://github.com/kvaps/kubectl-node-shell/blob/master/kubectl-node_shell

Next steps:
1. Consider updating the existing `node_bash_enricher` to use this function
2. Consider adding tolerations in `exec_on_node` just like https://github.com/kvaps/kubectl-node-shell/blob/master/kubectl-node_shell