### PR TITLE
supporting env vars in playbooks repo key

### DIFF
--- a/docs/user-guide/configuration.rst
+++ b/docs/user-guide/configuration.rst
@@ -311,8 +311,24 @@ For public repos load the playbook via HTTPS, for private repos you will need to
           ewfrcfsfvC1rZXktdjEAAAAABG5vb.....
           -----END OPENSSH PRIVATE KEY-----
 
-
 The ``key`` should contain a deployment key, with ``read`` access. The ``key`` is required when accessing a git repo via ssh, even for public repositories.
+
+You can also save the SSH key in a `Kubernetes Secret <https://kubernetes.io/docs/concepts/configuration/secret/>`_, and reference it using an environment variable, like this:
+
+.. code-block:: yaml
+
+    additional_env_vars:
+     - name: GITHUB_SSH_KEY
+       valueFrom:
+         secretKeyRef:
+           name: ssh-key
+           key: id_rsa
+
+    playbookRepos:
+      # we're adding the robusta chaos-engineering playbooks here
+      my_extra_playbooks:
+        url: "git@github.com:robusta-dev/robusta-chaos.git"
+        key: "{{env.GITHUB_SSH_KEY}}"
 
 .. note::
 


### PR DESCRIPTION
Making this possible:

```
additional_env_vars:
 - name: GITHUB_SSH_KEY
   valueFrom:
     secretKeyRef:
       name: ssh-key
       key: id_rsa

playbookRepos:
  # we're adding the robusta chaos-engineering playbooks here
  my_extra_playbooks:
    url: "git@github.com:robusta-dev/robusta-chaos.git"
    key: "{{env.GITHUB_SSH_KEY}}"
```