### PR TITLE
log enricher regex + PrometheusRuleFailures playbook 

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -156,7 +156,7 @@ builtinPlaybooks:
         alert_name: PrometheusRuleFailures
   actions:
   - logs_enricher:
-      lines_with_regex: ".*Evaluating rule failed.*"
+      filter_regex: ".*Evaluating rule failed.*"
 
 - triggers:
   - on_prometheus_alert:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -153,6 +153,12 @@ builtinPlaybooks:
 
 - triggers:
   - on_prometheus_alert:
+        alert_name: PrometheusRuleFailures
+  actions:
+  - prometheus_logs_enricher: {}
+
+- triggers:
+  - on_prometheus_alert:
       alert_name: KubeCPUOvercommit
   actions:
   - cpu_overcommited_enricher: {}

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -155,6 +155,7 @@ builtinPlaybooks:
   - on_prometheus_alert:
         alert_name: PrometheusRuleFailures
   actions:
+  - prometheus_rules_enricher: {}
   - logs_enricher:
       filter_regex: ".*Evaluating rule failed.*"
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -155,7 +155,8 @@ builtinPlaybooks:
   - on_prometheus_alert:
         alert_name: PrometheusRuleFailures
   actions:
-  - prometheus_logs_enricher: {}
+  - prometheus_logs_enricher:
+      lines_with_regex: ".*Evaluating rule failed.*"
 
 - triggers:
   - on_prometheus_alert:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -155,7 +155,7 @@ builtinPlaybooks:
   - on_prometheus_alert:
         alert_name: PrometheusRuleFailures
   actions:
-  - prometheus_logs_enricher:
+  - logs_enricher:
       lines_with_regex: ".*Evaluating rule failed.*"
 
 - triggers:

--- a/playbooks/robusta_playbooks/prometheus_enrichments.py
+++ b/playbooks/robusta_playbooks/prometheus_enrichments.py
@@ -4,13 +4,12 @@ from typing import List, Optional, Tuple, Union
 
 from prometheus_api_client import PrometheusApiClientException
 from kubernetes import client
