### PR TITLE
update docs related to triggers and events

### DIFF
--- a/docs/developer-guide/actions/triggers-and-events.rst
+++ b/docs/developer-guide/actions/triggers-and-events.rst
@@ -1,10 +1,10 @@
-Event Hierarchy
+Events and Triggers
 =====================
 
 When configuring Robusta as a user, you define :ref:`triggers <Triggers>` in ``values.yaml`` but when writing playbook
 actions you deal with events.
 
-This page explains the connection between the two.
+The basic idea is that **triggers** generate **event** objects and those events are passed to **action** functions.
 
 Lifecycle of a Robusta event
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,21 +12,67 @@ Lifecycle of a Robusta event
 2. The API Server notifies Robusta
 3. Robusta checks if any triggers like ``on_pod_update`` are activated by the pod change
 4. If yes, Robusta calls that trigger
-5. The trigger converts data from the APIServer to a concrete event like ``PodChangeEvent``
-6. The ``PodChangeEvent`` is passed to all playbook actions
+5. The trigger converts data from the APIServer to a concrete event like ``PodEvent``
+6. The ``PodEvent`` is passed to all playbook actions
 
+Compatibility of actions and events
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This is discussed in :ref:`Trigger-Action Compatibility` from the perspective of a user who configures playbooks in YAML.
+
+Let's look at this from the perspective of a developer who is writing a playbook action in Python.
+
+You declare which events your playbook is compatible with by choosing the first parameter of your playbook's Python function. For example:
+
+.. code-block:: python
+
+    @action
+    def delete_pod(event: PrometheusKubernetesAlert):
+    if not event.get_pod():
+        logging.info("alert is not related to pod")
+        return
+
+    event.get_pod().delete()
+
+The above action takes ``PrometheusKubernetesAlert`` as input and can therefore only be connected to an ``on_prometheus_alert`` trigger as no other trigger generates that event object.
+
+However, this action doesn't actually need a Prometheus alert as input as it does nothing with the alert itself. We can modify this action so it takes a ``PodEvent`` as input.
+
+.. code-block:: python
+
+    @action
+    def delete_pod(event: PodEvent):
+    if not event.get_pod():
+        logging.info("alert is not related to pod")
+        return
+
+    event.get_pod().delete()
+
+``PrometheusKubernetesAlert`` is a subclass of ``PodEvent``, so general object-oriented principles apply here:
+``PrometheusKubernetesAlert`` can be used wherever ``PodEvent`` is expected.
+
+Therefore this action can be triggered with ``on_prometheus_alert`` but it can **also** be triggered on any other PodEvent.
+
+Who is compatible with who
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Here is the Robusta event hierarchy:
 
 .. image:: ../../images/event-inheritance.png
   :align: center
 
-
 ..
+    this is a sphinx comment
     the above image was generated like this by a patched version of inheritance-diagram based on
     https://github.com/sphinx-doc/sphinx/pull/8159
     .. inheritance-diagram2:: robusta.api.ExecutionBaseEvent
         :parts: 1
         :include-subclasses:
+
+
+.. note::
+
+    Note that ``PrometheusKubernetesAlert`` inherits from many Kubernetes event classes, so you can use
+    ``on_prometheus_alert`` with many types of playbook actions. For example, ``on_prometheus_alert`` is
+    compatible with any playbook that accepts ``PodEvent``, ``NodeEvent``, ``DeploymentEvent``, and so on.
 
 Support manual triggers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,3 +83,4 @@ specify the pod's name and Robusta will generate an artificial event.
 
 On the other hand, events like ``PodChangeEvent`` don't support manual triggers. ``PodChangeEvent`` cannot be generated
 artificially because it requires two versions of the pod - a before and after version.
+

--- a/docs/developer-guide/actions/triggers-and-events.rst
+++ b/docs/developer-guide/actions/triggers-and-events.rst
@@ -73,6 +73,8 @@ Here is the Robusta event hierarchy:
     Note that ``PrometheusKubernetesAlert`` inherits from many Kubernetes event classes, so you can use
     ``on_prometheus_alert`` with many types of playbook actions. For example, ``on_prometheus_alert`` is
     compatible with any playbook that accepts ``PodEvent``, ``NodeEvent``, ``DeploymentEvent``, and so on.
