### PR TITLE
Update event-enrichment.rst

### DIFF
--- a/docs/catalog/actions/event-enrichment.rst
+++ b/docs/catalog/actions/event-enrichment.rst
@@ -27,7 +27,7 @@ Pod Enrichers
 
 These actions can add context to any pod-related event, be it from ``on_prometheus_alert`` or ``on_pod_update``.
 
-.. robusta-action:: playbooks.robusta_playbooks.alerts_integration.logs_enricher
+.. robusta-action:: playbooks.robusta_playbooks.alerts_integration.logs_enricher on_pod_crash_loop
 
 .. robusta-action:: playbooks.robusta_playbooks.bash_enrichments.pod_bash_enricher
 


### PR DESCRIPTION
Today the autogenerated docs for the `logs_enricher` action aren't great.

![Screen Shot 2022-06-13 at 18 35 38](https://user-images.githubusercontent.com/494087/173391061-20105db4-8171-4fe7-90c6-49e05ca01ae6.png)

While technically the `logs_enricher` action is compatible with the `on_pod_delete` trigger, it wouldn't make much sense to configure and it probably wouldn't work because the pod was deleted.

This tiny PR improves the autogenerated docs by explicitly instructing our Sphinx extension to use the `on_pod_crash_loop` trigger in the examples.