### PR TITLE
Add host param to opsgenie_sink

### DIFF
--- a/src/robusta/core/sinks/opsgenie/opsgenie_sink.py
+++ b/src/robusta/core/sinks/opsgenie/opsgenie_sink.py
@@ -31,6 +31,9 @@ class OpsGenieSink(SinkBase):
         self.conf = opsgenie_sdk.configuration.Configuration()
         self.conf.api_key["Authorization"] = self.api_key
 
+        if sink_config.opsgenie_sink.host is not None:
+            self.conf.host = sink_config.opsgenie_sink.host
+
         self.api_client = opsgenie_sdk.api_client.ApiClient(configuration=self.conf)
         self.alert_api = opsgenie_sdk.AlertApi(api_client=self.api_client)
 

--- a/src/robusta/core/sinks/opsgenie/opsgenie_sink_params.py
+++ b/src/robusta/core/sinks/opsgenie/opsgenie_sink_params.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from ..sink_config import SinkConfigBase
 from ..sink_base_params import SinkBaseParams
@@ -8,6 +8,7 @@ class OpsGenieSinkParams(SinkBaseParams):
     api_key: str
     teams: List[str] = []
     tags: List[str] = []
+    host: Optional[str] = None  # NOTE: If None, the default value will be used from opsgenie_sdk
 
 
 class OpsGenieSinkConfigWrapper(SinkConfigBase):


### PR DESCRIPTION
Added a new parameter to opsgenie sink: `host`
If it is not provided it will be `None`, meaning the default from opsgenie_sdk will be used.
Otherwise - it will be used in ospgenie configuration.

See https://docs.opsgenie.com/docs/opsgenie-python-sdk-configurations