### PR TITLE
Add Telegram message threads (topics) support

### DIFF
--- a/docs/catalog/sinks/telegram.rst
+++ b/docs/catalog/sinks/telegram.rst
@@ -21,6 +21,13 @@ If you want to send messages to a group, add the created Bot to your group (new 
 
 Next, we will need to obtain the ``chat id``. Checkout this `post <https://dev.to/rizkyrajitha/get-notifications-with-telegram-bot-537l#:~:text=keep%20the%20access%20token%20securely.%20Anyone%20with%20access%20token%20can%20manipulate%20your%20bot>`_ to find out how.
 
+Thread id
+------------------------------------------------
+You can configure Robusta to send alerts to a specific message thread (topic) if your group chat has them enabled.
+To do this you need to:
+1. Obtain the thread id by copying a link to the topic (``Topic Info - Copy Topic Link`` in the desktop client). The number after the last forward slash is the thread id.
+2. Pass the thread id to the Telegram sink via the ``thread_id`` parameter in the sink configuration.
+
 Configuring the Telegram sink
 ------------------------------------------------
 Now we're ready to configure the Telegram sink.
@@ -34,6 +41,7 @@ Now we're ready to configure the Telegram sink.
             name: personal_telegram sink
             bot_token: <YOUR BOT TOKEN>
             chat_id: <CHAT ID>
+            thread_id: <THREAD ID> # Optional thread (topic) ID
 .. note::
 
     If you don't want Robusta to send file attachments, set ``send_files`` to ``False`` under your Telegram sink. (True by default)

--- a/src/robusta/core/sinks/telegram/telegram_client.py
+++ b/src/robusta/core/sinks/telegram/telegram_client.py
@@ -9,14 +9,16 @@ TELEGRAM_BASE_URL = os.environ.get("TELEGRAM_BASE_URL", "https://api.telegram.or
 
 
 class TelegramClient:
-    def __init__(self, chat_id: int, bot_token: str):
+    def __init__(self, chat_id: int, thread_id: int, bot_token: str):
         self.chat_id = chat_id
+        self.thread_id = thread_id
         self.bot_token = bot_token
 
     def send_message(self, message: str, disable_links_preview: bool = True):
         url = f"{TELEGRAM_BASE_URL}/bot{self.bot_token}/sendMessage"
         message_json = {
             "chat_id": self.chat_id,
+            "message_thread_id": self.thread_id,
             "disable_web_page_preview": disable_links_preview,
             "parse_mode": "Markdown",
             "text": message,

--- a/src/robusta/core/sinks/telegram/telegram_sink.py
+++ b/src/robusta/core/sinks/telegram/telegram_sink.py
@@ -24,7 +24,7 @@ class TelegramSink(SinkBase):
     def __init__(self, sink_config: TelegramSinkConfigWrapper, registry):
         super().__init__(sink_config.telegram_sink, registry)
 
-        self.client = TelegramClient(sink_config.telegram_sink.chat_id, sink_config.telegram_sink.bot_token)
+        self.client = TelegramClient(sink_config.telegram_sink.chat_id, sink_config.telegram_sink.thread_id, sink_config.telegram_sink.bot_token)
         self.send_files = sink_config.telegram_sink.send_files
 
     def write_finding(self, finding: Finding, platform_enabled: bool):

--- a/src/robusta/core/sinks/telegram/telegram_sink_params.py
+++ b/src/robusta/core/sinks/telegram/telegram_sink_params.py
@@ -5,6 +5,7 @@ from robusta.core.sinks.sink_config import SinkConfigBase
 class TelegramSinkParams(SinkBaseParams):
     bot_token: str
     chat_id: int
+    thread_id: int = None
     send_files: bool = True  # Change to False, to omit file attachments
 
 


### PR DESCRIPTION
This PR adds support for sending alerts to [Telegram group threads/topics](https://telegram.org/blog/topics-in-groups-collectible-usernames/ru?setln=en#topics-in-groups). This is entirely optional and doesn't introduce any breaking changes to existing Robusta installations that send alerts to regular Telegram groups or channels.

This change has been manually tested in a real-world scenario with multiple Telegram sinks.