### PR TITLE
Make the disk enricher show less information by default

### DIFF
--- a/playbooks/robusta_playbooks/node_disk_analysis.py
+++ b/playbooks/robusta_playbooks/node_disk_analysis.py
@@ -7,18 +7,20 @@ import humanize
 
 
 class DiskAnalyzerParams(ActionParams):
-    show_pod_level_details: bool = True
-    show_container_level_details: bool = False
+    show_pods: bool = True
+    show_containers: bool = False
 
 
 @action
 def node_disk_analyzer(event: NodeEvent, params: DiskAnalyzerParams):
     """
     Provides relevant disk information for troubleshooting disk issues.
-    Currently, the following information is provided:
-        1. The total disk space used by pods, and the total disk space used by the node for other purposes
-        2. Disk usage of pods, sorted from highest to lowest
-        3. Disk usage of containers, sorted (separately for every pod) from highest to lowest
+    Currently, the following information is provided by default:
+        * The total disk space used by pods, and the total disk space used by the node for other purposes
+        * Disk usage of pods, sorted from highest to lowest
+
+    You can change the parameters to show additional data:
+        * Disk usage of containers, sorted (separately for every pod) from highest to lowest
     """
     node = event.get_node()
     if not node:
@@ -107,7 +109,7 @@ def node_disk_analyzer(event: NodeEvent, params: DiskAnalyzerParams):
     )
 
     # calculate pod-level disk distribution block
-    if params.show_pod_level_details:
+    if params.show_pods:
         pod_distribution_headers = ["pod_namespace", "pod_name", "disk_space"]
         pod_distribution_rows = [
             [
@@ -125,7 +127,7 @@ def node_disk_analyzer(event: NodeEvent, params: DiskAnalyzerParams):
         )
 
     # calculate container-level disk distribution block
-    if params.show_container_level_details:
+    if params.show_containers:
         container_distribution_headers = [
             "pod_namespace",
             "pod_name",


### PR DESCRIPTION
The disk enricher currently shoves a wall of text at you containing both pod-level and container-level details:

![Screen Shot 2022-05-25 at 0 30 10](https://user-images.githubusercontent.com/494087/170135944-5a08c7de-42d1-4a4c-aa3d-acec3a9e0b71.png)

Note that the above screenshot is actually only part of the data, as the message was so long I couldn't get a full screenshot.

In this PR I've removed the container level details by default (while giving the user the option to re-enable them) which results in a much shorter message that doesn't lose much troubleshooting quality:

![Screen Shot 2022-05-25 at 0 30 15](https://user-images.githubusercontent.com/494087/170136068-3493eedd-a927-4430-9a70-3e41096af078.png)

