### PR TITLE
Improve the way that the python_memory action chooses which process to profile

### DIFF
--- a/playbooks/robusta_playbooks/pod_troubleshooting.py
+++ b/playbooks/robusta_playbooks/pod_troubleshooting.py
@@ -3,6 +3,7 @@ import json
 import textwrap
 import humanize
 from robusta.api import *
+from robusta.utils.parsing import load_json
 from typing import List
 
 
@@ -10,7 +11,7 @@ class StartProfilingParams(ActionParams):
     """
     :var seconds: Profiling duration.
     :var process_name: Profiled process name prefix.
-    :var include_idle: Inclide idle threads
+    :var include_idle: Include idle threads
     """
 
     seconds: int = 2
@@ -116,13 +117,11 @@ def pod_ps(event: PodEvent):
     event.add_finding(finding)
 
 
-class MemoryTraceParams(ActionParams):
+class MemoryTraceParams(PythonProcessParams):
     """
     :var seconds: Memory allocations analysis duration.
-    :var process_substring: Inspected process name prefix.
     """
 
-    process_substring: str
     seconds: int = 60
 
 
@@ -159,11 +158,6 @@ def python_memory(event: PodEvent, params: MemoryTraceParams):
         logging.info(f"python_memory - pod not found for event: {event}")
         return
 
-    find_pid_cmd = f"debug-toolkit find-pid '{pod.metadata.uid}' '{params.process_substring}' python"
-    cmd = f"debug-toolkit memory --seconds={params.seconds} `{find_pid_cmd}`"
-    output = RobustaPod.exec_in_debugger_pod(pod.metadata.name, pod.spec.nodeName, cmd)
-    snapshot = PythonMemorySnapshot(**json.loads(output))
-
     finding = Finding(
         title=f"Memory allocations for {pod.metadata.name} in namespace {pod.metadata.namespace}:",
         source=FindingSource.MANUAL,
@@ -174,6 +168,19 @@ def python_memory(event: PodEvent, params: MemoryTraceParams):
             pod.metadata.namespace,
         ),
     )
