### PR TITLE
if the current state isnt oomkilled send the correct state

### DIFF
--- a/playbooks/robusta_playbooks/oom_killer.py
+++ b/playbooks/robusta_playbooks/oom_killer.py
@@ -187,7 +187,7 @@ class OomKillsExtractor:
 
         # Check if the container OOMKilled by inspecting the lastState field
         if self.is_last_state_in_oom_status(c_status):
-            return c_status.state
+            return c_status.lastState
 
         # OOMKilled state not found
         return None


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/robusta/core/playbooks/playbooks_event_handler_impl.py", line 219, in __run_playbook_actions
    registered_action.func(execution_event, params)
  File "/usr/local/lib/python3.9/site-packages/robusta_playbooks/oom_killer.py", line 54, in oom_killer_enricher
    oom_kills = oom_kills_extractor.extract_oom_kills()
  File "/usr/local/lib/python3.9/site-packages/robusta_playbooks/oom_killer.py", line 133, in extract_oom_kills
    pod_oom_kills = self.get_oom_kills_from_pod(pod)
  File "/usr/local/lib/python3.9/site-packages/robusta_playbooks/oom_killer.py", line 155, in get_oom_kills_from_pod
    dt = parse_kubernetes_datetime_to_ms(state.terminated.finishedAt)
AttributeError: 'NoneType' object has no attribute 'finishedAt'

```
is the error we recieve

in `get_oom_killed_state`, `is_state_in_oom_status` verifies `state.terminated` isnt none so it must be from `is_last_state_in_oom_status` since it only verifies `c_status.lastState.terminated` isnt none and not `c_status.state.terminated `
so when we return the the `c_status.state` when the `c_status.lastState` had the oomkill it is possible there is no `c_status.state.terminated`
