### PR TITLE
Fix pre-merge checks

### DIFF
--- a/.github/workflows/test_robusta.yaml
+++ b/.github/workflows/test_robusta.yaml
@@ -1,6 +1,6 @@
 name: Test robusta with pytest
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
     run_tests:


### PR DESCRIPTION
Right now the `run_tests` actions doesn't run when you open a PR. It only runs when a commit is pushed after opening the PR, or on an approved branch (I think) before opening the PR.