### PR TITLE
Additional playbooks

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -113,13 +113,7 @@ builtinPlaybooks:
   stop: true
 
 # playbooks for prometheus alerts enrichment
-- triggers:
-  - on_prometheus_alert:
-      alert_name: KubePodCrashLooping
-  actions:
-  - logs_enricher: {}
-  - pod_events_enricher: {}
-
+# Prometheus Overcommit playbooks
 - triggers:
   - on_prometheus_alert:
       alert_name: KubeCPUOvercommit
@@ -138,6 +132,14 @@ builtinPlaybooks:
       url: https://bit.ly/memory-overcommit
       name: Memory Overcommited
 
+# Prometheus Pods playbooks
+- triggers:
+  - on_prometheus_alert:
+      alert_name: KubePodCrashLooping
+  actions:
+  - logs_enricher: {}
+  - pod_events_enricher: {}
+
 - triggers:
   - on_prometheus_alert:
       alert_name: KubePodNotReady
@@ -145,6 +147,7 @@ builtinPlaybooks:
   - logs_enricher: {}
   - pod_events_enricher: {}
 
+# Prometheus Jobs playbooks
 - triggers:
   - on_prometheus_alert:
       alert_name: KubeJobFailed
@@ -157,14 +160,13 @@ builtinPlaybooks:
   - job_events_enricher: {}
   - job_pod_enricher: {}
 
+# Prometheus Daemonset playbooks
 - triggers:
   - on_prometheus_alert:
-      alert_name: KubeNodeNotReady
-  - on_prometheus_alert:
-      alert_name: KubeletTooManyPods
+      alert_name: KubeDaemonSetRolloutStuck
   actions:
-  - node_allocatable_resources_enricher: {}
-  - node_running_pods_enricher: {}
+  - resource_events_enricher: {}
+
 - triggers:
   - on_prometheus_alert:
       alert_name: KubernetesDaemonsetMisscheduled
@@ -173,6 +175,23 @@ builtinPlaybooks:
   actions:
   - daemonset_status_enricher: {}
   - daemonset_misscheduled_analysis_enricher: {}
+
+# Prometheus Node related playbooks
+- triggers:
+  - on_prometheus_alert:
+      alert_name: KubeNodeNotReady
+  - on_prometheus_alert:
+      alert_name: KubeletTooManyPods
+  actions:
+  - node_allocatable_resources_enricher: {}
+  - node_running_pods_enricher: {}
+
+- triggers:
+  - on_prometheus_alert:
+      alert_name: KubeNodeUnreachable
+  actions:
+  - resource_events_enricher: {}
+
 - triggers:
   - on_prometheus_alert:
       alert_name: HostHighCpuLoad
@@ -181,6 +200,7 @@ builtinPlaybooks:
   - alert_graph_enricher:
       resource_type: CPU
       item_type: Node
+
 - triggers:
   - on_prometheus_alert:
       alert_name: HostOomKillDetected
@@ -189,6 +209,7 @@ builtinPlaybooks:
   - alert_graph_enricher:
       resource_type: Memory
       item_type: Node
+
 - triggers:
   - on_prometheus_alert:
       alert_name: NodeFilesystemSpaceFillingUp
@@ -199,6 +220,7 @@ builtinPlaybooks:
   - alert_graph_enricher:
       resource_type: Disk
       item_type: Node
+
 - triggers:
   - on_prometheus_alert:
       alert_name: CPUThrottlingHigh
@@ -208,6 +230,7 @@ builtinPlaybooks:
   - alert_graph_enricher:
       resource_type: CPU
       item_type: Pod
+
 - triggers:
   - on_prometheus_alert:
       alert_name: KubernetesDeploymentReplicasMismatch
@@ -220,14 +243,10 @@ builtinPlaybooks:
       included_types: ["Warning", "Normal"]
       dependent_pod_mode: true
 
-# Default event enrichment for relevant Prometheus alerts
+# Prometheus Statefulset playbooks
 - triggers:
   - on_prometheus_alert:
       alert_name: KubeStatefulSetReplicasMismatch
-  - on_prometheus_alert:
-      alert_name: KubeDaemonSetRolloutStuck
-  - on_prometheus_alert:
-      alert_name: KubeNodeUnreachable
   - on_prometheus_alert:
       alert_name: KubeStatefulSetUpdateNotRolledOut
   actions:

--- a/playbooks/robusta_playbooks/prometheus_simulation.py
+++ b/playbooks/robusta_playbooks/prometheus_simulation.py
@@ -28,6 +28,8 @@ class PrometheusAlertParams(ActionParams):
     container_name: Optional[str] = None
     service: Optional[str] = None
     job_name: Optional[str] = None
+    statefulset_name: Optional[str] = None
+    daemonset_name: Optional[str] = None
     namespace: str = "default"
     status: str = "firing"
     severity: str = "error"
@@ -60,7 +62,11 @@ def prometheus_alert(event: ExecutionBaseEvent, prometheus_event_data: Prometheu
     if prometheus_event_data.service is not None:
         labels["service"] = prometheus_event_data.service
     if prometheus_event_data.job_name is not None:
-        labels["job"] = prometheus_event_data.job_name
+        labels["job_name"] = prometheus_event_data.job_name
+    if prometheus_event_data.statefulset_name is not None:
+        labels["statefulset"] = prometheus_event_data.statefulset_name
+    if prometheus_event_data.daemonset_name is not None:
+        labels["daemonset"] = prometheus_event_data.daemonset_name
 
     annotations = {
         "description": prometheus_event_data.description,


### PR DESCRIPTION
1. Added playbooks for 6 alerts
2. Rearranged the builtin prometheus playbooks by category (easier to see what is available and add new ones)
3. Improved prometheus alert test action

the added playbooks are here

```
- triggers:
  - on_prometheus_alert:
      alert_name: KubeletTooManyPods
  actions:
  - node_allocatable_resources_enricher: {}
  - node_running_pods_enricher: {}
 
- triggers:
  - on_prometheus_alert:
      alert_name: KubeJobNotCompleted
  actions:
  - job_info_enricher: {}
  - job_events_enricher: {}
  - job_pod_enricher: {}

- triggers:
  - on_prometheus_alert:
      alert_name: KubeStatefulSetReplicasMismatch
  - on_prometheus_alert:
      alert_name: KubeStatefulSetUpdateNotRolledOut
  actions:
  - resource_events_enricher: {}

- triggers:
  - on_prometheus_alert:
      alert_name: KubeDaemonSetRolloutStuck
  actions:
  - resource_events_enricher: {}

- triggers:
  - on_prometheus_alert:
      alert_name: KubeNodeUnreachable
  actions:
  - resource_events_enricher: {}
```

 
<img width="1212" alt="Screen Shot 2023-03-06 at 9 57 40" src="https://user-images.githubusercontent.com/97387909/223055156-228464c7-c878-4f57-b4c4-43edabac4186.png">
<img width="1212" alt="Screen Shot 2023-03-06 at 10 16 12" src="https://user-images.githubusercontent.com/97387909/223055160-ddb60c0f-b7a2-4c19-9c30-272ebcbe4b2a.png">
