### PR TITLE
fixing bad import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ prometheus-api-client = { version = "^0.4.2", optional = true }
 datadog-api-client = { version = "^1.2.0", optional = true }
 dpath = "^2.0.5"
 prometheus-client = "^0.12.0"
+pyyaml = "^6.0"
 pytz = "^2021.3"
 docutils="^0.17.0"
 sentry-sdk = "^1.5.2"


### PR DESCRIPTION
older versions of pyyaml will block gen-config from working because some of the parameters are missing