### PR TITLE
Prevent python exception for no robusta-runner while fetching logs

### DIFF
--- a/src/robusta/cli/playbooks_cmd.py
+++ b/src/robusta/cli/playbooks_cmd.py
@@ -80,7 +80,7 @@ def push(
     with fetch_runner_logs(namespace):
         runner_pod = get_runner_pod(namespace)
         if not runner_pod:
-            log_title("Runner pod not found.", color="red")
+            log_title(f"Runner pod not found in the {namespace} namespace. If robusta is installed in a different namespace, use the --namespace flag.", color="red")
             return
 
         subprocess.check_call(

--- a/src/robusta/cli/utils.py
+++ b/src/robusta/cli/utils.py
@@ -84,16 +84,20 @@ def fetch_runner_logs(namespace: Optional[str], all_logs=False):
         yield
     finally:
         log_title("Fetching logs...")
-        if all_logs:
-            subprocess.check_call(
-                f"kubectl logs {namespace_to_kubectl(namespace)} deployment/robusta-runner -c runner",
-                shell=True,
-            )
-        else:
-            subprocess.check_call(
-                f"kubectl logs {namespace_to_kubectl(namespace)} deployment/robusta-runner -c runner --since={int(time.time() - start + 1)}s",
-                shell=True,
-            )
+        try:
+            if all_logs:
+                subprocess.check_call(
+                    f"kubectl logs {namespace_to_kubectl(namespace)} deployment/robusta-runner -c runner",
+                    shell=True,
+                )
+            else:
+                subprocess.check_call(
+                    f"kubectl logs {namespace_to_kubectl(namespace)} deployment/robusta-runner -c runner --since={int(time.time() - start + 1)}s",
+                    shell=True,
+                )
+        except:
+            log_title("Cannot fetch logs. robusta-runner not found", color="red")
+            return
 
 
 def get_package_name(playbooks_dir: str) -> str:


### PR DESCRIPTION
Fixes #239 

Addresses both issues mentioned in the [issue comment](https://github.com/robusta-dev/robusta/issues/239#issuecomment-1053556851)