-from kubernetes.client import V1ServiceList
 from kubernetes.client.models.v1_service import V1Service
 from robusta.api import (
     ExecutionBaseEvent,
-    PrometheusAlert,
     PrometheusDateRange,
     PrometheusDuration,
+    PrometheusKubernetesAlert,
     PrometheusQueryParams,
     PrometheusQueryResult,
     action,
@@ -94,7 +93,7 @@ def get_duplicate_kubelet_msg(rule_group) -> str:
 
 
 @action
-def prometheus_rules_enricher(alert: PrometheusAlert):
+def prometheus_rules_enricher(alert: PrometheusKubernetesAlert):
     """
     Enriches the finding with a for information due to rule failure
     """

--- a/playbooks/robusta_playbooks/prometheus_enrichments.py
+++ b/playbooks/robusta_playbooks/prometheus_enrichments.py
@@ -1,22 +1,18 @@
 import logging
-import re
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from prometheus_api_client import PrometheusApiClientException
 from robusta.api import (
-    ActionParams,
     ExecutionBaseEvent,
-    NamedRegexPattern,
     PrometheusDateRange,
-    PrometheusDiscovery,
     PrometheusDuration,
     PrometheusQueryParams,
     PrometheusQueryResult,
     action,
     run_prometheus_query,
 )
-from robusta.core.reporting.blocks import FileBlock, PrometheusBlock
+from robusta.core.reporting.blocks import PrometheusBlock
 
 
 def parse_timestamp_string(date_string: str) -> Optional[datetime]:
@@ -40,48 +36,6 @@ def parse_duration(
         return starts_at, ends_at
     logging.error("Non supported duration provided")
     return None, None
-
-
-class PrometheusLogsParams(ActionParams):
-    """
-    :var regex_replacer_patterns: regex patterns to replace text, for example for security reasons (Note: Replacements are executed in the given order)
-    :var regex_replacement_style: one of SAME_LENGTH_ASTERISKS or NAMED (See RegexReplacementStyle)
-    :var lines_with_regex: only shows lines that match the regex
-    """
-
-    regex_replacer_patterns: Optional[List[NamedRegexPattern]] = None
-    regex_replacement_style: str = "SAME_LENGTH_ASTERISKS"
-    lines_with_regex: Optional[str] = None
-
-
-def filter_logs(logs: str, lines_with_regex: str) -> str:
-    regex = re.compile(lines_with_regex)
-    return "\n".join(re.findall(regex, logs))
-
-
-@action
-def prometheus_logs_enricher(event: ExecutionBaseEvent, params: PrometheusLogsParams):
-    """
-    Enriches the finding with the logs from your prometheus pod
-
-    For clusters with an out of cluster prometheus or no detectable prometheus this action will silently do nothing.
-    """
-    regex_replacement_style = (
-        RegexReplacementStyle[params.regex_replacement_style] if params.regex_replacement_style else None
-    )
-    pods = PrometheusDiscovery.find_prometheus_pods()
-    logging.warning(len(pods))
-    if pods:
-        log_data = pods[0].get_logs(
-            regex_replacer_patterns=params.regex_replacer_patterns, regex_replacement_style=regex_replacement_style
-        )
-        if params.lines_with_regex:
-            log_data = filter_logs(log_data, params.lines_with_regex)
-        logging.warning(log_data)
-        if log_data:
-            event.add_enrichment(
-                [FileBlock(f"{pods[0].metadata.name}.log", log_data.encode())],
-            )
 
 
 @action

--- a/src/robusta/api/__init__.py
+++ b/src/robusta/api/__init__.py
@@ -127,6 +127,7 @@ from robusta.core.reporting import (
     KubernetesFieldsBlock,
     ListBlock,
     MarkdownBlock,
+    PrometheusBlock,
     TableBlock,
     VideoLink,
 )

--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -171,6 +171,7 @@ class RobustaPod(Pod):
         tail_lines=None,
         regex_replacer_patterns: Optional[List[NamedRegexPattern]] = None,
         regex_replacement_style: Optional[RegexReplacementStyle] = None,
+        filter_regex: Optional[str] = None,
     ) -> str:
         """
         Fetch pod logs, can replace sensitive data in the logs using a regex
@@ -184,6 +185,10 @@ class RobustaPod(Pod):
             previous,
             tail_lines,
         )
+
+        if pods_logs and filter_regex:
+            regex = re.compile(filter_regex)
+            pods_logs = "\n".join(re.findall(regex, pods_logs))
 
         if pods_logs and regex_replacer_patterns:
             logging.info("Sanitizing log data with the provided regex patterns")

--- a/src/robusta/integrations/prometheus/utils.py
+++ b/src/robusta/integrations/prometheus/utils.py
@@ -2,13 +2,11 @@ import logging
 from typing import TYPE_CHECKING, List, Optional, Dict
 
 from cachetools import TTLCache
-from hikaru.model import Pod, PodList, StatefulSetList
 from requests.exceptions import ConnectionError, HTTPError
 
 from robusta.core.exceptions import PrometheusNotFound
 from robusta.core.model.base_params import PrometheusParams
 from robusta.core.model.env_vars import PROMETHEUS_SSL_ENABLED, SERVICE_CACHE_TTL_SEC
-from robusta.integrations.kubernetes.custom_models import build_selector_query
 from robusta.utils.service_discovery import find_service_url
 
 if TYPE_CHECKING:
@@ -91,24 +89,7 @@ class ServiceDiscovery:
         return None
 
 
-class PrometheusDiscovery(ServiceDiscovery, PodsDiscovery):
-    PROMETHEUS_SELECTORS = [
-        "app=kube-prometheus-stack-prometheus",
-        "app=prometheus,component=server",
-        "app=prometheus-server",
-        "app=prometheus-operator-prometheus",
-        "app=prometheus-msteams",
-        "app=rancher-monitoring-prometheus",
-        "app=prometheus-prometheus",
-    ]
-
-    @classmethod
-    def find_prometheus_pods(cls) -> Optional[List[Pod]]:
-        return super().find_pods(
-            selectors=cls.PROMETHEUS_SELECTORS,
-            error_msg="Prometheus pods could not be found.",
-        )
-
+class PrometheusDiscovery(ServiceDiscovery):
     @classmethod
     def find_prometheus_url(cls) -> Optional[str]:
         return super().find_url(


### PR DESCRIPTION
adds regex filter to log_enricher + playbook for PrometheusRuleFailures to bring only relevant logs
It is important to note that the regex filter is run before our regex replacement 
so a filter can return all lines that contain the secret XYZ for example but the regex replacement will print it as ***