### PR TITLE
add spinner to guess_cluster_name

### DIFF
--- a/src/robusta/cli/main.py
+++ b/src/robusta/cli/main.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 import urllib.request
 import uuid
+import click_spinner
 from distutils.version import StrictVersion
 from typing import Optional
 from zipfile import ZipFile
@@ -72,14 +73,15 @@ def slack_integration(
 
 
 def guess_cluster_name():
-    try:
-        all_contexts, current_context = config.list_kube_config_contexts()
-        if current_context and current_context.get("name"):
-            return current_context.get("name")
-    except Exception:  # this happens, for example, if you don't have a kubeconfig file
-        typer.echo("Error reading kubeconfig to generate cluster name")
+    with click_spinner.spinner():
+        try:
+            all_contexts, current_context = config.list_kube_config_contexts()
+            if current_context and current_context.get("name"):
+                return current_context.get("name")
+        except Exception:  # this happens, for example, if you don't have a kubeconfig file
+            typer.echo("Error reading kubeconfig to generate cluster name")
 
-    return f"cluster_{random.randint(0, 1000000)}"
+        return f"cluster_{random.randint(0, 1000000)}"
 
 
 @app.command()


### PR DESCRIPTION
This adds a spinner to gen-config when it fetches information about the clusters.

I don't know *why* fetching cluster information can take a while, but we saw it happen on a recent install. I want users to at least know that something is happening and not think that Robusta is stuck.