### PR TITLE
removed non supported options --install-completion,  --show-completion

### DIFF
--- a/src/robusta/cli/auth.py
+++ b/src/robusta/cli/auth.py
@@ -19,7 +19,7 @@ from robusta.cli.playbooks_cmd import NAMESPACE_EXPLANATION, get_playbooks_confi
 from robusta.cli.utils import exec_in_robusta_runner_output, namespace_to_kubectl
 
 AUTH_SECRET_NAME = "robusta-auth-config-secret"
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 
 
 class RSAKeyPair(BaseModel):

--- a/src/robusta/cli/integrations_cmd.py
+++ b/src/robusta/cli/integrations_cmd.py
@@ -11,7 +11,7 @@ import typer
 from robusta.cli.backend_profile import backend_profile
 from robusta.cli.utils import log_title
 
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 
 SLACK_INTEGRATION_SERVICE_ADDRESS = os.environ.get(
     "SLACK_INTEGRATION_SERVICE_ADDRESS",

--- a/src/robusta/cli/main.py
+++ b/src/robusta/cli/main.py
@@ -34,7 +34,7 @@ from robusta.integrations.prometheus.utils import AlertManagerDiscovery
 # TODO - separate shared classes to a separated shared repo, to remove dependencies between the cli and runner
 
 
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 app.add_typer(playbooks_commands, name="playbooks", help="Playbooks commands menu")
 app.add_typer(integrations_commands, name="integrations", help="Integrations commands menu")
 app.add_typer(auth_commands, name="auth", help="Authentication commands menu")

--- a/src/robusta/cli/playbooks_cmd.py
+++ b/src/robusta/cli/playbooks_cmd.py
@@ -27,7 +27,7 @@ PLAYBOOKS_MOUNT_LOCATION = "/etc/robusta/playbooks/storage"
 NAMESPACE_EXPLANATION = "Installation namespace. If none use the namespace currently active with kubectl."
 CONFIG_SECRET_NAME = "robusta-playbooks-config-secret"
 
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 
 
 def __validate_playbooks_dir(playbooks_dir: str) -> bool:

--- a/src/robusta/cli/self_host.py
+++ b/src/robusta/cli/self_host.py
@@ -123,7 +123,7 @@ class SelfHostValues(BaseModel):
     enableRobustaUI: bool = True
 
 
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 
 
 @app.command()


### PR DESCRIPTION
removed those options in robusta CLI:

```
Options:
  --install-completion [bash|zsh|fish|powershell|pwsh]
                                  Install completion for the specified shell.
  --show-completion [bash|zsh|fish|powershell|pwsh]
                                  Show completion for the specified shell, to
                                  copy it or customize the installation.
```
