### PR TITLE
break installation steps for ease of use. add pip3 step to solve path…

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -9,45 +9,29 @@ The standard installation uses Helm and the robusta-cli, but :ref:`other alterna
 Standard Installation
 ------------------------------
 
-1. Download the Helm chart:
+1. Download the Helm chart and generate a Robusta configuration. This will setup Slack and other integrations.
 
 .. code-block:: bash
 
-    helm repo add robusta https://robusta-charts.storage.googleapis.com && helm repo update
-
-2. Install Robusta-CLI:
-
-.. code-block::
-
-    pip install robusta-cli
+   helm repo add robusta https://robusta-charts.storage.googleapis.com && helm repo update
+   pip install -U robusta-cli --no-cache
+   robusta gen-config
 
 .. warning:: If you are using a system such as macOS that includes both Python 2 and Python 3, run pip3 instead of pip.
 
-3. Generate a Robusta configuration. This will setup Slack and other integrations.
-    
-.. code-block::
+2. Save ``generated_values.yaml``, somewhere safe. This is your Helm ``values.yaml`` file.
 
-    robusta gen-config
-
-4. Save ``generated_values.yaml``, somewhere safe. This is your Helm ``values.yaml`` file.
-
-5. Install Robusta using Helm:
+3. Install Robusta using Helm:
 
 .. code-block:: bash
 
     helm install robusta robusta/robusta -f ./generated_values.yaml
 
-6. Verify that Robusta installed two deployments in the current namespace:
+4. Verify that Robusta installed two deployments in the current namespace:
 
 .. code-block:: bash
 
     kubectl get pods
-
-.. admonition:: Common errors
-    :class: caution
-
-    * Permissions error: re-run the command as root or append ``--user`` to the command
-    * ``robusta`` not found error: add `Python's script directory to PATH <https://www.makeuseof.com/python-windows-path/>`_ before you run ``robusta gen-config``
 
 Seeing Robusta in action
 ------------------------------

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -9,17 +9,19 @@ The standard installation uses Helm and the robusta-cli, but :ref:`other alterna
 Standard Installation
 ------------------------------
 
-1. Download the Helm chart 
+1. Download the Helm chart:
 
 .. code-block:: bash
 
     helm repo add robusta https://robusta-charts.storage.googleapis.com && helm repo update
 
-2. Install Robusta-CLI
+2. Install Robusta-CLI:
 
 .. code-block::
 
-    pip3 install robusta-cli
+    pip install robusta-cli
+
+.. warning:: If you are using a system such as macOS that includes both Python 2 and Python 3, run pip3 instead of pip.
 
 3. Generate a Robusta configuration. This will setup Slack and other integrations.
     

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -9,23 +9,33 @@ The standard installation uses Helm and the robusta-cli, but :ref:`other alterna
 Standard Installation
 ------------------------------
 
-1. Download the Helm chart and generate a Robusta configuration. This will setup Slack and other integrations.
+1. Download the Helm chart 
 
 .. code-block:: bash
 
-   helm repo add robusta https://robusta-charts.storage.googleapis.com && helm repo update
-   python3 -m pip install -U robusta-cli --no-cache
-   robusta gen-config
+    helm repo add robusta https://robusta-charts.storage.googleapis.com && helm repo update
 
-2. Save ``generated_values.yaml``, somewhere safe. This is your Helm ``values.yaml`` file.
+2. Install Robusta-CLI
 
-3. Install Robusta using Helm:
+.. code-block::
+
+    pip3 install robusta-cli
+
+3. Generate a Robusta configuration. This will setup Slack and other integrations.
+    
+.. code-block::
+
+    robusta gen-config
+
+4. Save ``generated_values.yaml``, somewhere safe. This is your Helm ``values.yaml`` file.
+
+5. Install Robusta using Helm:
 
 .. code-block:: bash
 
     helm install robusta robusta/robusta -f ./generated_values.yaml
 
-4. Verify that Robusta installed two deployments in the current namespace:
+6. Verify that Robusta installed two deployments in the current namespace:
 
 .. code-block:: bash
 

--- a/docs/user-guide/robusta-cli.rst
+++ b/docs/user-guide/robusta-cli.rst
@@ -7,7 +7,9 @@ The robusta cli is installed via pip:
 
 .. code-block::
 
-    pip3 install robusta-cli
+    pip install robusta-cli
+
+.. warning:: If you are using a system such as macOS that includes both Python 2 and Python 3, run pip3 instead of pip.
 
 Using the cli
 ---------------------

--- a/docs/user-guide/robusta-cli.rst
+++ b/docs/user-guide/robusta-cli.rst
@@ -7,7 +7,7 @@ The robusta cli is installed via pip:
 
 .. code-block::
 
-    pip install robusta-cli
+    pip3 install robusta-cli
 
 Using the cli
 ---------------------


### PR DESCRIPTION
other solution is to use the python prefix. lets discuss this.