### PR TITLE
Encoding RSAKeyPair by default with new public and private values

### DIFF
--- a/helm/robusta/templates/auth-config.yaml
+++ b/helm/robusta/templates/auth-config.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
+{{- if and .Values.rsa.public .Values.rsa.private }}
+  prv: {{ .Values.rsa.private }}
+  pub: {{ .Values.rsa.public }}
+{{- else }}
   prv: {{ .Values.rsa.prv | b64enc }}
   pub: {{ .Values.rsa.pub | b64enc }}
+{{- end }}
 {{- end }}

--- a/src/robusta/cli/auth.py
+++ b/src/robusta/cli/auth.py
@@ -22,10 +22,10 @@ app = typer.Typer()
 
 
 class RSAKeyPair(BaseModel):
-    prv: str = "none"
-    pub: str = "none"
-    private: str = "none"
-    public: str = "none"
+    prv: str = None
+    pub: str = None
+    private: str = None
+    public: str = None
 
 
 def gen_rsa_pair() -> RSAKeyPair:

--- a/src/robusta/cli/auth.py
+++ b/src/robusta/cli/auth.py
@@ -22,8 +22,10 @@ app = typer.Typer()
 
 
 class RSAKeyPair(BaseModel):
-    prv: str
-    pub: str
+    prv: str = "none"
+    pub: str = "none"
+    private: str = "none"
+    public: str = "none"
 
 
 def gen_rsa_pair() -> RSAKeyPair:
@@ -41,8 +43,8 @@ def gen_rsa_pair() -> RSAKeyPair:
     )
 
     return RSAKeyPair(
-        pub=public_key.decode('utf-8'),
-        prv=pem.decode('utf-8')
+        public=base64.b64encode(public_key),
+        private=base64.b64encode(pem)
     )
 
 


### PR DESCRIPTION
* Modified the auth-config helm chart with new public and private values.
* Added code to encode RSA keys by default.