### PR TITLE
By default, only trigger on_prometheus_alert for firing alerts

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -35,7 +35,8 @@ playbooksPersistentVolumeSize: 4Gi
 priorityBuiltinPlaybooks:
 # playbooks for prometheus silencing
 - triggers:
-  - on_prometheus_alert: {}
+  - on_prometheus_alert:
+      status: "all"
   actions:
   - name_silencer:
       names: ["Watchdog", "KubeSchedulerDown", "KubeControllerManagerDown", "InfoInhibitor"]
@@ -118,7 +119,8 @@ builtinPlaybooks:
   actions:
   - deployment_status_enricher: {}
 - triggers:
-  - on_prometheus_alert: {}
+  - on_prometheus_alert:
+      status: "all"
   actions:
   - default_enricher: {}
 

--- a/src/robusta/core/playbooks/base_trigger.py
+++ b/src/robusta/core/playbooks/base_trigger.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from typing import Dict, Optional, Type, List
 
 from ..model.events import ExecutionBaseEvent
+from ...utils.documented_pydantic import DocumentedModel
 from ..model.k8s_operation_type import K8sOperationType
 from ..reporting.base import Finding
 import abc
@@ -14,7 +15,7 @@ class TriggerEvent(BaseModel):
         return ""
 
 
-class BaseTrigger(BaseModel):
+class BaseTrigger(DocumentedModel):
     def get_trigger_event(self) -> str:
         pass
 
@@ -22,7 +23,7 @@ class BaseTrigger(BaseModel):
         return True
 
     def build_execution_event(
-        self, event: TriggerEvent, sink_findings: Dict[str,List[Finding]]
+        self, event: TriggerEvent, sink_findings: Dict[str, List[Finding]]
     ) -> Optional[ExecutionBaseEvent]:
         pass
 

--- a/src/robusta/integrations/prometheus/trigger.py
+++ b/src/robusta/integrations/prometheus/trigger.py
@@ -35,8 +35,12 @@ MAPPINGS = [
 
 
 class PrometheusAlertTrigger(BaseTrigger):
+    """
+    :var status: one of "firing", "resolved", or "all"
+    """
+
     alert_name: str = None
-    status: str = None
+    status: str = "firing"
     pod_name_prefix: str = None
     namespace_prefix: str = None
     instance_name_prefix: str = None
@@ -52,7 +56,7 @@ class PrometheusAlertTrigger(BaseTrigger):
         if not exact_match(self.alert_name, labels["alertname"]):
             return False
 
-        if not exact_match(self.status, event.alert.status):
+        if self.status != "all" and not exact_match(self.status, event.alert.status):
             return False
 
         if not prefix_match(self.pod_name_prefix, labels.get("pod")):


### PR DESCRIPTION
This changes the default behaviour for `on_prometheus_alert` so that it only triggers for currently firing alerts, *unless configured otherwise*.

### Rationale
When configuring playbooks with `on_prometheus_alert`, most users don't want to run the action on resolved alerts. The previous default behave led to surprising behaviour. We know this because we received questions from users on why their playbook actions were failing and it was because they were unknowingly running the actions on resolved alerts. The same happened to me when I did some work on Prometheus alerts recently. 

### Docs
This change will need to be communicated in the release notes. I suggest the following text:

**Breaking: `on_prometheus_alert` will no longer trigger by default on resolved alerts. This can be overriden if you need. See the [docs](https://docs.robusta.dev/master/catalog/triggers/prometheus.html) for details**

### Other
This PR also includes a tiny fix for Sphinx documentation. The trigger classes didn't inherit from DocumentedModel so the following output was *not* shown properly in the docs:

<img width="766" alt="Screen Shot 2022-06-14 at 4 02 11" src="https://user-images.githubusercontent.com/494087/173471927-81be3e23-c31f-4c9e-b703-e83c37c63a0d.png">

Now it's fixed.
