### PR TITLE
bad/missing imports throwing error

### DIFF
--- a/playbooks/robusta_playbooks/job_restart_on_oomkilled_community.py
+++ b/playbooks/robusta_playbooks/job_restart_on_oomkilled_community.py
@@ -1,6 +1,9 @@
-from robusta.api import *
-from ...src.robusta.core.playbooks.job_utils import get_job_latest_pod
+import logging
+from typing import Optional
+
 import bitmath as bitmath
+from hikaru.model import Container, JobSpec, ObjectMeta, PodSpec, PodTemplateSpec, ResourceRequirements
+from robusta.api import *
 
 
 class IncreaseResources(ActionParams):


### PR DESCRIPTION
youll get errors like this in master since the imports need to be fixed

```
2023-02-26 14:46:55.724 ERROR    failed to module job_restart_on_oomkilled_community
Traceback (most recent call last):
  File "/app/src/robusta/runner/config_loader.py", line 150, in __import_playbooks_package
    m = importlib.reload(importlib.import_module(module_name))
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/robusta_playbooks/job_restart_on_oomkilled_community.py", line 2, in <module>
    from ...src.robusta.core.playbooks.job_utils import get_job_latest_pod
ImportError: attempted relative import beyond top-level package


2023-02-26 14:59:20.662 ERROR    failed to module job_restart_on_oomkilled_community
Traceback (most recent call last):
  File "/app/src/robusta/runner/config_loader.py", line 151, in __import_playbooks_package
    m = importlib.reload(importlib.import_module(module_name))
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/robusta_playbooks/job_restart_on_oomkilled_community.py", line 5, in <module>
    class IncreaseResources(ActionParams):
  File "/usr/local/lib/python3.9/site-packages/robusta_playbooks/job_restart_on_oomkilled_community.py", line 12, in IncreaseResources
    increase_by: Optional[str] = "500MiB"
NameError: name 'Optional' is not defined
```