### PR TITLE
Make Mattermost client work with non-admin bots and fix logo url

### DIFF
--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -39,6 +39,11 @@ Getting your mattermost webhook url
       :width: 600
       :align: center
 
+.. note::
+
+    If you are not able to use an admin bot, make sure to include `team_id` in your sink configuration.
+    Also, be aware that you won't be able to post to private channels with a non-admin bot.
+
 4. Copy the token value of the bot - it will be used to send all the messages to the channel.
 
     .. image:: /images/add_mattermost_bot_5.png
@@ -67,6 +72,7 @@ Now we're ready to configure the Mattermost sink.
             token: <YOUR BOT TOKEN> (the token we copied the first after bot creation)
             token_id: <YOUR BOT TOKEN ID> (the token id visible in bot panel)
             channel: <YOUR CHANNEL NAME> (the channel name you want to send messages to - either display name or channel name divided by hyphen (e.g. channel-name))
+            team_id: <YOUR TEAM ID> (OPTIONAL - this is only needed if your mattermost bot is not an admin)
 
 Save the file and run
 
@@ -75,7 +81,7 @@ Save the file and run
 
     helm upgrade robusta robusta/robusta --values=generated_values.yaml
 
-You should now get playbooks results in Mattermost!
+You should now get playbooks results in Mattermost! Make sure to add the bot to the required channels.
 
 
 

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -41,8 +41,10 @@ Getting your mattermost webhook url
 
 .. note::
 
-    If you are not able to use an admin bot, make sure to include `team_id` in your sink configuration.
-    Also, be aware that you won't be able to post to private channels with a non-admin bot.
+    If you are not able to use an admin bot, there are a few more requirements:
+      * Make sure to include `team_id` in your sink configuration.
+      * In order to receive enrichments like logs or graphs, the bot needs to already be added to the channel
+      * You won't be able to post to private channels with a non-admin bot.
 
 4. Copy the token value of the bot - it will be used to send all the messages to the channel.
 
@@ -81,7 +83,7 @@ Save the file and run
 
     helm upgrade robusta robusta/robusta --values=generated_values.yaml
 
-You should now get playbooks results in Mattermost! Make sure to add the bot to the required channels.
+You should now get playbooks results in Mattermost!
 
 
 

--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -2,7 +2,7 @@ import os
 
 import pytz
 
-ROBUSTA_LOGO_URL = os.environ.get("ROBUSTA_LOGO_URL", "https://platform.robusta.dev/android-chrome-512x512.png")
+ROBUSTA_LOGO_URL = os.environ.get("ROBUSTA_LOGO_URL", "https://docs.robusta.dev/master/_static/robusta-logo.png")
 PLAYBOOKS_ROOT = os.environ.get("PLAYBOOKS_ROOT", "/etc/robusta/playbooks/")
 # should be the same as the one in out Dockerfile
 DEFAULT_PLAYBOOKS_ROOT = os.environ.get("DEFAULT_PLAYBOOKS_ROOT", os.path.join(PLAYBOOKS_ROOT, "defaults"))

--- a/src/robusta/core/sinks/mattermost/mattermost_sink.py
+++ b/src/robusta/core/sinks/mattermost/mattermost_sink.py
@@ -15,6 +15,7 @@ class MattermostSink(SinkBase):
             token=sink_config.mattermost_sink.token,
             token_id=sink_config.mattermost_sink.token_id,
             team=sink_config.mattermost_sink.team,
