### PR TITLE
track init container crashes by default

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -41,7 +41,7 @@ builtinPlaybooks:
   - on_pod_update: {}
   actions:
   - restart_loop_reporter:
-      restart_reason: CrashLoopBackOff
+      restart_reason: ["CrashLoopBackOff", "Init:CrashLoopBackOff"]
   - image_pull_backoff_reporter:
       rate_limit: 3600
 - triggers:

--- a/playbooks/robusta_playbooks/restart_loop_reporter.py
+++ b/playbooks/robusta_playbooks/restart_loop_reporter.py
@@ -7,21 +7,22 @@ class RestartLoopParams(RateLimitParams):
     :var restart_reason: Limit restart loops for this specific reason. If omitted, all restart reasons will be included.
     """
 
-    restart_reason: str = None
+    restart_reason: List[str] = None
 
 
 def get_crashing_containers(
     status: PodStatus, config: RestartLoopParams
 ) -> [ContainerStatus]:
+    all_statuses = status.containerStatuses + status.initContainerStatuses
     return [
         container_status
-        for container_status in status.containerStatuses
+        for container_status in all_statuses
         if container_status.state.waiting is not None
         and container_status.restartCount
         > 1  # report only after the 2nd restart and get previous logs
         and (
             config.restart_reason is None
-            or container_status.state.waiting.reason == config.restart_reason
+            or container_status.state.waiting.reason in config.restart_reason
         )
     ]
 


### PR DESCRIPTION
@arikalon1 feel free to hand off the review to Roi or Avi if you like.

This fixes an issue I heard yesterday from someone in the Slack community. Namely, we don't currently track crashes to init containers.