### PR TITLE
Updating free videos link

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -6,7 +6,7 @@ Kubernetes Kommunity
 
 Our free videos on Kubernetes are fairly popular. They are extremely short (under five minutes) and mildly entertaining.
 
-See `Kubernetes Kommunity for details <https://home.robusta.dev/learning/>`_
+See `Kubernetes Kommunity for details <https://home.robusta.dev/videos>`_
 
 Join the conversation
 ----------------------


### PR DESCRIPTION
Earlier the videos link redirected to https://home.robusta.dev/learning which gave a 404 updated it to https://home.robusta.dev/videos