### PR TITLE
move docs on flow-control to their own page

### DIFF
--- a/docs/developer-guide/actions/writing-playbooks.rst
+++ b/docs/developer-guide/actions/writing-playbooks.rst
@@ -136,41 +136,11 @@ Sometimes you need to prevent an action from running too often. You can use the 
 
 The second parameter to ``RateLimiter.mark_and_test`` defines a key used for checking the rate limit. Each key is rate-limited individually.
 
-Flow control
--------------
-Every Robusta playbook has a list of :ref:`Triggers` and a list of :ref:`Actions`.
+stop_processing
+--------------------------------------
+Normally, multiple actions run one after another. (See :ref:`Flow Control`.)
 
-.. code-block:: yaml
-
-   - triggers:
-     - on_deployment_create: {}
-     - on_daemonset_update: {}
-     actions:
-     - my_first_action: {}
-     - my_second_action: {}
-
-For every incoming event, Robusta will run actions if any of the ``triggers`` match.
-
-All the playbook's ``actions`` will be executed, according to the order specified in the configuration.
-
-Playbooks execution order, is the same as the configuration file order. For example:
-
-.. code-block:: yaml
-
-   - triggers:  # playbook A
-     - on_deployment_create: {}
-     actions:
-     - my_first_action: {}
-   - triggers:  # playbook B
-     - on_deployment_create: {}
-     actions:
-     - my_second_action: {}
-
-On the example above, ``playbook A`` will run before ``playbook B``
-
-There is a mechanisms in place, to stop the processing flow, if needed:
-
-Set ``event.stop_processing = True``. No other ``playbooks`` or ``actions`` will be executed
+A playbook can stop Robusta from running further actions by setting ``event.stop_processing = True``.
 
 .. code-block:: python
    :emphasize-lines: 5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,7 @@ Next Steps
 
    upgrade
    user-guide/configuration
+   user-guide/flow-control
    catalog/triggers/index
    catalog/actions/index
    catalog/sinks/index

--- a/docs/user-guide/configuration.rst
+++ b/docs/user-guide/configuration.rst
@@ -56,6 +56,8 @@ Triggers define when a playbook runs:
 
 Most triggers support extra filters like ``name_prefix`` which further restricts the trigger.
 
+If multiple triggers match, multiple playbooks will run according to the rules in :ref:`Flow Control`
+
 Multiple playbook instances
 -----------------------------------
 

--- a/docs/user-guide/flow-control.rst
+++ b/docs/user-guide/flow-control.rst
@@ -38,6 +38,8 @@ On the example above, ``playbook A`` will run before ``playbook B``
 
 Stop Processing
 ^^^^^^^^^^^^^^^^^^
-An action can stop the processing flow if needed. No further actions will run.
+Any action can :ref:`stop the processing flow <stop_processing>` if needed. No further actions will run.
 
-See :ref:`stop_processing` for details.
+This is how actions like :ref:`node_restart_silencer <node_restart_silencer>` work.
+
+Only actions that appear **after** the current action will be stopped. This means, for example, that silencers must appear before other playbooks.

--- a/docs/user-guide/flow-control.rst
+++ b/docs/user-guide/flow-control.rst
@@ -1,0 +1,43 @@
+Flow Control
+################################
+
+The :ref:`Configuration Guide` covers basic playbook definition.
+This page explains how playbooks interact with one another.
+
+Basics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Every Robusta playbook has a list of :ref:`Triggers` and a list of :ref:`Actions`.
+
+.. code-block:: yaml
+
+   - triggers:
+     - on_deployment_create: {}
+     - on_daemonset_update: {}
+     actions:
+     - my_first_action: {}
+     - my_second_action: {}
+
+For every incoming event, Robusta will run actions if any of the ``triggers`` match.
+
+All the ``actions`` will be executed, according to the order specified in the configuration.
+
+Execution order is the same as the configuration order. For example:
+
+.. code-block:: yaml
+
+   - triggers:  # playbook A
+     - on_deployment_create: {}
+     actions:
+     - my_first_action: {}
+   - triggers:  # playbook B
+     - on_deployment_create: {}
+     actions:
+     - my_second_action: {}
+
+On the example above, ``playbook A`` will run before ``playbook B``
+
+Stop Processing
+^^^^^^^^^^^^^^^^^^
+An action can stop the processing flow if needed. No further actions will run.
+
+See :ref:`stop_processing` for details.


### PR DESCRIPTION
@arikalon1 I recently had some trouble finding the docs on flow-control because they're buried in the playbook writer's docs. This PR puts them in a more obvious location.