### PR TITLE
Alerts tuning v1

### DIFF
--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -41,6 +41,8 @@ spec:
             value: {{ .Values.enablePrometheusStack | quote}}
           - name: SEND_ADDITIONAL_TELEMETRY
             value: {{ .Values.runner.sendAdditionalTelemetry | quote }}
+          - name: AUTO_SILENCE_ALERTS
+            value: { { .Values.runner.autoSilenceAlerts | quote } }
           - name: LOG_LEVEL
             value: {{ .Values.runner.log_level }}
           - name: INSTALLATION_NAMESPACE

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -188,6 +188,8 @@ builtinPlaybooks:
 - triggers:
   - on_prometheus_alert:
       alert_name: NodeFilesystemSpaceFillingUp
+  - on_prometheus_alert:
+      alert_name: NodeFilesystemAlmostOutOfSpace
   actions:
   - node_disk_analyzer: {}
   - alert_graph_enricher:
@@ -255,7 +257,7 @@ platformPlaybooks:
 
 # parameters for the robusta forwarder deployment
 kubewatch:
-  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v2.1
+  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v2.0
   imagePullPolicy: IfNotPresent
   pprof: True
   resources:
@@ -266,7 +268,6 @@ kubewatch:
       cpu: ~
   tolerations: []
   annotations: {}
-  nodeSelector: ~
 
 # parameters for the renderer service used in robusta runner to render grafana graphs
 grafanaRenderer:
@@ -298,7 +299,6 @@ runner:
   additional_env_froms: []
   tolerations: []
   annotations: {}
-  nodeSelector: ~
 
 kube-prometheus-stack:
   alertmanager:
@@ -367,3 +367,5 @@ kube-prometheus-stack:
         cpu: 10m
 
 rsa: ~
+
+

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -136,7 +136,9 @@ builtinPlaybooks:
   - on_prometheus_alert:
       alert_name: TargetDown
   actions:
+  - default_enricher: {}
   - target_down_dns_enricher: {}
+  stop: true
 
 - triggers:
   - on_prometheus_alert:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -257,7 +257,7 @@ platformPlaybooks:
 
 # parameters for the robusta forwarder deployment
 kubewatch:
-  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v2.0
+  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v2.1
   imagePullPolicy: IfNotPresent
   pprof: True
   resources:
@@ -268,6 +268,7 @@ kubewatch:
       cpu: ~
   tolerations: []
   annotations: {}
+  nodeSelector: ~
 
 # parameters for the renderer service used in robusta runner to render grafana graphs
 grafanaRenderer:
@@ -300,6 +301,7 @@ runner:
   additional_env_froms: []
   tolerations: []
   annotations: {}
+  nodeSelector: ~
 
 kube-prometheus-stack:
   alertmanager:
@@ -368,5 +370,3 @@ kube-prometheus-stack:
         cpu: 10m
 
 rsa: ~
-
-

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -290,6 +290,7 @@ runner:
   log_level: INFO
   sentry_dsn: https://53b627690db14de7b02095407596fa16@o1120648.ingest.sentry.io/6156573
   sendAdditionalTelemetry: false
+  autoSilenceAlerts: true
   certificate: "" # base64 encoded
   resources:
     requests:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -136,7 +136,6 @@ builtinPlaybooks:
   - on_prometheus_alert:
       alert_name: TargetDown
   actions:
-  - default_enricher: {}
   - target_down_dns_enricher: {}
   stop: true
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -136,6 +136,7 @@ builtinPlaybooks:
   - on_prometheus_alert:
       alert_name: TargetDown
   actions:
+  - default_enricher: {}
   - target_down_dns_enricher: {}
   stop: true
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -190,8 +190,6 @@ builtinPlaybooks:
 - triggers:
   - on_prometheus_alert:
       alert_name: NodeFilesystemSpaceFillingUp
-  - on_prometheus_alert:
-      alert_name: NodeFilesystemAlmostOutOfSpace
   actions:
   - node_disk_analyzer: {}
   - alert_graph_enricher:

