### PR TITLE
Fix edge case where `robusta logs` failed

### DIFF
--- a/src/robusta/cli/utils.py
+++ b/src/robusta/cli/utils.py
@@ -46,11 +46,11 @@ def exec_in_robusta_runner(
     return subprocess.check_call(cmd)
 
 
-def exec_in_robusta_runner_output(command: str, namespace: Optional[str]) -> Optional[bytes]:
+def exec_in_robusta_runner_output(
+    command: str, namespace: Optional[str]
+) -> Optional[bytes]:
     exec_cmd = _build_exec_command(command, namespace)
-    result = subprocess.check_output(
-        exec_cmd
-    )
+    result = subprocess.check_output(exec_cmd)
     return result
 
 
@@ -126,10 +126,13 @@ def get_package_name(playbooks_dir: str) -> str:
 
 
 def get_runner_pod(namespace: str) -> Optional[str]:
-    return subprocess.run(  
-        f'kubectl get pods {namespace_to_kubectl(namespace)} --selector="robustaComponent=runner" --no-headers -o custom-columns=":metadata.name"',
+    return subprocess.run(
+        f"kubectl get pods {namespace_to_kubectl(namespace)} "
+        f'--selector="robustaComponent=runner" '
+        f"--field-selector=status.phase==Running "
+        f"--no-headers "
+        f'-o custom-columns=":metadata.name"',
         shell=True,
         text=True,
         capture_output=True,
     ).stdout.strip()
-


### PR DESCRIPTION
The `robusta logs` command is broken on the following edge case and this PR fixes it.

# The Edge Case
I use spot instances on one of my clusters. This led to a situation where a node on which Robusta was running was terminated and I ended up with three Robusta pods (obviously only one of which is running):

<img width="1173" alt="Screen Shot 2022-09-09 at 17 00 50" src="https://user-images.githubusercontent.com/494087/189452853-86ba81d1-d35f-43d0-9c7b-39959c1872d4.png">

<img width="794" alt="Screen Shot 2022-09-10 at 1 13 57" src="https://user-images.githubusercontent.com/494087/189452925-45f4e106-4cac-450d-be28-314878a1aa6a.png">