### PR TITLE
Add nodeSelectors for kubewatch and runner to values.yaml

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -255,6 +255,7 @@ kubewatch:
       cpu: ~
   tolerations: []
   annotations: {}
+  nodeSelector: ~
 
 # parameters for the renderer service used in robusta runner to render grafana graphs
 grafanaRenderer:
@@ -286,6 +287,7 @@ runner:
   additional_env_froms: []
   tolerations: []
   annotations: {}
+  nodeSelector: ~
 
 kube-prometheus-stack:
   alertmanager:
@@ -354,5 +356,3 @@ kube-prometheus-stack:
         cpu: 10m
 
 rsa: ~
-
-


### PR DESCRIPTION
They already exist in the templates, this just documents them.

**UNTESTED!** Do not merge without testing.