### PR TITLE
Extend OpenShift SCC support

### DIFF
--- a/docs/setup-robusta/supported-clusters.rst
+++ b/docs/setup-robusta/supported-clusters.rst
@@ -11,15 +11,68 @@ Distribution-specific instructions are below.
 OpenShift
 ========================================
 
-OpenShift is supported. Robusta needs to be granted permissions to run:
+OpenShift is supported via the Helm chart. 
 
-.. code-block:: bash
-   :name: cb-oc-adm-policy-add
+.. warning::
 
-    oc adm policy add-scc-to-user anyuid -z robusta-forwarder-service-account
-    oc adm policy add-scc-to-user anyuid -z robusta-runner-service-account
+      Do **not** install Robusta in the ``default`` OpenShift project.
 
-The above is very permissive. More restrictive policies can be applied.
+Update the ``generated_values.yaml`` file to enable OpenShift support:
+
+.. code-block:: yaml
+
+    openshift:
+      enabled: true
+      createScc: true
+    
+
+For users that do not have access to create their own SCCs in the cluster, see the
+`openshift-scc-baseline.yaml <../../helm/robusta/templates/openshift-scc-baseline.yaml>`_ file for the baseline SCC for the product. This SCC can be
+created in advance by administrators and referenced using the following set of values:
+
+.. code-block:: yaml
+
+    openshift:
+      enabled: true
+      sccName: my-admins-scc
+
+A test installation in OpenShift can use the existing SCC ``anyuid``.
+
+OpenShift Prometheus Stack
+--------------------------
+
+OpenShift comes with an existing Prometheus installation. In order to point
+to the preconfigued stack, update the ``globalConfig`` in the Helm values with
+the following:
+
+.. code-block:: yaml
+
+    globalConfig:
+      prometheus_url: http://prometheus-operated.openshift-monitoring.svc.cluster.local:9090
+
+Robusta Advanced Debug Features
+--------------------------------
+
+In order to support the ``python_debugger``, ``java_debugger`` and ``node_disk_analyzer``
+playbooks, permission to run a far more privileged container needs to be granted to
+the ``runner`` service account. This container has ``SYS_ADMIN`` capabilities and must
+run as root on the node.
+
+To support these features in a production environment, you may want to only temporarily
+enable this permission so that a normal request cannot bypass the the less permissive SCC found
+in the baseline. To enable these privileged operations in your OpenShift environment,
+update the ``generated_values.yaml`` as follows:
+
+.. code-block:: yaml
+
+    openshift:
+      enabled: true
+      createScc: true
+      createPrivilegedScc: true
+
+You may also reference an existing SCC using the ``openshift.privilegedSccName`` value.
+In test environments, you can reference the ``privileged`` SCC to enable these features in your
+installation.
 
 Minikube
 ==========

--- a/helm/robusta/templates/forwarder-service-account.yaml
+++ b/helm/robusta/templates/forwarder-service-account.yaml
@@ -82,6 +82,16 @@ rules:
       - get
       - list
       - watch
+{{- if .Values.openshift.enabled }}
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+    resourceNames:
+    - {{ if .Values.openshift.createScc }}"{{ .Release.Name }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/robusta/templates/openshift-scc-baseline.yaml
+++ b/helm/robusta/templates/openshift-scc-baseline.yaml
@@ -1,0 +1,40 @@
+{{- if (and .Values.openshift.enabled .Values.openshift.createScc) }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Release.Name }}-scc
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/description: {{ .Release.Name }}-scc provides the features required to run robusta
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+priority: {{ .Values.sccPriority }}
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- ALL
+runAsUser:
+  type: MustRunAs
+  uid: 1000
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: MustRunAs
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret
+{{- end }}

--- a/helm/robusta/templates/openshift-scc-privileged.yaml
+++ b/helm/robusta/templates/openshift-scc-privileged.yaml
@@ -1,0 +1,45 @@
+{{- if (and .Values.openshift.enabled .Values.openshift.createPrivilegedScc) }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Release.Name }}-scc-privileged
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/description: {{ .Release.Name }}-scc provides the features required to run robusta enhanced debuggers for Java, Python, and node host capabilities
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- SYS_PTRACE
+- SYS_ADMIN
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: {{ .Values.privilegedSccPriority }}
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret
+- hostPath
+{{- end }}

--- a/helm/robusta/templates/runner-service-account.yaml
+++ b/helm/robusta/templates/runner-service-account.yaml
@@ -174,6 +174,22 @@ rules:
       - create
       - update
 {{- end }}
+{{- if .Values.openshift.enabled }}
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+    resourceNames:
+    - {{ if .Values.openshift.createScc }}"{{ .Release.Name }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
+{{- if .Values.openshift.createPrivilegedScc }}
+    - {{ .Release.Name }}-scc-privileged
+{{- end }}
+{{- if .Values.openshift.privilegedSccName }}
+    - {{ .Values.openshift.privilegedSccName }}
+{{- end }}
+{{- end }}
 
 ---
 apiVersion: v1

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -520,3 +520,15 @@ kube-prometheus-stack:
         cpu: 10m
 
 rsa: ~
+
+# custom parameters for OpenShift clusters
+openshift:
+  enabled: false
+  createScc: false
+  createPrivilegedScc: false
+
+  privilegedSccName: null
+  sccName: null
+
+  sccPriority: null
+  privilegedSccPriority: null


### PR DESCRIPTION
While the current installation documentation works to install the product in an OpenShift cluster, on one hand `anyuid` is far too broad for the standard product install and on the other hand key privileged playbooks fail on the cluster even when granted `anyuid`. The right way to tackle this problem is to provide a separation between the standard product operation mode and the privileged debugging mode.

One current challenge is that the `runner` project spins up the debug pod using its own service account. If this was split into a `runner-debug` service account, the Kubernetes privileges could be removed from `runner-debug` while the privileged host capabilities could be limited to this serviceaccount that only runs pods for debug purposes. See the `create_debugger_pod` method for the current request that is being sent to the API server: https://github.com/robusta-dev/robusta/blob/master/src/robusta/integrations/kubernetes/custom_models.py#L215.

With these two SCCs defined in the PR, users can install the current product without privileged access using the baseline instructions. Then, if debugger features are desired, the privileged mode can be enabled.

I see that the generated values file is created by your `robusta gen-config` CLI. This set of inputs could be added via an `--(no-)enable-openshift` option set.