### PR TITLE
added a job failure to built in playbooks

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -94,6 +94,18 @@ builtinPlaybooks:
   - image_pull_backoff_reporter:
       rate_limit: 3600
 
+- triggers:
+  - on_job_failure: {}
+  actions:
+  - create_finding:
+      aggregation_key: "job_failure"
+      title: "Job Failed"
+  - job_info_enricher: {}
+  - job_events_enricher: {}
+  - job_pod_enricher: {}
+  sinks:
+    - "robusta_ui_sink"
+
 # playbooks for non-prometheus based monitoring that use prometheus for enrichment
 - triggers:
   - on_pod_oom_killed:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -94,18 +94,6 @@ builtinPlaybooks:
   - image_pull_backoff_reporter:
       rate_limit: 3600
 
-- triggers:
-  - on_job_failure: {}
-  actions:
-  - create_finding:
-      aggregation_key: "job_failure"
-      title: "Job Failed"
-  - job_info_enricher: {}
-  - job_events_enricher: {}
-  - job_pod_enricher: {}
-  sinks:
-    - "robusta_ui_sink"
-
 # playbooks for non-prometheus based monitoring that use prometheus for enrichment
 - triggers:
   - on_pod_oom_killed:
@@ -251,6 +239,17 @@ platformPlaybooks:
     - on_statefulset_all_changes: {}
   actions:
     - resource_babysitter: {}
+  sinks:
+    - "robusta_ui_sink"
+- triggers:
+  - on_job_failure: {}
+  actions:
+  - create_finding:
+      aggregation_key: "job_failure"
+      title: "Job Failed"
+  - job_info_enricher: {}
+  - job_events_enricher: {}
+  - job_pod_enricher: {}
   sinks:
     - "robusta_ui_sink"
 


### PR DESCRIPTION
added on job failure trigger to built in playbooks,
It's more immediately fired than prometheus so it can give logs for pods that will be terminated after job failure.