### PR TITLE
don't track replicas in the babysitter because it's extremely spammy with autoscaling

### DIFF
--- a/playbooks/robusta_playbooks/babysitter.py
+++ b/playbooks/robusta_playbooks/babysitter.py
@@ -15,12 +15,14 @@ class BabysitterConfig(ActionParams):
     :var fields_to_monitor: List of yaml attributes to monitor. Any field that contains one of these strings will match.
     :var omitted_fields: List of yaml attributes changes to ignore.
     """
+
     fields_to_monitor: List[str] = ["spec"]
     omitted_fields: List[str] = [
         "status",
         "metadata.generation",
         "metadata.resourceVersion",
         "metadata.managedFields",
+        "spec.replicas",
     ]
 
 


### PR DESCRIPTION
@arikalon1 tiny change, but please review.

I tested this with a regular deployment (not autoscaled). I changed the replicacount and verified that no babysitter notification was sent.

I didn't test this with the autoscaler, but I did review some existing autoscaler diffs in the UI and verified that each of the fields changed there are excluded by the babysitter.