### PR TITLE
Fix list items for add_enrichment in playbook example

### DIFF
--- a/docs/developer-guide/actions/writing-playbooks.rst
+++ b/docs/developer-guide/actions/writing-playbooks.rst
@@ -26,7 +26,7 @@ Lets write a playbook action in Python:
 
         # this is how you send data to slack or other destinations
         event.add_enrichment([
-            MarkdownBlock("*Oh no!* An alert occurred on " + pod_name)
+            MarkdownBlock("*Oh no!* An alert occurred on " + pod_name),
             FileBlock("crashing-pod.log", pod_logs)
         ])
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,7 +164,7 @@ Many automations are included, but you can also write your own in Python.
 
             # this is how you send data to slack or other destinations
             event.add_enrichment([
-                MarkdownBlock("*Oh no!* An alert occurred on " + pod_name)
+                MarkdownBlock("*Oh no!* An alert occurred on " + pod_name),
                 FileBlock("crashing-pod.log", pod_logs)
             ])
 


### PR DESCRIPTION
There is a missing comma in the example for writing playbooks. The comma needs to be present for the list items passed to `add_enrichment` method, without which the action will not run.