+            team_id=sink_config.mattermost_sink.team_id,
         )
         self.sender = MattermostSender(
             cluster_name=self.cluster_name, account_id=self.account_id, client=client,

--- a/src/robusta/core/sinks/mattermost/mattermost_sink_params.py
+++ b/src/robusta/core/sinks/mattermost/mattermost_sink_params.py
@@ -13,6 +13,7 @@ class MattermostSinkParams(SinkBaseParams):
     token_id: str
     channel: str
     team: Optional[str]
+    team_id: Optional[str]
 
     @validator("url")
     def set_http_schema(cls, url):

--- a/src/robusta/integrations/mattermost/client.py
+++ b/src/robusta/integrations/mattermost/client.py
@@ -46,6 +46,7 @@ class MattermostClient:
         response = self._send_mattermost_request(url, HttpMethod.GET)
         if not check_response_succeed(response):
             logging.error("Could not connect to Mattermost with bot account")
+            return
         response_data = response.json()
         if "system_admin" in response_data.get("roles"):
             logging.info("Using Mattermost admin bot")
@@ -77,18 +78,15 @@ class MattermostClient:
             logging.warning("Cannot update bot logo, probably bot has not enough permissions")
 
     def _init_setup(self, channel_name: str, team_name: Optional[str] = None):
-        bot_id = None
         if self.is_admin:
-            bot_id = self.get_token_owner_id()
-        if team_name and self.is_admin:
-            self.team_id = self.get_team_id(team_name)
+            self.bot_id = self.get_token_owner_id()
+            self.team_id = self.get_team_id(team_name) if team_name else None
+            if self.bot_id:
+                self.update_bot_settings(self.bot_id)
+
         self.channel_id = self.get_channel_id(channel_name)
         if not self.channel_id:
             logging.warning("No channel found, messages won't be sent")
-        if bot_id:
-            self.bot_id = bot_id
-            if self.is_admin:
-                self.update_bot_settings(bot_id)
 
     def get_channel_id(self, channel_name: str) -> Optional[str]:
         if self.is_admin:

--- a/src/robusta/integrations/mattermost/client.py
+++ b/src/robusta/integrations/mattermost/client.py
@@ -6,19 +6,20 @@ from robusta.integrations.common.requests import HttpMethod, check_response_succ
 
 _API_PREFIX = "api/v4"
 
-
 class MattermostClient:
     channel_id: str
     bot_id: str
     team_id: Optional[str]
 
-    def __init__(self, url: str, token: str, token_id: str, channel_name: str, team: Optional[str]):
+    def __init__(self, url: str, token: str, token_id: str, channel_name: str, team: Optional[str], team_id: Optional[str]):
         """
         Set the Mattermost webhook url.
         """
         self.client_url = url
         self.token = token
         self.token_id = token_id
+        self.team_id = team_id
+        self.is_admin = self.is_admin_bot()
         self._init_setup(channel_name, team)
 
     def _send_mattermost_request(self, url: str, method: HttpMethod, **kwargs):
@@ -39,6 +40,24 @@ class MattermostClient:
         response_data = response.json()
         return response_data.get("user_id")
 
+    def is_admin_bot(self):
+        endpoint = "/users/me"
+        url = self._get_full_mattermost_url(endpoint)
+        response = self._send_mattermost_request(url, HttpMethod.GET)
+        if not check_response_succeed(response):
+            logging.error("Could not connect to Mattermost with bot account")
+        response_data = response.json()
+        if "system_admin" in response_data.get("roles"):
+            logging.info("Using Mattermost admin bot")
+            return True
+        else:
+            logging.warning("Bot is not an admin. You will not be able to post to private channels.")
+            if self.team_id is None:
+                logging.error(
+                    "You need to provide 'team_id' in your configuration if your bot account is not an admin."
+                )
+            return False
+
     def update_bot_settings(self, bot_id: str):
         endpoint = f"bots/{bot_id}"
         url = self._get_full_mattermost_url(endpoint)
@@ -58,21 +77,31 @@ class MattermostClient:
             logging.warning("Cannot update bot logo, probably bot has not enough permissions")
 
     def _init_setup(self, channel_name: str, team_name: Optional[str] = None):
-        bot_id = self.get_token_owner_id()
-        self.team_id = self.get_team_id(team_name) if team_name else None
+        bot_id = None
+        if self.is_admin:
+            bot_id = self.get_token_owner_id()
+        if team_name and self.is_admin:
+            self.team_id = self.get_team_id(team_name)
         self.channel_id = self.get_channel_id(channel_name)
         if not self.channel_id:
             logging.warning("No channel found, messages won't be sent")
         if bot_id:
             self.bot_id = bot_id
-            self.update_bot_settings(bot_id)
+            if self.is_admin:
+                self.update_bot_settings(bot_id)
 
     def get_channel_id(self, channel_name: str) -> Optional[str]:
-        endpoint = "channels/search"
-        url = self._get_full_mattermost_url(endpoint)
-        payload = {"term": channel_name}
-        if self.team_id:
-            payload["team_ids"] = [self.team_id]
+        if self.is_admin:
+            endpoint = "channels/search"
+            url = self._get_full_mattermost_url(endpoint)
+            payload = {"term": channel_name}
+            if self.team_id:
+                payload["team_ids"] = [self.team_id]
+        else:
+            endpoint = f"teams/{self.team_id}/channels/search"
+            url = self._get_full_mattermost_url(endpoint)
+            payload = {"term": channel_name}
+
         response = self._send_mattermost_request(url, HttpMethod.POST, json=payload)
         if check_response_succeed(response):
             response = response.json()
@@ -81,6 +110,9 @@ class MattermostClient:
             return response[0].get("id")
 
     def get_team_id(self, team_name: str) -> Optional[str]:
+        if not self.is_admin:
+            logging.error("You are using a non-admin bot account, which means you need to configure 'team_id'.")
+            return
         endpoint = "teams/search"
         url = self._get_full_mattermost_url(endpoint)
         response = self._send_mattermost_request(url, HttpMethod.POST, json={"term": team_name})


### PR DESCRIPTION
Discussed with Arik [here](https://robustacommunity.slack.com/archives/C02R0LSAHNJ/p1681656740413749) to maintain backwards compatibility.

This did feel a bit like writing spaghetti code due to that requirement. Any feedback / improvements is most welcome.
Both flows have been tested 👍 