### PR TITLE
Improve docs for customise_finding action

### DIFF
--- a/docs/catalog/actions/message-formatting.rst
+++ b/docs/catalog/actions/message-formatting.rst
@@ -6,4 +6,4 @@ These actions are useful for customising the output of existing actions
 Finding attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. robusta-action:: playbooks.robusta_playbooks.common_actions.customise_finding
+.. robusta-action:: playbooks.robusta_playbooks.common_actions.customise_finding on_pod_crash_loop

--- a/playbooks/robusta_playbooks/common_actions.py
+++ b/playbooks/robusta_playbooks/common_actions.py
@@ -2,15 +2,16 @@ from robusta.api import *
 
 
 class FindingOverrides(ActionParams):
-    title: Optional[str] = None
-    description: Optional[str] = None
-    severity: Optional[str] = None
-
     """
     :var title: Overriding finding title.
     :var description: Overriding finding description.
     :var severity: Overriding finding severity. Allowed values: DEBUG, INFO, LOW, MEDIUM, HIGH
+    :example severity: DEBUG
     """
+
+    title: Optional[str] = None
+    description: Optional[str] = None
+    severity: Optional[str] = None
 
 
 @action
@@ -26,7 +27,7 @@ def customise_finding(event: ExecutionBaseEvent, params: FindingOverrides):
     It must be placed as the last action in the playbook configuration, to override the attributes created by previous
     actions
     """
-    severity: Optional[FindingSeverity] = FindingSeverity[params.severity] if params.severity else None
-    event.override_finding_attributes(
-        params.title, params.description, severity
+    severity: Optional[FindingSeverity] = (
+        FindingSeverity[params.severity] if params.severity else None
     )
+    event.override_finding_attributes(params.title, params.description, severity)


### PR DESCRIPTION
1. Use `on_pod_crash_loop` in the autogenerated example
2. Fix a bug in the docs that caused them to not show up in sphinx