### PR TITLE
Add account context to silence button

### DIFF
--- a/src/robusta/core/reporting/base.py
+++ b/src/robusta/core/reporting/base.py
@@ -259,10 +259,11 @@ class Finding(Filterable):
     def __str__(self):
         return f"title: {self.title} desc: {self.description} severity: {self.severity} sub-name: {self.subject.name} sub-type:{self.subject.subject_type.value} enrich: {self.enrichments}"
 
-    def get_prometheus_silence_url(self, cluster_id: str) -> str:
+    def get_prometheus_silence_url(self, account_id: str, cluster_name: str) -> str:
         labels: Dict[str, str] = {
             "alertname": self.aggregation_key,
-            "cluster": cluster_id,
+            "cluster": cluster_name,
+            "account": account_id
         }
         if self.subject.namespace:
             labels["namespace"] = self.subject.namespace

--- a/src/robusta/core/sinks/opsgenie/opsgenie_sink.py
+++ b/src/robusta/core/sinks/opsgenie/opsgenie_sink.py
@@ -89,7 +89,7 @@ class OpsGenieSink(SinkBase):
         if platform_enabled:
             description = f'<a href="{finding.get_investigate_uri(self.account_id, self.cluster_name)}">🔎 Investigate</a>'
             if finding.add_silence_url:
-                description = f'{description}  <a href="{finding.get_prometheus_silence_url(self.cluster_name)}">🔕 Silence</a>'
+                description = f'{description}  <a href="{finding.get_prometheus_silence_url(self.account_id, self.cluster_name)}">🔕 Silence</a>'
 
             for video_link in finding.video_links:
                 description = f"{description}  <a href=\"{video_link.url}\">🎬 {video_link.name}</a>"

--- a/src/robusta/core/sinks/pagerduty/pagerduty_sink.py
+++ b/src/robusta/core/sinks/pagerduty/pagerduty_sink.py
@@ -55,10 +55,7 @@ class PagerdutySink(SinkBase):
             custom_details["🔎 Investigate"] = finding.get_investigate_uri(self.account_id, self.cluster_name)
 
             if finding.add_silence_url:
-                custom_details["🔕 Silence"] = finding.get_prometheus_silence_url(
-                    self.cluster_name
-                )
-
+                custom_details["🔕 Silence"] = finding.get_prometheus_silence_url(self.account_id, self.cluster_name)
         # custom fields that don't have an inherent meaning in PagerDuty itself:
         custom_details["Resource"] = finding.subject.name
         custom_details["Cluster running Robusta"] = self.cluster_name

--- a/src/robusta/core/sinks/sink_base.py
+++ b/src/robusta/core/sinks/sink_base.py
@@ -10,8 +10,8 @@ class SinkBase:
         self.registry = registry
         global_config = self.registry.get_global_config()
 
-        self.account_id = global_config.get("account_id", "")
-        self.cluster_name = global_config.get("cluster_name", "")
+        self.account_id : str = global_config.get("account_id", "")
+        self.cluster_name : str = global_config.get("cluster_name", "")
         self.signing_key = global_config.get("signing_key", "")
 
     def is_global_config_changed(self):

--- a/src/robusta/core/sinks/telegram/telegram_sink.py
+++ b/src/robusta/core/sinks/telegram/telegram_sink.py
@@ -57,7 +57,7 @@ class TelegramSink(SinkBase):
         if platform_enabled:
             message_content += f"[{INVESTIGATE_ICON} Investigate]({finding.get_investigate_uri(self.account_id, self.cluster_name)}) "
             if finding.add_silence_url:
-                message_content += f"[{SILENCE_ICON} Silence]({finding.get_prometheus_silence_url(self.cluster_name)})"
+                message_content += f"[{SILENCE_ICON} Silence]({finding.get_prometheus_silence_url(self.account_id, self.cluster_name)})"
 
             for video_link in finding.video_links:
                 message_content = f"[{VIDEO_ICON} {video_link.name}]({video_link.url})"

