### PR TITLE
removing config map changes by default

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -181,14 +181,6 @@ platformPlaybooks:
     - resource_babysitter: {}
   sinks:
     - "robusta_ui_sink"
-- triggers:
-    - on_configmap_all_changes: {}
-  actions:
-    - resource_babysitter:
-        fields_to_monitor: ["ConfigMap.data"]
-        ignored_namespaces: ["kube-system"] # kube-system configmaps updated a lot (spammy)
-  sinks:
-    - "robusta_ui_sink"
 
 # parameters for the robusta forwarder deployment
 kubewatch:


### PR DESCRIPTION
-- breaking changes - Removed config-map playbooks from built in playbook
need to alert users of change
this was removed due to spammy config map changes were sent to UI