### PR TITLE
Make underline longer to avoid sphinx build error

### DIFF
--- a/docs/tutorials/my-first-custom-action.rst
+++ b/docs/tutorials/my-first-custom-action.rst
@@ -200,7 +200,7 @@ Use this useful debugging commands to make sure your action ( ``report_schedulin
     ======================================================================
 
 Connecting the trigger to the action - a **playbook** is born!
--------------------------------------------------------------
+---------------------------------------------------------------
 
 We need to add a custom playbook that this action it in the generated_values.yaml.
 


### PR DESCRIPTION
Avoid this error when building the docs

```
Connecting the trigger to the action - a **playbook** is born!
-------------------------------------------------------------
/Users/natanyellin/Projects/robusta/docs/tutorials/my-first-custom-action.rst:203: WARNING: Title underline too short.
```