--- a/src/robusta/core/sinks/victorops/victorops_sink.py
+++ b/src/robusta/core/sinks/victorops/victorops_sink.py
@@ -28,7 +28,7 @@ class VictoropsSink(SinkBase):
             if finding.add_silence_url:
                 json_dict[
                     "vo_annotate.u.🔕 Silence"
-                ] = finding.get_prometheus_silence_url(self.cluster_name)
+                ] = finding.get_prometheus_silence_url(self.account_id, self.cluster_name)
 
             for video_link in finding.video_links:
                 json_dict[

--- a/src/robusta/core/sinks/webex/webex_sink.py
+++ b/src/robusta/core/sinks/webex/webex_sink.py
@@ -11,6 +11,7 @@ class WebexSink(SinkBase):
         self.sender = WebexSender(
             bot_access_token=sink_config.webex_sink.bot_access_token,
             room_id=sink_config.webex_sink.room_id,
+            account_id=self.account_id,
             cluster_name=self.cluster_name,
         )
 

--- a/src/robusta/core/sinks/webhook/webhook_sink.py
+++ b/src/robusta/core/sinks/webhook/webhook_sink.py
@@ -23,7 +23,7 @@ class WebhookSink(SinkBase):
             message_lines.append(f"Investigate: {finding.get_investigate_uri(self.account_id, self.cluster_name)}")
 
             if finding.add_silence_url:
-                message_lines.append(f"Silence: {finding.get_prometheus_silence_url(self.cluster_name)}")
+                message_lines.append(f"Silence: {finding.get_prometheus_silence_url(self.account_id, self.cluster_name)}")
 
             for video_link in finding.video_links:
                 message_lines.append(f"{video_link.name}: {video_link.url}")

--- a/src/robusta/integrations/discord/sender.py
+++ b/src/robusta/integrations/discord/sender.py
@@ -253,7 +253,7 @@ class DiscordSender:
         if platform_enabled:  # add link to the robusta ui, if it's configured
             actions = f"[:mag_right: Investigate]({finding.get_investigate_uri(self.account_id, self.cluster_name)})"
             if finding.add_silence_url:
-                actions = f"{actions} [:no_bell: Silence]({finding.get_prometheus_silence_url(self.cluster_name)})"
+                actions = f"{actions} [:no_bell: Silence]({finding.get_prometheus_silence_url(self.account_id, self.cluster_name)})"
 
             for video_link in finding.video_links:
                 actions = f"{actions} [:clapper: {video_link.name}]({video_link.url})"

--- a/src/robusta/integrations/mattermost/sender.py
+++ b/src/robusta/integrations/mattermost/sender.py
@@ -135,7 +135,7 @@ class MattermostSender:
         if platform_enabled:  # add link to the robusta ui, if it's configured
             actions = f"[:mag_right: Investigate]({finding.get_investigate_uri(self.account_id, self.cluster_name)})"
             if finding.add_silence_url:
-                actions = f"{actions} [:no_bell: Silence]({finding.get_prometheus_silence_url(self.cluster_name)})"
+                actions = f"{actions} [:no_bell: Silence]({finding.get_prometheus_silence_url(self.account_id, self.cluster_name)})"
             for video_link in finding.video_links:
                 actions = f"{actions} [:clapper: {video_link.name}]({video_link.url})"
 

--- a/src/robusta/integrations/msteams/msteams_msg.py
+++ b/src/robusta/integrations/msteams/msteams_msg.py
@@ -33,7 +33,7 @@ class MsTeamsMsg:
         block = MsTeamsTextBlock(text=f"{severity.to_emoji()} {severity.name} - {finding.title}", font_size='extraLarge')
         self.__write_to_entire_msg([block])
         if platform_enabled:  # add link to the Robusta ui, if it's configured
-            silence_url = finding.get_prometheus_silence_url(cluster_name)
+            silence_url = finding.get_prometheus_silence_url(account_id, cluster_name)
             actions = f"[🔎 Investigate]({finding.get_investigate_uri(account_id, cluster_name)})"
             if finding.add_silence_url:
                 actions = f"{actions}  [🔕 Silence]({silence_url})"

--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -267,7 +267,7 @@ class SlackSender:
         title = finding.title.removeprefix("[RESOLVED] ")
         sev = finding.severity
         if platform_enabled:
-            title = f"<{finding.investigate_uri}|*{title}*>"
+            title = f"<{finding.get_investigate_uri(self.account_id, self.cluster_name)}|*{title}*>"
 
         status_str: str = (
             f"{status.to_emoji()} `{status.name.lower()}`"
@@ -293,7 +293,7 @@ class SlackSender:
             links.append(
                 LinkProp(
                     text=f"Silence 🔕",
-                    url=finding.get_prometheus_silence_url(self.cluster_name),
+                    url=finding.get_prometheus_silence_url(self.account_id, self.cluster_name),
                 )
             )
 

--- a/src/robusta/integrations/webex/sender.py
+++ b/src/robusta/integrations/webex/sender.py
@@ -34,9 +34,10 @@ class WebexSender:
     Parse different findings to show on Webex UI
     """
 
-    def __init__(self, bot_access_token: str, room_id: str, cluster_name: str):
+    def __init__(self, bot_access_token: str, room_id: str, account_id: str, cluster_name: str):
         self.cluster_name = cluster_name
         self.room_id = room_id
+        self.account_id = account_id
         self.client = WebexTeamsAPI(
             access_token=bot_access_token
         )  # Create a client using webexteamssdk
@@ -142,7 +143,7 @@ class WebexSender:
         description = None
 
         message_content = self._create_message_content(
-            finding, platform_enabled, self.cluster_name
+            finding, platform_enabled
         )
 
         blocks = [MarkdownBlock(text=f"*Source:* _{self.cluster_name}_\n\n")]
@@ -202,18 +203,18 @@ class WebexSender:
                     )
                     f.close()  # File is deleted when closed
 
-    @classmethod
+
     def _create_message_content(
-        self, finding: Finding, platform_enabled: bool, cluster_name: str
+        self, finding: Finding, platform_enabled: bool
     ):
         message_content = self.__build_webex_title(finding.title, finding.severity)
 
         if platform_enabled:
             message_content += (
-                f"[{INVESTIGATE_ICON} Investigate]({finding.investigate_uri}) "
+                f"[{INVESTIGATE_ICON} Investigate]({finding.get_investigate_uri(self.account_id, self.cluster_name)}) "
             )
             if finding.add_silence_url:
-                message_content += f"[{SILENCE_ICON} Silence]({finding.get_prometheus_silence_url(cluster_name)})"
+                message_content += f"[{SILENCE_ICON} Silence]({finding.get_prometheus_silence_url(self.account_id, self.cluster_name)})"
 
             message_content += "\n\n"
 


### PR DESCRIPTION
Update sinks get_silence_url call with the account. some minor changes to the webex sink to support that as well.
@anFatum  you did something similar with the investigate url, so I could use your review here.