### PR TITLE
Show playbook action names in docs

### DIFF
--- a/docs/_ext/autorobusta.py
+++ b/docs/_ext/autorobusta.py
@@ -282,7 +282,7 @@ class RobustaActionDirective(SphinxDirective):
             {to_name(action_definition.action_name)}
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-            .. admonition:: Playbook Action
+            .. admonition:: Playbook Action: {action_definition.action_name}
             
                 .. tab-set::
             

--- a/docs/advanced/robusta-ui-triggers.rst
+++ b/docs/advanced/robusta-ui-triggers.rst
@@ -21,5 +21,6 @@ To use this feature on multiple clusters, make sure you install Robusta with the
     - :code:`globalConfig.account_id`
     - :code:`globalConfig.signing_key`
     - :code:`rsa`
+
 | These values are inside the :code:`values.yaml` file you use when you run :code:`helm install robusta...`
 | See `Installation Guide <https://docs.robusta.dev/master/installation.html>`_ for more details.


### PR DESCRIPTION
Today if you search for a playbook action in the docs (e.g. `alert_graph_enricher`) then you often find no results because the docs display a "humanized" version of the name (e.g. `Alert Graph Enricher`) and the actual action name never appears in the docs. This means people don't find things when they use the search.

This fixes that.

@arikalon1 FYI