### PR TITLE
Docs: corrected deprecated syntax for severity matching

### DIFF
--- a/docs/user-guide/alert-manager.rst
+++ b/docs/user-guide/alert-manager.rst
@@ -33,11 +33,11 @@ Below is an example AlertManager configuration. Depending on your setup, the exa
 
         route:
           routes:
-          - receiver: 'robusta'
-          matchers:
-            - severity =~ "info|warn|error|critical"
-            repeat_interval: 4h
-            continue: true
+            - receiver: 'robusta'
+              matchers:
+                - severity =~ "info|warn|error|critical"
+              repeat_interval: 4h
+              continue: true
 
 .. admonition:: Common Mistakes
 

--- a/docs/user-guide/alert-manager.rst
+++ b/docs/user-guide/alert-manager.rst
@@ -34,8 +34,8 @@ Below is an example AlertManager configuration. Depending on your setup, the exa
         route:
           routes:
           - receiver: 'robusta'
-            match_re:
-              severity: 'info|warn|error|critical'
+          matchers:
+            - severity =~ "info|warn|error|critical"
             repeat_interval: 4h
             continue: true
 
@@ -105,8 +105,8 @@ If AlertManager is located outside of your Kubernetes cluster then a few more st
         route:
           routes:
           - receiver: 'robusta'
-            match_re:
-              severity: 'info|warn|error|critical'
+            matchers:
+              - severity =~ "info|warn|error|critical"
             repeat_interval: 4h
             continue: true
 


### PR DESCRIPTION
Previous syntax `match_re` is deprecated now :
```
level=warn ts=2023-03-06T10:21:49.894421379Z caller=amcfg.go:1921 component=alertmanageroperator alertmanager=prometheus-kube-prometheus-alertmanager namespace=monitoring receiver=robusta msg="'matchers' field is using a deprecated syntax which will be removed in future versions" match=map[] match_re=map[severity:info\|warn\|error\|critical]
```

so let's upgrade this to avoid any future errors. 