### PR TITLE
Removed space that was getting replaced as + in the UI

### DIFF
--- a/playbooks/robusta_playbooks/cpu_throttling.py
+++ b/playbooks/robusta_playbooks/cpu_throttling.py
@@ -51,7 +51,7 @@ def cpu_throttling_analysis_enricher(event: PodEvent):
                 MarkdownBlock( 
                     f"{Emojis.Recommend.value} *Robusta's Recommendation:* Remove this pod's CPU limit entirely. <https://home.robusta.dev/"
                     "blog/stop-using-cpu-limits/"
-                    " |Using CPU limits is *not* a best "
+                    "|Using CPU limits is *not* a best "
                     "practice.>"
                 ),
             ],


### PR DESCRIPTION
This fixes the "+" that was breaking the link. 
![image](https://user-images.githubusercontent.com/25551553/213201724-cb7ea5cc-709c-4ad4-a01b-709aa01179f0.png)
