### PR TITLE
fixed memory spec parse

### DIFF
--- a/src/robusta/core/model/pods.py
+++ b/src/robusta/core/model/pods.py
@@ -96,7 +96,7 @@ class PodResources(BaseModel):
                 return int(mem_spec[:-1]) * k8s_memory_factors[mem_spec[-1]]
 
             try:
-                return float(mem_spec)
+                return int(mem_spec)
             except ValueError:
                 raise Exception("number of bytes could not be extracted from memory spec: " + mem_spec)
 

--- a/src/robusta/core/model/pods.py
+++ b/src/robusta/core/model/pods.py
@@ -95,7 +95,10 @@ class PodResources(BaseModel):
             if len(mem_spec) > 1 and mem_spec[-1] in k8s_memory_factors:
                 return int(mem_spec[:-1]) * k8s_memory_factors[mem_spec[-1]]
 
-            raise Exception("number of bytes could not be extracted from memory spec: " + mem_spec)
+            try:
+                return float(mem_spec)
+            except ValueError:
+                raise Exception("number of bytes could not be extracted from memory spec: " + mem_spec)
 
         except Exception as e: # could be a valueError with mem_spec
             logging.error(f"error parsing memory {mem_spec}", exc_info=True)


### PR DESCRIPTION
```2022-09-10 05:46:26.297 ERROR    error parsing memory 268435456
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/robusta/core/model/pods.py", line 98, in get_number_of_bytes_from_kubernetes_mem_spec
    raise Exception("number of bytes could not be extracted from memory spec: " + mem_spec)
Exception: number of bytes could not be extracted from memory spec: 268435456```