### PR TITLE
run discovery in batches

### DIFF
--- a/helm/robusta/kubewatch.yaml
+++ b/helm/robusta/kubewatch.yaml
@@ -1,7 +1,7 @@
 namespace: ""
 resource:
   deployment: true
-  replicationcontroller: true
+  replicationcontroller: false  # 0.10.12 disabled because not supported on the runner
   replicaset: true
   daemonset: true
   statefulset: true

--- a/src/robusta/core/model/cluster_status.py
+++ b/src/robusta/core/model/cluster_status.py
@@ -1,6 +1,16 @@
 from pydantic.main import BaseModel, List, Optional
 
 
+class ClusterStats(BaseModel):
+    deployments: int
+    statefulsets: int
+    daemonsets: int
+    replicasets: int
+    pods: int
+    nodes: int
+    jobs: int
+
+
 class ClusterStatus(BaseModel):
     account_id: str
     cluster_id: str
@@ -8,3 +18,4 @@ class ClusterStatus(BaseModel):
     last_alert_at: Optional[str]  # ts
     light_actions: List[str]
     ttl_hours: int
+    stats: ClusterStats

--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -74,3 +74,6 @@ PORT = int(os.environ.get("PORT", 5000))  # PORT
 
 # additional certificate to verify, base64 encoded.
 ADDITIONAL_CERTIFICATE: str = os.environ.get("CERTIFICATE", "")
+
+DISCOVERY_MAX_BATCHES = int(os.environ.get("DISCOVERY_MAX_BATCHES", 100))
+DISCOVERY_BATCH_SIZE = int(os.environ.get("DISCOVERY_BATCH_SIZE", 500))

--- a/src/robusta/core/sinks/robusta/robusta_sink.py
+++ b/src/robusta/core/sinks/robusta/robusta_sink.py
@@ -9,7 +9,7 @@ from kubernetes.client import V1Node, V1NodeCondition, V1NodeList, V1Taint
 
 from robusta.core.discovery.discovery import Discovery, DiscoveryResults
 from robusta.core.discovery.top_service_resolver import TopLevelResource, TopServiceResolver
-from robusta.core.model.cluster_status import ClusterStatus
+from robusta.core.model.cluster_status import ClusterStatus, ClusterStats
 from robusta.core.model.env_vars import CLUSTER_STATUS_PERIOD_SEC, DISCOVERY_PERIOD_SEC
 from robusta.core.model.jobs import JobInfo
 from robusta.core.model.namespaces import NamespaceInfo
@@ -268,7 +268,8 @@ class RobustaSink(SinkBase):
 
         # new or changed nodes
         for node_name in curr_nodes.keys():
-            updated_node = self.__from_api_server_node(curr_nodes.get(node_name), node_requests[node_name])
+            pod_requests = node_requests.get(node_name, [])  # if all the pods on the node have no requests
+            updated_node = self.__from_api_server_node(curr_nodes.get(node_name), pod_requests)
             if self.__nodes_cache.get(node_name) != updated_node:  # node not in the cache, or changed
                 updated_nodes.append(updated_node)
                 self.__nodes_cache[node_name] = updated_node
@@ -308,6 +309,7 @@ class RobustaSink(SinkBase):
 
     def __update_cluster_status(self):
         try:
+            cluster_stats: ClusterStats = Discovery.discover_stats()
             cluster_status = ClusterStatus(
                 cluster_id=self.cluster_name,
                 version=self.registry.get_telemetry().runner_version,
@@ -315,6 +317,7 @@ class RobustaSink(SinkBase):
                 account_id=self.account_id,
                 light_actions=self.registry.get_light_actions(),
                 ttl_hours=self.ttl_hours,
+                stats=cluster_stats,
             )
 
             self.dal.publish_cluster_status(cluster_status)

--- a/src/robusta/utils/auth_provider.py
+++ b/src/robusta/utils/auth_provider.py
@@ -23,6 +23,9 @@ class AuthProvider:
     @staticmethod
     def _load_private_key(file_name: str) -> Optional[RSAPrivateKey]:
         try:
+            if not os.path.isfile(file_name):
+                logging.info(f"no rsa private key at {file_name}")
+                return None
             with open(file_name, "rb") as key_file:
                 private_key = serialization.load_pem_private_key(
                     key_file.read(),
@@ -38,6 +41,9 @@ class AuthProvider:
     @staticmethod
     def _load_public_key(file_name: str) -> Optional[RSAPublicKey]:
         try:
+            if not os.path.isfile(file_name):
+                logging.info(f"no rsa public key at {file_name}")
+                return None
             with open(file_name, "rb") as key_file:
                 public_key = serialization.load_pem_public_key(key_file.read())
                 logging.info(f"Loaded public key file {file_name}")


### PR DESCRIPTION
Changed discovery to work in batches for bigger clusters
Not throwing error in case of no rsa keys
Removed forwarder events of ReplicationController (not supported on runner, and not in use)
