### PR TITLE
Updated announcement with Robusta Careers page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ todo_include_todos = False
 # html_theme_path = [furo.get_pygments_stylesheet()]
 html_theme = "furo"
 html_theme_options = {
-    "announcement": "Want to work at an open source company? We're hiring in Israel and remote! Email jobs@robusta.dev",
+    "announcement": "Want to work at an Open Source Company? We're hiring in Israel and remote! Explore <a href=\"https://home.robusta.dev/jobs/\">open roles</a>.",
     "sidebar_hide_name": True,
     "light_logo": "logo.png",
     "dark_logo": "logo-dark.png",


### PR DESCRIPTION
Modified the announcement in the Docs from this:

![image](https://user-images.githubusercontent.com/25551553/168481483-fa64985e-8f64-4762-831d-30099ac1f9fd.png)

To this: 
![image](https://user-images.githubusercontent.com/25551553/168481596-32bb2498-626b-4880-bb67-b430e0241d61.png)
with a URL pointing to the Robusta Careers page(https://home.robusta.dev/jobs/).