--- a/playbooks/robusta_playbooks/prometheus_simulation.py
+++ b/playbooks/robusta_playbooks/prometheus_simulation.py
@@ -9,7 +9,9 @@ class PrometheusAlertParams(ActionParams):
     """
     :var alert_name: Simulated alert name.
     :var pod_name: Pod name, for a simulated pod alert.
+    :var job_name: Job name, for a simulated Job alert.
     :var namespace: Pod namespace, for a simulated pod alert.
+    :var service: service name, for additional prometheus labels.
     :var status: Simulated alert status. firing/resolved.
     :var severity: Simulated alert severity.
     :var description: Simulated alert description.
@@ -21,7 +23,7 @@ class PrometheusAlertParams(ActionParams):
     node_name: Optional[str] = None
     deployment_name: Optional[str] = None
     service: Optional[str] = None
-    job: Optional[str] = None
+    job_name: Optional[str] = None
     namespace: str = "default"
     status: str = "firing"
     severity: str = "error"
@@ -50,8 +52,8 @@ def prometheus_alert(event: ExecutionBaseEvent, prometheus_event_data: Prometheu
         labels["deployment"] = prometheus_event_data.deployment_name
     if prometheus_event_data.service is not None:
         labels["service"] = prometheus_event_data.service
-    if prometheus_event_data.job is not None:
-        labels["job"] = prometheus_event_data.job
+    if prometheus_event_data.job_name is not None:
+        labels["job"] = prometheus_event_data.job_name
 
     prometheus_event = AlertManagerEvent(
         **{

--- a/playbooks/robusta_playbooks/prometheus_simulation.py
+++ b/playbooks/robusta_playbooks/prometheus_simulation.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Dict, Optional
 
 import requests
-
 from robusta.api import ActionParams, AlertManagerEvent, ExecutionBaseEvent, action
 
 
@@ -21,6 +20,8 @@ class PrometheusAlertParams(ActionParams):
     pod_name: Optional[str] = None
     node_name: Optional[str] = None
     deployment_name: Optional[str] = None
+    service: Optional[str] = None
+    job: Optional[str] = None
     namespace: str = "default"
     status: str = "firing"
     severity: str = "error"
@@ -47,6 +48,10 @@ def prometheus_alert(event: ExecutionBaseEvent, prometheus_event_data: Prometheu
         labels["node"] = prometheus_event_data.node_name
     if prometheus_event_data.deployment_name is not None:
         labels["deployment"] = prometheus_event_data.deployment_name
+    if prometheus_event_data.service is not None:
+        labels["service"] = prometheus_event_data.service
+    if prometheus_event_data.job is not None:
+        labels["job"] = prometheus_event_data.job
 
     prometheus_event = AlertManagerEvent(
         **{

--- a/playbooks/robusta_playbooks/targetdown_enrichment.py
+++ b/playbooks/robusta_playbooks/targetdown_enrichment.py
@@ -10,7 +10,7 @@ def target_down_dns_enricher(alert: PrometheusKubernetesAlert, params: TimedProm
     Enrich the finding with a detailed explanation for the cause of the CoreDNS and
     Kube-DNS unreachable
     """
-    if not alert.job or alert.job not in ["corens", "kube-dns"]:
+    if not alert.job or alert.job not in ["coredns", "kube-dns"]:
         return
     res = list_available_services("kube-system")
     try:

--- a/playbooks/robusta_playbooks/targetdown_enrichment.py
+++ b/playbooks/robusta_playbooks/targetdown_enrichment.py
@@ -1,16 +1,25 @@
 import json
+from typing import Optional
 
+from hikaru.model import PodList
 from robusta.api import PrometheusKubernetesAlert, TimedPrometheusParams, action
 from robusta.integrations.kubernetes.api_client_utils import list_available_services
 
 
+def get_alert_label(alert: PrometheusKubernetesAlert, label: str) -> Optional[str]:
+    try:
+        return alert.alert.labels[label]
+    except KeyError:
+        return None
+
 @action
-def target_down_dns_enricher(alert: PrometheusKubernetesAlert, params: TimedPrometheusParams):
+def target_down_dns_enricher(alert: PrometheusKubernetesAlert):
     """
     Enrich the finding with a detailed explanation for the cause of the CoreDNS and
     Kube-DNS unreachable
     """
-    if not alert.job or alert.job not in ["coredns", "kube-dns"]:
+    job = get_alert_label(alert, 'job')
+    if not job or job not in ["coredns", "kube-dns"]:
         return
     res = list_available_services("kube-system")
     try:
