### PR TITLE
Enable Robusta UI by default in gen-config and handle invalid token format error

### DIFF
--- a/src/robusta/cli/integrations_cmd.py
+++ b/src/robusta/cli/integrations_cmd.py
@@ -45,21 +45,22 @@ def _get_slack_key_once() -> SlackApiKey:
     return slack_api_key
 
 
-def get_slack_key() -> str:
+def get_slack_key() -> (str, str):
     slack_api_key = _get_slack_key_once()
     if not slack_api_key or not slack_api_key.team_name:
-        return slack_api_key.key
+        return slack_api_key.key, ""
     team_name = slack_api_key.team_name
     team_name_styled = typer.style(team_name, fg=typer.colors.CYAN, bold=True)
     typer.secho(f"You've just connected Robusta to the Slack of: {team_name_styled}")
-    return slack_api_key.key
+    return slack_api_key.key, team_name_styled
 
 
 @app.command()
 def slack():
     """generate slack api key"""
-    key = get_slack_key()
-    log_title(f"your slack key is:\n{key}\nAdd it to the slack sink configuration")
+    key, workspace = get_slack_key()
+    log_title(f"Connected to Slack workspace {workspace}.\n"
+              f"Your Slack key is:\n{key}\nAdd it to the slack sink configuration")
 
 
 if __name__ == "__main__":

--- a/src/robusta/cli/main.py
+++ b/src/robusta/cli/main.py
@@ -160,6 +160,9 @@ def gen_config(
         slack_channel = get_slack_channel()
 
     if slack_api_key and slack_channel:
+        while not verify_slack_channel(slack_api_key, cluster_name, slack_channel, slack_workspace):
+            slack_channel = get_slack_channel()
+
         sinks_config.append(
             SlackSinkConfigWrapper(
                 slack_sink=SlackSinkParams(
@@ -169,8 +172,6 @@ def gen_config(
                 )
             )
         )
-        while not verify_slack_channel(slack_api_key, cluster_name, slack_channel, slack_workspace):
-            slack_channel = get_slack_channel()
 
     if msteams_webhook is None and typer.confirm(
         "Do you want to configure MsTeams integration ?",
@@ -210,7 +211,7 @@ def gen_config(
                     except Exception:
                         typer.secho(
                             "Sorry, invalid token format. "
-                            "The token can be found in your generated_values.yaml file, under the robusta_sink",
+                            "The token can be found in any existing generated_values.yaml file, under the robusta_sink",
                             fg="red",
                         )
 

--- a/src/robusta/cli/slack_verification.py
+++ b/src/robusta/cli/slack_verification.py
@@ -26,7 +26,10 @@ def verify_slack_channel(slack_api_key: str, cluster_name: str, channel_name: st
         if e.response.data['error'] == 'channel_not_found':
             channel_name_styled = typer.style(channel_name, fg=typer.colors.RED)
             typer.secho(
-                f"The channel {channel_name_styled} was not found on Slack workspace {workspace}."
+                f"The channel {channel_name_styled} was not found on Slack workspace {workspace}.\n"
+                f"Please verify that the channel exists.\n"
+                f"If this is a private channel, verify the Robusta app was added to the channel."
+                f"(See https://docs.robusta.dev/master/catalog/sinks/slack.html#sending-robusta-notifications-to-a-private-channel)"
             )
         return False
     except Exception as e:

--- a/src/robusta/cli/slack_verification.py
+++ b/src/robusta/cli/slack_verification.py
@@ -9,7 +9,7 @@ SLACK_WELCOME_SUPPORT_MESSAGE = "If you have any questions or feedback feel free
                                 "<mailto:support@robusta.dev|support@robusta.dev> "
 
 
-def verify_slack_channel(slack_api_key: str, cluster_name: str, channel_name: str) -> bool:
+def verify_slack_channel(slack_api_key: str, cluster_name: str, channel_name: str, workspace: str) -> bool:
     try:
         output_welcome_message_blocks = gen_robusta_test_welcome_message(cluster_name)
         slack_client = WebClient(token=slack_api_key)
@@ -24,9 +24,9 @@ def verify_slack_channel(slack_api_key: str, cluster_name: str, channel_name: st
         return True
     except SlackApiError as e:
         if e.response.data['error'] == 'channel_not_found':
-            channel_name_styled = typer.style(channel_name, fg=typer.colors.WHITE, bg=typer.colors.RED)
+            channel_name_styled = typer.style(channel_name, fg=typer.colors.RED)
             typer.secho(
-                f"The channel '{channel_name_styled}' was not found."
+                f"The channel {channel_name_styled} was not found on Slack workspace {workspace}."
             )
         return False
     except Exception as e:


### PR DESCRIPTION
Don't abort on slack channel or ui token errors