### PR TITLE
Hard delete jobs

### DIFF
--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -305,7 +305,8 @@ class SupabaseDal:
                 .eq("cluster_id", self.cluster)
                 .eq("service_key", job.get_service_key())))
         status_code = res.get("status_code")
-        if status_code != 204:
+        valid_deleted_statuses = [204, 200, 202]
+        if status_code not in valid_deleted_statuses:
             logging.error(
                 f"Failed to delete job {job} error: {res.get('data')}"
             )

--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -283,8 +283,7 @@ class SupabaseDal:
         if not jobs:
             return
 
-        db_jobs = [self.__to_db_job(job) for job in jobs if job.deleted == False]
-
+        db_jobs = [self.__to_db_job(job) for job in jobs]
         res = (
             self.client.table(JOBS_TABLE).insert(db_jobs, upsert=True).execute()
         )

--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -322,10 +322,17 @@ class SupabaseDal:
         url: str = str(supabase_request_obj.session.base_url).rstrip("/")
         query: str = str(supabase_request_obj.session.params)
         response = requests.delete(f"{url}?{query}", headers=supabase_request_obj.session.headers)
+        response_data = ''
+        try:
+            response_data = response.json()
+        except Exception: # this can be okay if no data is expected
+            logging.warning(f"Failed to parse delete response data")
+
         return {
-            "data": '' if response.status_code == 204 else response.json(),
+            "data": response_data,
             "status_code": response.status_code,
         }
+
 
     def sign_in(self):
         if time.time() > self.sign_in_time + SUPABASE_LOGIN_RATE_LIMIT_SEC:

--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -308,10 +308,10 @@ class SupabaseDal:
         status_code = res.get("status_code")
         if status_code != 204:
             logging.error(
-                f"Failed to delete jobs {job} error: {res.get('data')}"
+                f"Failed to delete job {job} error: {res.get('data')}"
             )
             self.handle_supabase_error()
-            raise Exception(f"remove deleted job jobs failed. status: {status_code}")
+            raise Exception(f"remove deleted job failed. status: {status_code}")
 
 
     @staticmethod

--- a/src/robusta/core/sinks/robusta/robusta_sink.py
+++ b/src/robusta/core/sinks/robusta/robusta_sink.py
@@ -291,6 +291,7 @@ class RobustaSink(SinkBase):
 
     def __safe_delete_job(self, job_key):
         try:
+            # incase remove_deleted_job fails we mark it deleted in cache so our DB atleast has it saved as deleted instead of active
             self.__jobs_cache[job_key].deleted = True
             self.dal.remove_deleted_job(self.__jobs_cache[job_key])
             del self.__jobs_cache[job_key]

--- a/src/robusta/core/sinks/robusta/robusta_sink.py
+++ b/src/robusta/core/sinks/robusta/robusta_sink.py
@@ -291,13 +291,11 @@ class RobustaSink(SinkBase):
 
     def __safe_delete_job(self, job_key):
         try:
-            #TODO: REMOVE LOG
-            logging.info(f"Deleting job {self.__jobs_cache[job_key]}")
             self.__jobs_cache[job_key].deleted = True
             self.dal.remove_deleted_job(self.__jobs_cache[job_key])
             del self.__jobs_cache[job_key]
         except Exception:
-            logging.error(f"Failed to delete job {self.__jobs_cache[job_key]}", exc_info=True)
+            logging.error(f"Failed to delete job with service key {job_key}", exc_info=True)
 
     def __publish_new_jobs(self, active_jobs: List[JobInfo]):
         # convert to map


### PR DESCRIPTION
this version of supabase_py has a bug in delete.
```
# in package supabase_py/lib/query_builder.py for the 
def _execute_monkey_patch(self) -> Dict[str, Any]:
    """Temporary method to enable syncronous client code."""
    method: str = self.http_method.lower()
    additional_kwargs: Dict[str, Any] = {}
    if method == "get":
        func = requests.get
    elif method == "post":
        func = requests.post
        # Additionally requires the json body (e.g on insert, self.json==row).
        additional_kwargs = {"json": self.json}
    elif method == "put":
        func = requests.put
    elif method == "patch":
        func = requests.patch
    elif method == "delete":
        func = requests.delete
    else:
        raise NotImplementedError(f"Method '{method}' not recognised.")
    url: str = str(self.session.base_url).rstrip("/")
    query: str = str(self.session.params)
    response = func(f"{url}?{query}", headers=self.session.headers, **additional_kwargs)
    return {
        "data": response.json(),
        "status_code": response.status_code,
    }

QueryRequestBuilder.execute = _execute_monkey_patch
```
response.json() throws an exception on status code 204(no content) since there is no data to be decoded
delete success returns 204
We have a similar solution in relay