### PR TITLE
change default port 9100 used by prometheus node exporter to avoid co…

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -211,6 +211,9 @@ kube-prometheus-stack:
               requests:
                 storage: 100Gi
   prometheus-node-exporter:
+    service:
+      port: 9104
+      targetPort: 9104
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
using hostnetwork:enable provides some network optimizations and speed to the container, so I think
changing the default port is a better solution for now.



I am planning on adding a small section about that issue in the upcoming common installations issues page ( and how to change that port ) wdyt?