+    However, at runtime the alert must contain a relevant label in order to map the alert to the relevant
+    Kubernetes object.
 
 Support manual triggers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/developer-guide/actions/writing-playbooks.rst
+++ b/docs/developer-guide/actions/writing-playbooks.rst
@@ -68,7 +68,7 @@ of what changed. These actions should take one of the ChangeEvent classes. For e
 To write a more general action that monitors all Kubernetes changes, we can use ``KubernetesAnyChangeEvent``.
 
 You should always use the highest-possible event class when writing actions. This will let your action be used in as many
-scenarios as possible. See :ref:`Event Hierarchy` for details.
+scenarios as possible. See :ref:`Events and Triggers` for details.
 
 Actions with parameters
 -------------------------------

--- a/docs/tutorials/my-first-custom-action.rst
+++ b/docs/tutorials/my-first-custom-action.rst
@@ -131,7 +131,7 @@ We'll use ``on_event_create`` in this tutorial because it will be easier to iden
 Writing the action
 --------------------
 
-Now we need to write code that checks this event and reports it. To find the correct event class that matches our trigger ``on_event_create``. please take a look at :ref:`Event Hierarchy`.
+Now we need to write code that checks this event and reports it. To find the correct event class that matches our trigger ``on_event_create``. please take a look at :ref:`Events and Triggers`.
 
 Okay! We find out it’s ``EventEvent``!
 

--- a/docs/user-guide/trigger-action-binding.rst
+++ b/docs/user-guide/trigger-action-binding.rst
@@ -1,7 +1,10 @@
-Trigger Action Binding
+Trigger-Action Compatibility
 ################################
 
 This page defines in-depth how triggers are bound to actions.
+
+We're working on improving this documentation.
+Please `open an issue on Github <https://github.com/robusta-dev/robusta/issues/new?assignees=&labels=&template=other.md&title=>`_ about anything that is unclear.
 
 Simple actions
 -----------------
@@ -25,7 +28,7 @@ Therefore, ``logs_enricher`` can only be connected to triggers which output a po
 Error handling
 -----------------
 
-Where possible, trigger-action compatibility is checked when Robusta loads its config. Feel free to experiment though.
+Where possible, trigger-action compatibility is checked when Robusta loads its config, so feel free to experiment.
 Incompatible triggers and actions will fail gracefully with a warning.
 
 Trigger hierarchies
@@ -37,6 +40,7 @@ descendants of that trigger.
 For example, the trigger ``on_deployment_all_changes`` has a child trigger ``on_deployment_create``.
 The latter may be used wherever the former is expected.
 
+
 .. graphviz::
 
     digraph trigger_inheritance {
@@ -45,7 +49,7 @@ The latter may be used wherever the former is expected.
         size="8.0, 12.0";
         node [fillcolor=white,fontname="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans",fontsize=10,height=0.25,shape=box,style="setlinewidth(0.5),filled"]
         "on_schedule";
-        "on_prometheus_alert";
+        "on_prometheus_alert**";
         "on_kubernetes_any_resource_all_changes";
         "on_deployment_all_changes";
         "on_deployment_create";
@@ -56,3 +60,11 @@ The latter may be used wherever the former is expected.
         "on_deployment_all_changes" -> "on_deployment_delete" [arrowsize=0.5,style="setlinewidth(0.5)"];
         "on_kubernetes_any_resource_all_changes" -> "on_deployment_all_changes" [arrowsize=0.5,style="setlinewidth(0.5)"];
     }
+
+.. note::
+
+    **Note that on_prometheus_alert is compatible with most Robusta actions that takes Kubernetes resources.
+
+Further Reading
+-----------------
+The way this works under the hood is explained on the :ref:`Events and Triggers` page.


### PR DESCRIPTION
@arikalon1 this still needs work. Please feel free to suggest changes.

The main problem I'm trying to solve is that `PrometheusKubernetesAlert` and `on_prometheus_alert` are under-documented and its not clear how they interact with playbook actions, what they're compatible with, etc.

I don't think I've solved that problem entirely, but that was the motivation for working on this.