@@ -21,18 +30,18 @@ def target_down_dns_enricher(alert: PrometheusKubernetesAlert, params: TimedProm
     service_found = False
     for kube_item in items:
         kube_item_name = kube_item.get("metadata", {}).get("name")
-        if kube_item_name == alert.job:
+        if kube_item_name == get_alert_label(alert, 'service'):
             service_found = True
             break
 
     if not service_found:
         alert.override_finding_attributes(
-            description=f"The Prometheus Stack expects the {alert.job} to exist, but it can't be found"
-            f" in kube-system (some cluster managers do not provide this service)"
-            f", you can disable it by changing the following values in "
-            f"prometheus stack. "
-            f"```kube-prometheus-stack:\n\tcoreDns:"
-            f"\n\t\tenabled: false\n\tkubeDns:\n\t\tenabled: true```"
+            description=f"The Prometheus Stack expects the {job} to exist, but it can't be found"
+                        f" in kube-system (some cluster managers do not provide this service)"
+                        f", you can disable it by changing the following values in "
+                        f"prometheus stack. "
+                        f"```kube-prometheus-stack:\n\tcoreDns:"
+                        f"\n\t\tenabled: false\n\tkubeDns:\n\t\tenabled: true```"
         )
     else:
         # We cannot reach out the service, so alert should be risen

--- a/playbooks/robusta_playbooks/targetdown_enrichment.py
+++ b/playbooks/robusta_playbooks/targetdown_enrichment.py
@@ -26,8 +26,8 @@ def auto_silence_target_down(alert: PrometheusKubernetesAlert, job: str, reason_
     )
     relevant_silence_labels = ['service', 'alertname', 'job']
     comment = f"Misconfigured target {job} auto-silenced"
-    logging.info(f"{comment}, reason: {reason_for_silence}")
-    add_silence_from_prometheus_alert(alert, labels=relevant_silence_labels, comment=comment)
+    log_message = f"{comment}, reason: {reason_for_silence}"
+    add_silence_from_prometheus_alert(alert, labels=relevant_silence_labels, comment=comment, log_message=log_message )
 
 @action
 def target_down_dns_enricher(alert: PrometheusKubernetesAlert):

--- a/src/robusta/api/__init__.py
+++ b/src/robusta/api/__init__.py
@@ -28,6 +28,7 @@ from robusta.core.model.base_params import (
 )
 from robusta.core.model.env_vars import (
     ALERT_BUILDER_WORKERS,
+    AUTO_SILENCE_ALERTS,
     CLUSTER_STATUS_PERIOD_SEC,
     CUSTOM_PLAYBOOKS_ROOT,
     DEFAULT_PLAYBOOKS_PIP_INSTALL,

--- a/src/robusta/api/__init__.py
+++ b/src/robusta/api/__init__.py
@@ -1,10 +1,13 @@
 from robusta.core.external_apis.prometheus.models import PrometheusQueryResult
 from robusta.core.model.base_params import (
     ActionParams,
+    AddSilenceParams,
     AlertResourceGraphEnricherParams,
+    BaseSilenceParams,
     BashParams,
     ChartValuesFormat,
     CustomGraphEnricherParams,
+    DeleteSilenceParams,
     EventEnricherParams,
     FindingKeyParams,
     GrafanaAnnotationParams,
@@ -19,6 +22,7 @@ from robusta.core.model.base_params import (
     ResourceChartItemType,
     ResourceChartResourceType,
     ResourceGraphEnricherParams,
+    SilenceMatcher,
     TimedPrometheusParams,
     VideoEnricherParams,
 )
@@ -97,6 +101,13 @@ from robusta.core.playbooks.prometheus_enrichment_utils import (
     create_resource_enrichment,
     get_node_internal_ip,
     run_prometheus_query,
+)
+from robusta.core.playbooks.silence_utils import (
+    SilenceOperation,
+    add_silence_to_alert_manager,
+    silence_gen_headers,
+    silence_get_alertmanager_url,
+    silence_get_url_path,
 )
 from robusta.core.playbooks.trigger import (
     BaseTrigger,

--- a/src/robusta/api/__init__.py
+++ b/src/robusta/api/__init__.py
@@ -104,6 +104,7 @@ from robusta.core.playbooks.prometheus_enrichment_utils import (
 )
 from robusta.core.playbooks.silence_utils import (
     SilenceOperation,
+    add_silence_from_prometheus_alert,
     add_silence_to_alert_manager,
     silence_gen_headers,
     silence_get_alertmanager_url,

--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum, auto
 from typing import List, Optional, Union
 
@@ -220,3 +221,49 @@ class ProcessParams(ActionParams):
 class EventEnricherParams(ActionParams):
     max_events: int = 8
     included_types: List[str] = ["Warning", "Normal"]
+
+
+class SilenceMatcher(BaseModel):
+    # https://github.com/prometheus/alertmanager/blob/main/api/v2/models/matcher.go
+    isEqual: bool = (
+        True  # support old version matchers with omitted isEqual https://github.com/prometheus/alertmanager/pull/2603
+    )
+    isRegex: bool
+    name: str
+    value: str
+
+
+class BaseSilenceParams(ActionParams):
+    """
+    :var alertmanager_url: Alternative Alert Manager url to send requests.
+    """
+
+    alertmanager_flavor: str = None  # type: ignore
+    alertmanager_url: Optional[str]
+    grafana_api_key: str = None  # type: ignore
+
+
+class DeleteSilenceParams(BaseSilenceParams):
+    """
+    :var id: uuid of the silence.
+    """
+
+    id: str
+
+
+class AddSilenceParams(BaseSilenceParams):
+    """
+    :var id: uuid of the silence. use for update, empty on create.
+    :var comment: text comment of the silence.
+    :var createdBy: author of the silence.
+    :var startsAt: date.
+    :var endsAt: date.
+    :var matchers: List of matchers to filter the silence effect.
+    """
+
+    id: Optional[str]
+    comment: str
+    createdBy: str
+    startsAt: datetime
+    endsAt: datetime
+    matchers: List[SilenceMatcher]

--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -51,6 +51,9 @@ ROBUSTA_UI_DOMAIN = os.environ.get("ROBUSTA_UI_DOMAIN", "https://platform.robust
 ROBUSTA_TELEMETRY_ENDPOINT = os.environ.get("ROBUSTA_TELEMETRY_ENDPOINT", "https://api.robusta.dev/telemetry")
 ENABLE_TELEMETRY = os.environ.get("ENABLE_TELEMETRY", "true").lower() == "true"
 SEND_ADDITIONAL_TELEMETRY = os.environ.get("SEND_ADDITIONAL_TELEMETRY", "false").lower() == "true"
+
+AUTO_SILENCE_ALERTS = os.environ.get("AUTO_SILENCE_ALERTS", "true").lower() == "true"
+
 RELEASE_NAME = os.environ.get("RELEASE_NAME", "robusta")
 
 TELEMETRY_PERIODIC_SEC = int(os.environ.get("TELEMETRY_PERIODIC_SEC", 60 * 60 * 24))  # 24H

--- a/src/robusta/core/playbooks/silence_utils.py
+++ b/src/robusta/core/playbooks/silence_utils.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from enum import Enum
+from typing import Dict
+
+import requests
+
+from robusta.core.model.base_params import AddSilenceParams, BaseSilenceParams, SilenceMatcher
+from robusta.integrations.prometheus.models import PrometheusKubernetesAlert
+from robusta.integrations.prometheus.utils import AlertManagerDiscovery, ServiceDiscovery
+from robusta.utils.error_codes import ActionException, ErrorCodes
+
+SilenceOperation = Enum("SilenceOperation", "CREATE DELETE LIST")
+
+def create_label_matcher(name: str, value: str, isRegex: bool) -> SilenceMatcher:
+    return SilenceMatcher(name=name, value=value, isEqual=not isRegex, isRegex=isRegex)
+
+
+def add_silence_from_prometheus_alert(alert: PrometheusKubernetesAlert, labels: [str]):
+    matchers = [create_label_matcher(name=label, value=alert.get_alert_label(label), isRegex=False)
+                               for label in labels if alert.get_alert_label(label)]
+    comment = "This alert was auto-silenced"
+    created_by = "robusta"
+    starts_at = datetime.datetime.now()
+    ends_at = datetime.datetime.now() + datetime.timedelta(years=5)
+    silence_params = AddSilenceParams(matchers=matchers, comment=comment, createdBy=created_by, startsAt=starts_at, endsAt=ends_at)
+    add_silence_to_alert_manager(alert, silence_params)
+
+
+def add_silence_to_alert_manager(params: AddSilenceParams):
+    alertmanager_url = silence_get_alertmanager_url(params)
+    if not alertmanager_url:
+        raise ActionException(ErrorCodes.ALERT_MANAGER_DISCOVERY_FAILED)
+
+    try:
+        res = requests.post(
+            f"{alertmanager_url}{silence_get_url_path(SilenceOperation.CREATE, params)}",
+            data=params.json(exclude_defaults=True),  # support old versions.
+            headers=silence_gen_headers(params),
+        )
+    except Exception as e:
+        raise ActionException(ErrorCodes.ALERT_MANAGER_REQUEST_FAILED) from e
+
+    if not res.ok:
+        raise ActionException(ErrorCodes.ADD_SILENCE_FAILED, msg=f"Add silence failed: {res.text}")
+
+    silence_id = res.json().get("silenceID") or res.json().get("id")  # on grafana alertmanager the 'id' is returned
+    if not silence_id:
+        raise ActionException(ErrorCodes.ADD_SILENCE_FAILED)
+    return silence_id
+
+
+def silence_gen_headers(params: BaseSilenceParams) -> Dict:
+    headers = {"Content-type": "application/json"}
+    if params.grafana_api_key:
+        headers.update({"Authorization": "Bearer {0}".format(params.grafana_api_key)})
+    return headers
+
+
+def silence_get_url_path(operation: SilenceOperation, params: BaseSilenceParams) -> str:
+    prefix = ""
+    if "grafana" == params.alertmanager_flavor:
+        prefix = "/api/alertmanager/grafana"
+
+    if operation == SilenceOperation.DELETE:
+        return f"{prefix}/api/v2/silence"
+    else:
+        return f"{prefix}/api/v2/silences"
+
+
+def silence_get_alertmanager_url(params: BaseSilenceParams) -> str:
+    if params.alertmanager_url:
+        return params.alertmanager_url
+
+    if "grafana" == params.alertmanager_flavor:
+        return ServiceDiscovery.find_url(
+            selectors=["app.kubernetes.io/name=grafana"], error_msg="Failed to find grafana url"
+        )
+
+    return AlertManagerDiscovery.find_alert_manager_url()

--- a/src/robusta/core/playbooks/silence_utils.py
+++ b/src/robusta/core/playbooks/silence_utils.py
@@ -1,10 +1,12 @@
 import datetime
+import logging
 from enum import Enum
 from typing import Dict, Optional
 
 import requests
 
 from robusta.core.model.base_params import AddSilenceParams, BaseSilenceParams, SilenceMatcher
+from robusta.core.model.env_vars import AUTO_SILENCE_ALERTS
 from robusta.integrations.prometheus.models import PrometheusKubernetesAlert
 from robusta.integrations.prometheus.utils import AlertManagerDiscovery, ServiceDiscovery
 from robusta.utils.error_codes import ActionException, ErrorCodes
@@ -16,7 +18,11 @@ def create_label_matcher(name: str, value: str, isRegex: bool) -> SilenceMatcher
     return SilenceMatcher(name=name, value=value, isEqual=not isRegex, isRegex=isRegex)
 
 
-def add_silence_from_prometheus_alert(alert: PrometheusKubernetesAlert, labels: [str], comment: Optional[str] = None):
+def add_silence_from_prometheus_alert(alert: PrometheusKubernetesAlert, labels: [str], comment: Optional[str] = None,
+                                      log_message: Optional[str] = None):
+    if not AUTO_SILENCE_ALERTS:
+        return
+    logging.info(log_message)
     matchers = [create_label_matcher(name=label, value=alert.get_alert_label(label), isRegex=False)
                 for label in labels if alert.get_alert_label(label)]
     if not comment:

--- a/src/robusta/integrations/prometheus/models.py
+++ b/src/robusta/integrations/prometheus/models.py
@@ -77,6 +77,12 @@ class PrometheusKubernetesAlert(PodEvent, NodeEvent, DeploymentEvent, JobEvent, 
     def get_job(self) -> Optional[RobustaJob]:
         return self.job
 
+    def get_alert_label(self, label: str) -> Optional[str]:
+        try:
+            return self.alert.labels[label]
+        except KeyError:
+            return None
+
     def get_daemonset(self) -> Optional[DaemonSet]:
         return self.daemonset
 


### PR DESCRIPTION
It looks like allot of changes but its mostly refactoring the creation of silences to a utils file (to easily create specific silences for prometheus alerts at runtime)

Major changes:
- auto-silence feature
- fixed targetdown enricher - (would always return at first return)
- added auto-silence to targetdown when poorly configured