### PR TITLE
Slack feedback message

### DIFF
--- a/src/robusta/cli/main.py
+++ b/src/robusta/cli/main.py
@@ -9,6 +9,7 @@ import click_spinner
 from distutils.version import StrictVersion
 from typing import Optional, List, Union, Dict
 from zipfile import ZipFile
+import traceback
 
 import requests
 import typer
@@ -30,6 +31,7 @@ from ..core.sinks.slack.slack_sink_params import SlackSinkConfigWrapper, SlackSi
 from robusta._version import __version__
 from .integrations_cmd import app as integrations_commands, get_slack_key
 from .slack_verification import verify_slack_channel
+from .slack_feedback_message import SlackFeedbackMessagesSender
 from .playbooks_cmd import app as playbooks_commands
 from .utils import log_title, replace_in_file, namespace_to_kubectl
 
@@ -186,6 +188,16 @@ def gen_config(
                 )
             )
         )
+
+        try:
+            SlackFeedbackMessagesSender(
+                slack_api_key,
+                slack_channel,
+                debug
+            ).schedule_feedback_messages()
+        except Exception as e:
+            if debug:
+                typer.secho(traceback.format_exc())
 
     if msteams_webhook is None and typer.confirm(
         "Do you want to configure MsTeams integration ?",

--- a/src/robusta/cli/main.py
+++ b/src/robusta/cli/main.py
@@ -31,7 +31,7 @@ from ..core.sinks.slack.slack_sink_params import SlackSinkConfigWrapper, SlackSi
 from robusta._version import __version__
 from .integrations_cmd import app as integrations_commands, get_slack_key
 from .slack_verification import verify_slack_channel
-from .slack_feedback_message import SlackFeedbackMessagesSender
+from .slack_feedback_message import SlackFeedbackMessagesSender, SlackFeedbackConfig
 from .playbooks_cmd import app as playbooks_commands
 from .utils import log_title, replace_in_file, namespace_to_kubectl
 
@@ -173,6 +173,7 @@ def gen_config(
     if slack_api_key and not slack_channel:
         slack_channel = get_slack_channel()
 
+    slack_integration_configured = False
     if slack_api_key and slack_channel:
         while not verify_slack_channel(
             slack_api_key, cluster_name, slack_channel, slack_workspace, debug
@@ -189,15 +190,7 @@ def gen_config(
             )
         )
 
-        try:
-            SlackFeedbackMessagesSender(
-                slack_api_key,
-                slack_channel,
-                debug
-            ).schedule_feedback_messages()
-        except Exception as e:
-            if debug:
-                typer.secho(traceback.format_exc())
+        slack_integration_configured = True
 
     if msteams_webhook is None and typer.confirm(
         "Do you want to configure MsTeams integration ?",
@@ -287,6 +280,19 @@ def gen_config(
         enable_platform_playbooks = True
         require_eula_approval = True
 
+    slack_feedback_heads_up_message: Optional[str] = None
+    if slack_integration_configured:
+        try:
+            slack_feedback_heads_up_message = SlackFeedbackMessagesSender(
+                slack_api_key,
+                slack_channel,
+                account_id,
+                debug
+            ).schedule_feedback_messages()
+        except Exception as e:
+            if debug:
+                typer.secho(traceback.format_exc())
+
     if enable_prometheus_stack is None:
         enable_prometheus_stack = typer.confirm(
             "If you haven't installed Prometheus yet, Robusta can install a pre-configured Prometheus. Would you like to do so?"
@@ -364,6 +370,9 @@ def gen_config(
             f"Finish the Helm install and then login to Robusta UI at {backend_profile.robusta_ui_domain}\n",
             fg="green",
         )
+
+    if slack_feedback_heads_up_message:
+        typer.secho(slack_feedback_heads_up_message)
 
 
 @app.command()

--- a/src/robusta/cli/slack_feedback_message.py
+++ b/src/robusta/cli/slack_feedback_message.py
@@ -1,0 +1,96 @@
+import traceback
+import typer
+import datetime
+from slack_sdk import WebClient
+from typing import NamedTuple
+
+import json
+import urllib.request
+
+SLACK_WELCOME_MESSAGE_PREFIX = ":large_green_circle: "
+REMOTE_FEEDBACK_MESSAGE_ADDRESS = "http://[::]:8000/feedback_messages.json"
+
+
+class SlackFeedbackMessage(NamedTuple):
+    seconds_from_now: int
+    title: str
+    other_sections: list[str]
+
+
+class SlackFeedbackMessagesSender(object):
+    def __init__(self, slack_api_key: str, channel_name: str, debug: bool):
+        self.slack_api_key = slack_api_key
+        self.channel_name = channel_name
+        self.debug = debug
+
+    def schedule_feedback_messages(self):
+        typer.echo('schedule_feedback_messages')
+        raw_feedback_messages = self._get_feedback_messages_from_remote()
+        typer.echo(f'raw_feedback_messages: {raw_feedback_messages}')
+        feedback_messages = self._parse_feedback_messages(raw_feedback_messages)
+        typer.echo(f'feedback_messages: {feedback_messages}')
+        for feedback_message in feedback_messages:
+            self._schedule_message(
+                feedback_message.seconds_from_now,
+                feedback_message.title,
+                feedback_message.other_sections)
+
+    @staticmethod
+    def _parse_feedback_messages(raw_feedback_messages: str) -> list[SlackFeedbackMessage]:
+        json_feedback_messages = json.loads(raw_feedback_messages)
+        return [SlackFeedbackMessage(**feedback_message) for feedback_message in json_feedback_messages]
+
+    @staticmethod
+    def _get_feedback_messages_from_remote() -> str:
+        with urllib.request.urlopen(REMOTE_FEEDBACK_MESSAGE_ADDRESS) as response:
+            return response.read()
+
+    def _schedule_message(
+        self,
+        seconds_from_now: int,
+        title: str,
+        other_sections: list[str]
+    ) -> bool:
+        # noinspection PyBroadException
+        try:
+            slack_client = WebClient(token=self.slack_api_key)
+
+            schedule_datetime = datetime.datetime.now() + datetime.timedelta(seconds=seconds_from_now)
+            schedule_timestamp = schedule_datetime.strftime('%s')
+
+            slack_client.chat_scheduleMessage(
+                channel=self.channel_name,
+                post_at=schedule_timestamp,
+                text="Your feedback is important",
+                blocks=self._gen_robusta_slack_message(title, other_sections),
+                display_as_bot=True,
+                unfurl_links=True,
+                unfurl_media=True
+            )
+            return True
+        except Exception as e:
+            if self.debug:
+                typer.secho(traceback.format_exc())
+        return False
+
+    @staticmethod
+    def _gen_robusta_slack_message(title: str, other_sections: list[str]):
+        blocks = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": SLACK_WELCOME_MESSAGE_PREFIX + title,
+                    "emoji": True,
+                },
+            },
+        ]
+        additional_blocks = [{
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": message
+            },
+        } for message in other_sections]
+        blocks.extend(additional_blocks)
+        return blocks

--- a/src/robusta/cli/slack_verification.py
+++ b/src/robusta/cli/slack_verification.py
@@ -22,7 +22,7 @@ def verify_slack_channel(
     debug: bool,
 ) -> bool:
     try:
-        output_welcome_message_blocks = gen_robusta_test_welcome_message(cluster_name)
+        output_welcome_message_blocks = __gen_robusta_test_welcome_message(cluster_name)
         slack_client = WebClient(token=slack_api_key)
         slack_client.chat_postMessage(
             channel=channel_name,
@@ -53,7 +53,7 @@ def verify_slack_channel(
     return False
 
 
-def gen_robusta_test_welcome_message(cluster_name: str):
+def __gen_robusta_test_welcome_message(cluster_name: str):
     return [
         {
             "type": "header",


### PR DESCRIPTION
Feedback messages can be scheduled to be sent in Slack after configuring the sink in the CLI.
The configuration of when and what to send in those messages is saved in https://docs.robusta.dev/extra/feedback_messages.json

A sample configuration may look like this:
```
{
    "heads_up_message": "We're going to send a feedback message. We love you.",
    "messages": [
    {
        "minutes_from_now": 1,
        "title": ":raising_hand: Help the open-source improve and grow!",
        "other_sections": [
            "How do you feel about Robusta so far? Do you like it or not?",
            "We value your opinion and experience.",
            "Please help us improve Robusta with this short survey:",
            "<https://dx4xwuqz6wy.typeform.com/to/EGebO4rn#source=slack1&id=$ACCOUNT_ID|Fill Survey>",
            "Thanks! Natan from Robusta"
            ]
        }
    ]
}
```

The message then will be sent to the slack sync:
![Screen Shot 2022-04-24 at 16 10 56](https://user-images.githubusercontent.com/679727/164978182-3a19c577-81d1-47eb-a1b1-fbfcfecc5e6f.png)

The configurable heads up message in the CLI will appear only if a feedback message was scheduled. It will look like this:
![Screen Shot 2022-04-24 at 16 12 12](https://user-images.githubusercontent.com/679727/164978237-4742e2c0-dff6-4273-9479-37ab975790a2.png)

Just to clarify, the messages are scheduled from the cli. We do **not** save the Slack token on our end.

Furthermore, the account_id can be included in the message but if you didn't sign up for the UI then it's just a random ID.



