### PR TITLE
Add severity to node health watcher

### DIFF
--- a/playbooks/robusta_playbooks/node_enrichments.py
+++ b/playbooks/robusta_playbooks/node_enrichments.py
@@ -125,6 +125,7 @@ def node_health_watcher(event: NodeChangeEvent):
         title=f"Unhealthy node {event.obj.metadata.name}",
         source=FindingSource.KUBERNETES_API_SERVER,
         aggregation_key="node_not_ready",
+        severity=FindingSeverity.MEDIUM,
     )
     event.add_finding(finding, "DEFAULT")
     event.add_enrichment([KubernetesDiffBlock([], event.old_obj, event.obj)])


### PR DESCRIPTION
@arikalon1 right now I set this to MEDIUM. I'm not sure about the priority on this. Ideally we would be able to differentiate between:

1. An unexpected unhealthy node (e.g. a node that died) which causes a service disruption because pods running on it go kaput
2. An Unready node which is performing a normal transition. (E.g. a node going up/down with a cluster autoscaler or spot instances.)

Right now we're really just alerting on *any* node that isn't ready, which matches both of those states.