### PR TITLE
add pods to top-level services and fix possible bug with replicasets

### DIFF
--- a/src/robusta/core/playbooks/internal/discovery_events.py
+++ b/src/robusta/core/playbooks/internal/discovery_events.py
@@ -4,11 +4,13 @@ from robusta.core.discovery.top_service_resolver import TopServiceResolver
 
 from robusta.core.playbooks.common import get_events_list, get_event_timestamp
 
+
 @action
 def cluster_discovery_updates(event: KubernetesAnyChangeEvent):
     if (
         event.operation in [K8sOperationType.CREATE, K8sOperationType.UPDATE]
-        and event.obj.kind in ["Deployment", "ReplicaSet", "DaemonSet", "StatefulSet"]
+        and event.obj.kind
+        in ["Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod"]
         and not event.obj.metadata.ownerReferences
     ):
         TopServiceResolver.add_cached_service(
@@ -39,7 +41,7 @@ def event_history(event: ExecutionBaseEvent):
             "Resource events",
             warning_event.involvedObject.kind,
             warning_event.involvedObject.name,
-            warning_event.involvedObject.namespace
+            warning_event.involvedObject.namespace,
         )
         if events_table:
             finding.add_enrichment([events_table])
@@ -65,9 +67,11 @@ def create_debug_event_finding(event: Event):
             FindingSubjectType.from_kind(k8s_obj.kind.lower()),
             k8s_obj.namespace,
         ),
-        creation_date= get_event_timestamp(event)
+        creation_date=get_event_timestamp(event),
     )
-    finding.service_key = TopServiceResolver.guess_service_key(name=k8s_obj.name, namespace=k8s_obj.namespace)
+    finding.service_key = TopServiceResolver.guess_service_key(
+        name=k8s_obj.name, namespace=k8s_obj.namespace
+    )
     return finding
 
 

--- a/src/robusta/core/sinks/robusta/robusta_sink.py
+++ b/src/robusta/core/sinks/robusta/robusta_sink.py
@@ -160,7 +160,14 @@ class RobustaSink(SinkBase):
                 [
                     rs
                     for rs in ReplicaSetList.listReplicaSetForAllNamespaces().obj.items
-                    if rs.metadata.ownerReferences is None
+                    if not rs.metadata.ownerReferences
+                ]
+            )
+            current_services.extend(
+                [
+                    pod
+                    for pod in Pod.listPodForAllNamespaces().obj.items
+                    if not pod.metadata.ownerReferences
                 ]
             )
             self.__publish_new_services(current_services)
@@ -326,7 +333,10 @@ class RobustaSink(SinkBase):
 
     def __periodic_cluster_status(self):
         first_alert = False
-        if self.registry.get_telemetry().last_alert_at and self.first_prometheus_alert_time == 0:
+        if (
+            self.registry.get_telemetry().last_alert_at
+            and self.first_prometheus_alert_time == 0
+        ):
             first_alert = True
             self.first_prometheus_alert_time = time.time()
 


### PR DESCRIPTION
note that at least for pods, when there is no owner reference then the value is [] and not None. This might be the case for replicasets too, hence the change there