### PR TITLE
Fixed graph queries with multiple prometheus metrics jobs

### DIFF
--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -248,7 +248,7 @@ def create_resource_enrichment(
             values_format=ChartValuesFormat.CPUUsage,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Pod): ChartOptions(
-            query='sum(container_memory_working_set_bytes{pod=~"$pod", container!="", image!=""})',
+            query='sum(container_memory_working_set_bytes{pod=~"$pod", container!="", image!=""}) by (pod, job)',
             values_format=ChartValuesFormat.Bytes,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Node): ChartOptions(
@@ -256,7 +256,7 @@ def create_resource_enrichment(
             values_format=ChartValuesFormat.Percentage,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Container): ChartOptions(
-            query='sum(container_memory_working_set_bytes{pod=~"$pod", container=~"$container", image!=""})',
+            query='sum(container_memory_working_set_bytes{pod=~"$pod", container=~"$container", image!=""}) by (container, job)',
             values_format=ChartValuesFormat.Bytes,
         ),
         (ResourceChartResourceType.Disk, ResourceChartItemType.Pod): None,

--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -1,4 +1,3 @@
-import logging
 import math
 from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta

--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -173,7 +173,7 @@ def create_chart_from_prometheus_query(
     if filter_prom_jobs:
         series_list_result = filter_prom_jobs_results(series_list_result)
     for i, series in enumerate(series_list_result):
-        label = "\n".join([v for v in series.metric.values()])
+        label = "\n".join([v for (key, v) in series.metric.items() if key != "job"])
         # If the label is empty, try to take it from the additional_label_factory
         if label == "" and chart_label_factory is not None:
             label = chart_label_factory(i)


### PR DESCRIPTION
If prometheus had multiple jobs or a job not named kubelet the graphs from robusta would be empty since the job is specified in the query.
Now we get all the graphs and check for the relevant job metric graph. (we prefer kubelet if it exists)
Additionally `container_cpu_usage_seconds_total:sum_irate` doesn't always exist in every prometheus so it is replaced too.

To duplicate this issue add this to generated_values.yaml

```
kube-prometheus-stack:
  prometheus:
      prometheusSpec:
        additionalScrapeConfigs:
          - job_name: 'robusta-kubernetes-cadvisor'
            scheme: https
            metrics_path: /metrics/cadvisor
            tls_config:
              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
            kubernetes_sd_configs:
            - role: node
            relabel_configs:
            - action: labelmap
              regex: __meta_kubernetes_node_label_(.+)
```