### PR TITLE
Modified docs_build.sh to support --port option

### DIFF
--- a/docs/developer-guide/platform/docs-contributions.rst
+++ b/docs/developer-guide/platform/docs-contributions.rst
@@ -23,9 +23,7 @@ If you need to override an existing doc release, you can manually trigger the wo
 Local Build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The docs definitions are ``.rst`` files.
-
-Learn more about ``.rst`` files `here <https://learnxinyminutes.com/docs/rst/>`_
+The docs definitions are ``.rst`` files. Learn more about ``.rst`` files `here <https://learnxinyminutes.com/docs/rst/>`_
 
 Prerequisites to be present on your local machine:
 
@@ -33,13 +31,19 @@ Prerequisites to be present on your local machine:
 * `Poetry <https://python-poetry.org/docs/>`_
 * `Sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_
 
-First install the build requirements:
+First download Robusta(`source code <https://github.com/robusta-dev/robusta.git>`_):
+
+.. code-block:: bash
+
+   git clone https://github.com/robusta-dev/robusta.git && cd robusta
+
+Install the build requirements:
 
 .. code-block:: bash
 
    poetry install -E all
 
-To build the html and develop locally run the script:
+To build the docs and develop locally run the script:
 
 .. code-block:: bash
 
@@ -55,3 +59,5 @@ Troubleshooting
 1. ``poetry: command not found`` - Make sure you have `Poetry <https://python-poetry.org/docs/>`_ installed and run ``source $HOME/.poetry/env`` in Linux environments to set the poetry environment variables.
 
 2. ``sphinx-build: command not found`` - Make sure you have `Sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ installed.
+
+3. ``OSError: [Errno 98] Address already in use`` - Use the ``--port <Number>`` argument, with a port of your choice. Example: ``./docs_autobuild.sh --port 8822``

--- a/docs_autobuild.sh
+++ b/docs_autobuild.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 cd docs && make clean && cd ..
+<<<<<<< HEAD
 
 if [ "$1" == "--port" ];then
     poetry run sphinx-autobuild $@ docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
 else
     poetry run sphinx-autobuild docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
 fi
+=======
+poetry run sphinx-autobuild $@ docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
+>>>>>>> 74c5024 (Sphinx autobuild and doc change)

--- a/docs_autobuild.sh
+++ b/docs_autobuild.sh
@@ -1,13 +1,4 @@
 #!/bin/bash
 
 cd docs && make clean && cd ..
-<<<<<<< HEAD
-
-if [ "$1" == "--port" ];then
-    poetry run sphinx-autobuild $@ docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
-else
-    poetry run sphinx-autobuild docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
-fi
-=======
 poetry run sphinx-autobuild $@ docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
->>>>>>> 74c5024 (Sphinx autobuild and doc change)

--- a/docs_autobuild.sh
+++ b/docs_autobuild.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 cd docs && make clean && cd ..
-poetry run sphinx-autobuild docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
+
+if [ "$1" == "--port" ];then
+    poetry run sphinx-autobuild $@ docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
+else
+    poetry run sphinx-autobuild docs docs/_build/html || printf '\n\nError running docs_autobuild. \nMake sure you are using poetry >= 1.1.15. \nCheck out https://docs.robusta.dev/master/developer-guide/platform/docs-contributions.html\n'
+fi


### PR DESCRIPTION
Fixes **OSError: [Errno 98] Address already in use** error, caused when the default **sphinx-autobuild** port (8000) is reserved. 


![image](https://user-images.githubusercontent.com/25551553/188435732-f11dde4e-5b4b-43be-890c-a142fae649d9.png)
