### PR TITLE
feat: use slack upload v2 api

### DIFF
--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -191,7 +191,7 @@ class SlackSender:
         with tempfile.NamedTemporaryFile() as f:
             f.write(block.contents)
             f.flush()
-            result = self.slack_client.files_upload(title=block.filename, file=f.name, filename=block.filename)
+            result = self.slack_client.files_upload_v2(title=block.filename, file=f.name, filename=block.filename)
             return result["file"]["permalink"]
 
     def prepare_slack_text(self, message: str, files: List[FileBlock] = []):


### PR DESCRIPTION
Deployed robusta-runner in kubernetes(helm-chart version 0.10.14), having a warn logs:
```
/usr/local/lib/python3.9/site-packages/slack_sdk/web/internal_utils.py:450: UserWarning: client.files_upload() may cause some issues like timeouts for relatively large files. Our latest recommendation is to use client.files_upload_v2(), which is mostly compatible and much stabler, instead.
  warnings.warn(message)
```
Use files_upload_v2 instead of files_upload will be better.