### PR TITLE
improve default finding for kubernetes changes

### DIFF
--- a/src/robusta/integrations/kubernetes/base_event.py
+++ b/src/robusta/integrations/kubernetes/base_event.py
@@ -20,7 +20,17 @@ class K8sBaseChangeEvent(ExecutionBaseEvent):
     old_obj: Optional[HikaruDocumentBase] = None  # same above
 
     def create_default_finding(self) -> Finding:
-        title = f"Kubernetes change: operation: {self.operation}"
+        if (
+            self.obj
+            and hasattr(self.obj, "metadata")
+            and hasattr(self.obj.metadata, "name")
+        ):
+            # hikaru's docs say `kind` always exists on HikaruDocumentBase, but its not clear from hikaru's code
+            kind = getattr(self.obj, "kind", "").lower()
+            title = f"{self.operation.value.capitalize()} to {kind} {self.obj.metadata.name}"
+        else:
+            title = f"Kubernetes {self.operation.value.lower()}"
+
         return Finding(
             title=title,
             aggregation_key=title,


### PR DESCRIPTION
This improves the default finding for K8sBaseChangeEvent.

Old:
![image](https://user-images.githubusercontent.com/494087/144755052-2315190c-26e7-45e4-a051-087bd529db05.png)

New:
![image](https://user-images.githubusercontent.com/494087/144755062-01394e22-089c-4e95-b854-ef187098b48a.png)