+    event.add_finding(finding)
+
+    all_processes = pod.get_processes()
+    if not params.has_exactly_one_match(all_processes):
+        finding.add_enrichment(
+            params.get_retrigger_blocks(all_processes, pod, "Profile", python_memory)
+        )
+        return
+
+    pid = params.get_exact_match(all_processes).pid
+    cmd = f"debug-toolkit memory --seconds={params.seconds} {pid}"
+    output = RobustaPod.exec_in_debugger_pod(pod.metadata.name, pod.spec.nodeName, cmd)
+    snapshot = PythonMemorySnapshot(**load_json(output))
 
     blocks = [
         HeaderBlock("Summary"),
@@ -194,18 +201,12 @@ def python_memory(event: PodEvent, params: MemoryTraceParams):
     event.add_finding(finding)
 
 
-class DebuggerParams(ActionParams):
+class DebuggerParams(PythonProcessParams):
     """
-    :var process_substring: Debugged process name prefix.
-    :var pid: Process id of the target process.
-    :var port: Debugging port.
-    :var interactive: If more than one process is matched, interactively ask which process to debug via Slack. Note that you won't receive immediate output in Slack after clicking a button. It takes about 30-60 seconds for the playbook to finish running.
+    :var port: debugging port.
     """
 
-    process_substring: str = ""
-    pid: int = None
     port: int = 5678
-    interactive: bool = True
 
 
 def get_example_launch_json(params: DebuggerParams):
@@ -260,53 +261,6 @@ def get_debugger_warnings(data):
     return message
 
 
-def get_relevant_processes(all_processes: List[Process], params: DebuggerParams):
-    pid_to_process = {p.pid: p for p in all_processes}
-
-    if params.pid is None:
-        return [
-            p
-            for p in pid_to_process.values()
-            if "python" in p.exe and params.process_substring in " ".join(p.cmdline)
-        ]
-
-    if params.pid not in pid_to_process:
-        return []
-
-    return [pid_to_process[params.pid]]
-
-
-def get_process_blocks(
-    processes: List[Process], pod: RobustaPod, params: DebuggerParams
-) -> List[BaseBlock]:
-    blocks = [
-        TableBlock(
-            [[p.pid, p.exe, " ".join(p.cmdline)] for p in processes],
-            ["pid", "exe", "cmdline"],
-        ),
-    ]
-    # we don't enable this by default because it is bad UX. if you press a callback buttons then nothing
-    # seems to happen for 60 seconds while the playbook runs
-    if params.interactive:
-        choices = {}
-        for proc in processes:
-            updated_params = params.copy()
-            updated_params.process_substring = ""
-            updated_params.pid = proc.pid
-            choices[f"Debug {proc.pid}"] = CallbackChoice(
-                action=python_debugger,
-                action_params=updated_params,
-                kubernetes_object=pod,
-            )
-        blocks.append(CallbackBlock(choices))
-        blocks.append(
-            MarkdownBlock(
-                "*After clicking a button please wait up to 120 seconds for a response*"
-            )
-        )
-    return blocks
-
-
 @action
 def python_debugger(event: PodEvent, params: DebuggerParams):
     """
@@ -343,28 +297,15 @@ def python_debugger(event: PodEvent, params: DebuggerParams):
     event.add_finding(finding)
 
     all_processes = pod.get_processes()
-    relevant_processes = get_relevant_processes(all_processes, params)
-    if len(relevant_processes) == 0:
+    if not params.has_exactly_one_match(all_processes):
         finding.add_enrichment(
-            [MarkdownBlock(f"No matching processes. The processes in the pod are:")]
-            + get_process_blocks(all_processes, pod, params)
-        )
-        return
-    elif len(relevant_processes) > 1:
-        finding.add_enrichment(
-            [
-                MarkdownBlock(
-                    f"More than one matching process. The matching processes are:"
-                )
-            ]
-            + get_process_blocks(relevant_processes, pod, params)
+            params.get_retrigger_blocks(all_processes, pod, "Debug", python_debugger)
         )
         return
 
-    # we have exactly one process to debug
-    pid = relevant_processes[0].pid
+    pid = params.get_exact_match(all_processes).pid
     cmd = f"debug-toolkit debugger {pid} --port {params.port}"
-    output = json.loads(
+    output = load_json(
         RobustaPod.exec_in_debugger_pod(
             pod.metadata.name,
             pod.spec.nodeName,

--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -1,12 +1,21 @@
-from typing import List
+from typing import List, Callable
 from pydantic import SecretStr
 from ...utils.documented_pydantic import DocumentedModel
+from ...integrations.kubernetes.custom_models import Process, RobustaPod
+from ...core.reporting.blocks import (
+    BaseBlock,
+    CallbackBlock,
+    CallbackChoice,
+    MarkdownBlock,
+    TableBlock,
+)
 
 
 class ActionParams(DocumentedModel):
     """
     Base class for all Action parameter classes.
     """
+
     pass
 
 
@@ -16,6 +25,7 @@ class BashParams(ActionParams):
 
     :example bash_command: ls -l /etc/data/db
     """
+
     bash_command: str
 
 
@@ -25,6 +35,7 @@ class PrometheusParams(ActionParams):
 
     :example prometheus_url: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
     """
+
     prometheus_url: str = None
 
 
@@ -37,6 +48,7 @@ class GrafanaParams(ActionParams):
     :example grafana_url: http://grafana.namespace.svc
     :example grafana_dashboard_uid: 09ec8aa1e996d6ffcd6817bbaff4db1b
     """
+
     grafana_api_key: SecretStr
     grafana_dashboard_uid: str
     grafana_url: str = None
@@ -48,8 +60,106 @@ class GrafanaAnnotationParams(GrafanaParams):
     :var cluster_name: writen as one of the annotation's tags
     :var custom_tags: custom tags to add to the annotation
     """
+
     grafana_dashboard_panel: str = None
     cluster_name: str = None
     cluster_zone: str = None
     custom_tags: List[str] = None
 
+
+class PythonProcessParams(ActionParams):
+    """
+    :var process_substring: process name (or substring).
+    :var pid: pid
+    :var interactive: if more than one process matches, interactively ask which process to choose.
+    """
+
+    process_substring: str = ""
+    pid: int = None
+    interactive: bool = True
+
+    def has_exactly_one_match(self, all_processes: List[Process]) -> bool:
+        """
+        Returns true when exactly one process matches this class's filters
+        """
+        return len(self.get_matches(all_processes)) == 1
+
+    def get_exact_match(self, all_processes: List[Process]) -> Process:
+        """
+        Returns a process matching this class and throws when there is more than one match
+        """
+        matches = self.get_matches(all_processes)
+        if len(matches) != 1:
+            raise Exception("Only one match is expected")
+        return matches[0]
+
+    def get_matches(self, all_processes: List[Process]) -> List[Process]:
+        """
+        Returns all_processes filtered by this class
+        """
+        pid_to_process = {p.pid: p for p in all_processes}
+
+        if self.pid is None:
+            return [
+                p
+                for p in pid_to_process.values()
+                if "python" in p.exe and self.process_substring in " ".join(p.cmdline)
+            ]
+
+        if self.pid not in pid_to_process:
+            return []
+
+        return [pid_to_process[self.pid]]
+
+    def __retrigger_blocks_for_processes(
+        self, processes: List[Process], pod: RobustaPod, text: str, action: Callable
+    ) -> List[BaseBlock]:
+        blocks = [
+            TableBlock(
+                [[p.pid, p.exe, " ".join(p.cmdline)] for p in processes],
+                ["pid", "exe", "cmdline"],
+            ),
+        ]
+        if self.interactive:
+            choices = {}
+            for proc in processes:
+                updated_params = self.copy()
+                updated_params.process_substring = ""
+                updated_params.pid = proc.pid
+                choices[f"{text} {proc.pid}"] = CallbackChoice(
+                    action=action,
+                    action_params=updated_params,
+                    kubernetes_object=pod,
+                )
+            blocks.append(CallbackBlock(choices))
+            blocks.append(
+                MarkdownBlock(
+                    "*After clicking a button please wait up to 120 seconds for a response*"
+                )
+            )
+        return blocks
+
+    def get_retrigger_blocks(
+        self, all_processes: List[Process], pod: RobustaPod, text: str, action: Callable
+    ) -> List[BaseBlock]:
+        """
+        Return Blocks which will allow you to retrigger an action with a chosen process.
+        """
+        relevant_processes = self.get_matches(all_processes)
+        if len(relevant_processes) == 1:
+            raise Exception(
+                "Retrigger not supported when there is only one matching process"
+            )
+
+        if len(relevant_processes) == 0:
+            return [
+                MarkdownBlock(f"No matching processes. The processes in the pod are:")
+            ] + self.__retrigger_blocks_for_processes(all_processes, pod, text, action)
+        elif len(relevant_processes) > 1:
+            return [
+                MarkdownBlock(
+                    f"More than one matching process. The matching processes are:"
+                )
+            ] + self.__retrigger_blocks_for_processes(
+                relevant_processes, pod, text, action
+            )

--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -1,14 +1,6 @@
-from typing import List, Callable
+from typing import List
 from pydantic import SecretStr
 from ...utils.documented_pydantic import DocumentedModel
-from ...integrations.kubernetes.custom_models import Process, RobustaPod
-from ...core.reporting.blocks import (
-    BaseBlock,
-    CallbackBlock,
-    CallbackChoice,
-    MarkdownBlock,
-    TableBlock,
-)
 
 
 class ActionParams(DocumentedModel):
@@ -67,7 +59,7 @@ class GrafanaAnnotationParams(GrafanaParams):
     custom_tags: List[str] = None
 
 
-class PythonProcessParams(ActionParams):
+class ProcessParams(ActionParams):
     """
     :var process_substring: process name (or substring).
     :var pid: pid
@@ -77,89 +69,3 @@ class PythonProcessParams(ActionParams):
     process_substring: str = ""
     pid: int = None
     interactive: bool = True
-
-    def has_exactly_one_match(self, all_processes: List[Process]) -> bool:
-        """
-        Returns true when exactly one process matches this class's filters
-        """
-        return len(self.get_matches(all_processes)) == 1
-
-    def get_exact_match(self, all_processes: List[Process]) -> Process:
-        """
-        Returns a process matching this class and throws when there is more than one match
-        """
-        matches = self.get_matches(all_processes)
-        if len(matches) != 1:
-            raise Exception("Only one match is expected")
-        return matches[0]
-
-    def get_matches(self, all_processes: List[Process]) -> List[Process]:
-        """
-        Returns all_processes filtered by this class
-        """
-        pid_to_process = {p.pid: p for p in all_processes}
-
-        if self.pid is None:
-            return [
-                p
-                for p in pid_to_process.values()
-                if "python" in p.exe and self.process_substring in " ".join(p.cmdline)
-            ]
-
-        if self.pid not in pid_to_process:
-            return []
-
-        return [pid_to_process[self.pid]]
-
-    def __retrigger_blocks_for_processes(
-        self, processes: List[Process], pod: RobustaPod, text: str, action: Callable
-    ) -> List[BaseBlock]:
-        blocks = [
-            TableBlock(
-                [[p.pid, p.exe, " ".join(p.cmdline)] for p in processes],
-                ["pid", "exe", "cmdline"],
-            ),
-        ]
-        if self.interactive:
-            choices = {}
-            for proc in processes:
-                updated_params = self.copy()
-                updated_params.process_substring = ""
-                updated_params.pid = proc.pid
-                choices[f"{text} {proc.pid}"] = CallbackChoice(
-                    action=action,
-                    action_params=updated_params,
-                    kubernetes_object=pod,
-                )
-            blocks.append(CallbackBlock(choices))
-            blocks.append(
-                MarkdownBlock(
-                    "*After clicking a button please wait up to 120 seconds for a response*"
-                )
-            )
-        return blocks
-
-    def get_retrigger_blocks(
-        self, all_processes: List[Process], pod: RobustaPod, text: str, action: Callable
-    ) -> List[BaseBlock]:
-        """
-        Return Blocks which will allow you to retrigger an action with a chosen process.
-        """
-        relevant_processes = self.get_matches(all_processes)
-        if len(relevant_processes) == 1:
-            raise Exception(
-                "Retrigger not supported when there is only one matching process"
-            )
-
-        if len(relevant_processes) == 0:
-            return [
-                MarkdownBlock(f"No matching processes. The processes in the pod are:")
-            ] + self.__retrigger_blocks_for_processes(all_processes, pod, text, action)
-        elif len(relevant_processes) > 1:
-            return [
-                MarkdownBlock(
-                    f"More than one matching process. The matching processes are:"
-                )
-            ] + self.__retrigger_blocks_for_processes(
-                relevant_processes, pod, text, action
-            )

--- a/src/robusta/integrations/kubernetes/process_utils.py
+++ b/src/robusta/integrations/kubernetes/process_utils.py
@@ -1,0 +1,129 @@
+from typing import List, Callable, Optional
+from ...core.reporting.base import Finding
+from ...core.model.base_params import ProcessParams
+from ...integrations.kubernetes.custom_models import Process, RobustaPod
+from enum import Enum
+from ...core.reporting.blocks import (
+    BaseBlock,
+    CallbackBlock,
+    CallbackChoice,
+    MarkdownBlock,
+    TableBlock,
+)
+
+
+class ProcessType(Enum):
+    PYTHON = "python"
+
+
+class ProcessFinder:
+    """
+    Find the processes in a Kubernetes pod which match certain filters.
+    """
+
+    def __init__(
+        self, pod: RobustaPod, filters: ProcessParams, process_type: ProcessType
+    ):
+        if process_type != ProcessType.PYTHON:
+            raise Exception(f"Unsupported process type: {process_type}")
+        self.pod = pod
+        self.filters = filters
+        self.process_type = process_type
+        self.all_processes = pod.get_processes()
+        self.matching_processes = self.__get_matches(
+            self.all_processes, filters, process_type
+        )
+
+    def get_match_or_report_error(
+        self, finding: Finding, retrigger_text: str, retrigger_action: Callable
+    ) -> Optional[Process]:
+        """
+        Returns the single-matching process. If more than one process matches, blocks will be added to the Finding
+        to report the error and optionally allow re-triggering the action with a chosen process.
+        """
+        if self.has_exactly_one_match():
+            return self.get_exact_match()
+        elif len(self.matching_processes) == 0:
+            finding.add_enrichment(
+                [MarkdownBlock(f"No matching processes. The processes in the pod are:")]
+                + self.__get_error_blocks(
+                    self.all_processes, retrigger_text, retrigger_action
+                )
+            )
+            return None
+        elif len(self.matching_processes) > 1:
+            finding.add_enrichment(
+                [
+                    MarkdownBlock(
+                        f"More than one matching process. The matching processes are:"
+                    )
+                ]
+                + self.__get_error_blocks(
+                    self.matching_processes, retrigger_text, retrigger_action
+                )
+            )
+            return None
+
+    def has_exactly_one_match(self) -> bool:
+        """
+        Returns true when exactly one process matches
+        """
+        return len(self.matching_processes) == 1
+
+    def get_exact_match(self) -> Process:
+        """
+        Returns a process matching this class and throws when there is more than one match
+        """
+        if len(self.matching_processes) != 1:
+            raise Exception("Only one match is expected")
+        return self.matching_processes[0]
+
+    @staticmethod
+    def __get_matches(
+        processes: List[Process], filters: ProcessParams, process_type: ProcessType
+    ) -> List[Process]:
+        """
+        Returns the processes that match a ProcessParams class
+        """
+        pid_to_process = {p.pid: p for p in processes}
+
+        if filters.pid is None:
+            return [
+                p
+                for p in pid_to_process.values()
+                if process_type.value in p.exe
+                and filters.process_substring in " ".join(p.cmdline)
+            ]
+
+        if filters.pid not in pid_to_process:
+            return []
+
+        return [pid_to_process[filters.pid]]
+
+    def __get_error_blocks(
+        self, processes: List[Process], text: str, action: Callable
+    ) -> List[BaseBlock]:
+        blocks = [
+            TableBlock(
+                [[p.pid, p.exe, " ".join(p.cmdline)] for p in processes],
+                ["pid", "exe", "cmdline"],
+            ),
+        ]
+        if self.filters.interactive:
+            choices = {}
+            for proc in processes:
+                updated_params = self.filters.copy()
+                updated_params.process_substring = ""
+                updated_params.pid = proc.pid
+                choices[f"{text} {proc.pid}"] = CallbackChoice(
+                    action=action,
+                    action_params=updated_params,
+                    kubernetes_object=self.pod,
+                )
+            blocks.append(CallbackBlock(choices))
+            blocks.append(
+                MarkdownBlock(
+                    "*After clicking a button please wait up to 120 seconds for a response*"
+                )
+            )
+        return blocks

--- a/src/robusta/utils/parsing.py
+++ b/src/robusta/utils/parsing.py
@@ -1,0 +1,15 @@
+import json
+import logging
+from typing import Union, Any
+
+
+def load_json(s: Union[str, bytes]) -> Any:
+    """
+    Like json.loads() but prints the input if parsing fails
+    """
+    try:
+        return json.loads(s)
+    except json.decoder.JSONDecodeError:
+        sep = "----------------"
+        logging.error(f"could not parse json:\n{sep}\n{s}\n{sep}\n")
+        raise


### PR DESCRIPTION
1. Use the same logic as the python_debugger
2. Move that logic to a shared class
3. Add a function for parsing json with better error reporting (this is in response to several errors we've seen recently where we were missing context)