### PR TITLE
Fix babysitter messages for creations and deletions

### DIFF
--- a/src/robusta/core/reporting/blocks.py
+++ b/src/robusta/core/reporting/blocks.py
@@ -148,6 +148,17 @@ class KubernetesDiffBlock(BaseBlock):
             num_modifications=num_modifications,
         )
 
+    def get_description(self):
+        if self.old is None:
+            return "Resource created"
+        elif self.new is None:
+            return "Resource deleted"
+        else:
+            return (
+                f"Updates to significant fields: {self.num_additions} additions, {self.num_deletions} deletions, "
+                f"{self.num_modifications} changes."
+            )
+
     @staticmethod
     def _obj_to_content(obj: Optional[HikaruDocumentBase]):
         if obj is None:


### PR DESCRIPTION
This should fix the misleading message on the timeline for creations/deletions (see below):

<img width="626" alt="Screen Shot 2022-03-24 at 17 12 12" src="https://user-images.githubusercontent.com/494087/177016692-6ee41b68-07b8-47ab-a6c5-1f29fca67e36.png">
m

I haven't tested this properly. Please do not merge without testing creations, deletions, and modifications and seeing that each one shows up properly.