### PR TITLE
slack add support for additional cert

### DIFF
--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -68,3 +68,6 @@ TRACE_INCOMING_REQUESTS = bool(os.environ.get("TRACE_INCOMING_REQUESTS", False))
 
 SERVICE_CACHE_TTL_SEC = int(os.environ.get("SERVICE_CACHE_TTL_SEC", 900))
 SERVICE_CACHE_MAX_SIZE = int(os.environ.get("SERVICE_CACHE_MAX_SIZE", 1000))
+
+# additional certificate to verify, base64 encoded.
+ADDITIONAL_CERTIFICATE: str = os.environ.get("CERTIFICATE", "")

--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -47,7 +47,6 @@ class SlackSender:
                 ssl_context = ssl.create_default_context(cafile=certifi.where())
             except Exception as e:
                 logging.exception(f"Failed to use custom certificate. {e}")
-                ssl_context = None
 
         self.slack_client = WebClient(token=slack_token, ssl=ssl_context)
         self.signing_key = signing_key

--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -41,7 +41,14 @@ class SlackSender:
         Connect to Slack and verify that the Slack token is valid.
         Return True on success, False on failure
         """
-        ssl_context = ssl.create_default_context(cafile=certifi.where()) if ADDITIONAL_CERTIFICATE else None
+        ssl_context = None
+        if ADDITIONAL_CERTIFICATE:
+            try:
+                ssl_context = ssl.create_default_context(cafile=certifi.where())
+            except Exception as e:
+                logging.exception(f"Failed to use custom certificate. {e}")
+                ssl_context = None
+
         self.slack_client = WebClient(token=slack_token, ssl=ssl_context)
         self.signing_key = signing_key
         self.account_id = account_id

--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -1,11 +1,13 @@
 import logging
+import ssl
 import tempfile
 from typing import Any, Dict, List
 
+import certifi
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from robusta.core.model.env_vars import SLACK_TABLE_COLUMNS_LIMIT
+from robusta.core.model.env_vars import ADDITIONAL_CERTIFICATE, SLACK_TABLE_COLUMNS_LIMIT
 from robusta.core.reporting.base import Emojis, Finding, FindingStatus
 from robusta.core.reporting.blocks import (
     BaseBlock,
@@ -39,7 +41,8 @@ class SlackSender:
         Connect to Slack and verify that the Slack token is valid.
         Return True on success, False on failure
         """
-        self.slack_client = WebClient(token=slack_token)
+        ssl_context = ssl.create_default_context(cafile=certifi.where()) if ADDITIONAL_CERTIFICATE else None
+        self.slack_client = WebClient(token=slack_token, ssl=ssl_context)
         self.signing_key = signing_key
         self.account_id = account_id
         self.cluster_name = cluster_name

--- a/src/robusta/runner/main.py
+++ b/src/robusta/runner/main.py
@@ -1,7 +1,5 @@
-import os
-import os.path
-
 from robusta.core.model.env_vars import (
+    ADDITIONAL_CERTIFICATE,
     ENABLE_TELEMETRY,
     ROBUSTA_TELEMETRY_ENDPOINT,
     SEND_ADDITIONAL_TELEMETRY,
@@ -19,7 +17,7 @@ from robusta.runner.web import Web
 
 def main():
     init_logging()
-    if add_custom_certificate(os.environ.get("CERTIFICATE", "")):
+    if add_custom_certificate(ADDITIONAL_CERTIFICATE):
         logging.info("added custom certificate")
 
     create_monkey_patches()


### PR DESCRIPTION
When adding custom cert, use the same store in slack ssl context