### PR TITLE
null  ContainerImage names bugfix

### DIFF
--- a/src/robusta/patch/patch.py
+++ b/src/robusta/patch/patch.py
@@ -38,7 +38,7 @@ def create_monkey_patches():
 
 def names(self, names):
     if names:
-    self._names = names
+        self._names = names
     else:
         self._names = ['']
 

--- a/src/robusta/patch/patch.py
+++ b/src/robusta/patch/patch.py
@@ -4,6 +4,7 @@ from dataclasses import is_dataclass, InitVar
 from inspect import signature, getmodule
 from hikaru import HikaruDocumentBase, HikaruBase
 from ruamel.yaml import YAML
+from kubernetes.client.models.v1_container_image import V1ContainerImage
 
 try:
     from typing import get_args, get_origin
@@ -29,7 +30,14 @@ def create_monkey_patches():
     # We added caching to search for the plugins only once
     logging.info("Creating yaml monkey patch")
     YAML.official_plug_ins = official_plug_ins
+    # The patched method is due to a bug in containerd that allows for containerImages to have no names
+    # which causes the kubernetes python api to throw an exception
+    logging.info("Creating kubernetes container monkey patch")
+    V1ContainerImage.names = V1ContainerImage.names.setter(names)
 
+
+def names(self, names):
+    self._names = names
 
 def official_plug_ins(self):
     return []

--- a/src/robusta/patch/patch.py
+++ b/src/robusta/patch/patch.py
@@ -3,7 +3,6 @@ from typing import Union, List, Dict, get_type_hints, Optional
 from dataclasses import is_dataclass, InitVar
 from inspect import signature, getmodule
 from hikaru import HikaruDocumentBase, HikaruBase
-from hikaru.model import ContainerImage
 from ruamel.yaml import YAML
 from kubernetes.client.models.v1_container_image import V1ContainerImage
 


### PR DESCRIPTION
ContainerImages names can be None due to a containerd bug
we had to patch Hikaru - ContainerImage, and kubernetes python cli ContainerImage.
```
2022-11-10 12:15:57.973 ERROR    Failed to build execution event for update-Node-v1
2022-11-10 12:16:13.720 ERROR    Failed to run periodic nodes discovery
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/robusta/core/discovery/discovery.py", line 104, in discovery_process
    current_nodes: V1NodeList = client.CoreV1Api().list_node()
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api/core_v1_api.py", line 16414, in list_node
    return self.list_node_with_http_info(**kwargs)  # noqa: E501
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api/core_v1_api.py", line 16517, in list_node_with_http_info
    return self.api_client.call_api(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 192, in __call_api
    return_data = self.deserialize(response_data, response_type)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 264, in deserialize
    return self.__deserialize(data, response_type)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 303, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 639, in __deserialize_model
    kwargs[attr] = self.__deserialize(value, attr_type)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 280, in __deserialize
    return [self.__deserialize(sub_data, sub_kls)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 280, in <listcomp>
    return [self.__deserialize(sub_data, sub_kls)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 303, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 639, in __deserialize_model
    kwargs[attr] = self.__deserialize(value, attr_type)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 303, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 639, in __deserialize_model
    kwargs[attr] = self.__deserialize(value, attr_type)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 280, in __deserialize
    return [self.__deserialize(sub_data, sub_kls)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 280, in <listcomp>
    return [self.__deserialize(sub_data, sub_kls)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 303, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 641, in __deserialize_model
    instance = klass(**kwargs)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/models/v1_container_image.py", line 55, in __init__
    self.names = names
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/models/v1_container_image.py", line 80, in names
    raise ValueError("Invalid value for `names`, must not be `None`")  # noqa: E501

```