### PR TITLE
Remove Misconfigured example

### DIFF
--- a/docs/catalog/triggers/scheduled.rst
+++ b/docs/catalog/triggers/scheduled.rst
@@ -24,13 +24,13 @@ Dynamic delay
 ----------------------
 
 These triggers run with a different delay between each invocation. For example, the following will run 3 times with
-a delay of 10 seconds the first time, 20 the second, and 25 the third.
+a delay of 120 seconds the first time, 140 the second, and 165 the third.
 
 .. code-block:: yaml
 
     triggers:
     - on_schedule:
         dynamic_delay_repeat:
-          delay_periods: [10, 20, 25]
+          delay_periods: [120, 140, 165]
 
 The first delay cannot be less than 120 seconds. If you define less, 120 seconds will be used instead.


### PR DESCRIPTION
The way this was written the given example was incorrect, but that is only clarified in the follow up statement about the minimum of 120 seconds.  I just choose a random what I hope is valid example.  I was just browsing your docs and haven't actually started using robusta.