### PR TITLE
Add support for Azure Managed Identities

### DIFF
--- a/docs/configuration/azure-managed-prometheus.rst
+++ b/docs/configuration/azure-managed-prometheus.rst
@@ -23,13 +23,15 @@ To configure Azure to send alerts to Robusta:
 Configure Robusta to use Azure managed Prometheus
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For certain features, Robusta needs to reach out to Prometheus and pull in extra information.
-In this section we will Create an Azure Active Directory authentication app so that Robusta can analyze and present Prometheus data.
+For certain features, Robusta needs to reach out to Prometheus so that Robusta can analyze and present Prometheus data.
+In order to authenticate against the Azure managed Prometheus service, you have two options:
+- Create an Azure Active Directory authentication app
+- Create a Managed Identity (Recommended, no secret to carry around)
 
 Get the Azure prometheus query endpoint
 =========================================
 
-1. Go to `Azure Monitor workspaces <https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.monitor%2Faccounts>`_ and chose your monitored workspace.
+1. Go to `Azure Monitor workspaces <https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.monitor%2Faccounts>`_ and choose your monitored workspace.
 2. In your monitored workspace, `overview`, find the ``Query endpoint`` and copy it.
 3. In your `generated_values.yaml` file add the query endpoint url with a 443 port:
 
@@ -62,3 +64,35 @@ We will now create an Azure authentication app and get the necesssary credential
       value: "<your-client-secret>"
 
 3. Complete the `Allow your app access to your workspace <https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-self-managed-grafana-azure-active-directory#allow-your-app-access-to-your-workspace>`_ step, so your app can query data from your Azure Monitor workspace.
+
+Create a Managed Identity (Recommended)
+=========================================
+
+We will now create a Managed Identity and assign permissions to it so Robusta can access Prometheus data.
+
+1. Follow this Azure guide to `Create a Managed Identity <https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity>`_
+
+2. In your generated_values.yaml file add the following environment variables from the previous step.
+
+.. code-block:: yaml
+
+  runner:
+    additional_env_vars:
+    - name: PROMETHEUS_SSL_ENABLED
+      value: "true"
+    - name: AZURE_USE_MANAGED_ID
+      value: "true"
+    - name: AZURE_CLIENT_ID
+      value: "<your-client-id>"
+    - name: AZURE_TENANT_ID
+      value: "<your-tenant-id>"
+
+3. Give access to your Managed Identity on your workspace:
+
+   a. Open the Access Control (IAM) page for your Azure Monitor workspace in the Azure portal.
+   b. Select Add role assignment.
+   c. Select Monitoring Data Reader and select Next.
+   d. For Assign access to, select Managed identity.
+   e. Select + Select members.
+   f. Select the Managed Identity you created on step 1
+   g. Select Review + assign to save the configuration.

--- a/docs/configuration/azure-managed-prometheus.rst
+++ b/docs/configuration/azure-managed-prometheus.rst
@@ -25,8 +25,20 @@ Configure Robusta to use Azure managed Prometheus
 
 For certain features, Robusta needs to reach out to Prometheus so that Robusta can analyze and present Prometheus data.
 In order to authenticate against the Azure managed Prometheus service, you have two options:
-- Create an Azure Active Directory authentication app
-- Create a Managed Identity (Recommended, no secret to carry around)
+- Create an Azure Active Directory authentication app (Option #1)
+  - Pros:
+    - Quick setup. Just need to create an app, get the credentials and add them to the manifests
+    - Other pods can't use the Service Principal without having the secret
+  - Cons:
+    - Requires a service principal (Azure AD permission)
+    - Need the client secret in the kubernetes manifests
+    - Client secret expires, you need to manage its rotation
+- Use Kubelet's Managed Identity (Option #2)
+  - Pros:
+    - Quick setup. Get the Managed Identity Client ID and add them to the manifests
+    - No need to manage secrets. Removing the password element decreases the risk of the credentials being compromised
+  - Cons:
+    - Managed Identity is bound to the whole VMSS, so other pods can use it if they know the client ID
 
 Get the Azure prometheus query endpoint
 =========================================
@@ -41,8 +53,8 @@ Get the Azure prometheus query endpoint
   globalConfig:
       prometheus_url: "<https://your-workspace.region.prometheus.monitor.azure.com>:443"
 
-Create an Azure authentication app
-=====================================
+Option #1: Create an Azure authentication app
+==============================================
 
 We will now create an Azure authentication app and get the necesssary credentials so Robusta can access Prometheus data.
 
@@ -65,12 +77,16 @@ We will now create an Azure authentication app and get the necesssary credential
 
 3. Complete the `Allow your app access to your workspace <https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-self-managed-grafana-azure-active-directory#allow-your-app-access-to-your-workspace>`_ step, so your app can query data from your Azure Monitor workspace.
 
-Create a Managed Identity (Recommended)
-=========================================
+Option #2: Use Kubelet's Managed Identity
+==============================================
 
-We will now create a Managed Identity and assign permissions to it so Robusta can access Prometheus data.
+We will now use the Kubelet's Managed Identity so Robusta can access Prometheus data. Alternatively, you can create a new User Assigned Managed Identity and bind it to the underlying VMSS. This guide will use the Kubelet's Managed Identity.
 
-1. Follow this Azure guide to `Create a Managed Identity <https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity>`_
+1. Get the AKS kubelet's Managed Identity Client ID:
+
+.. code-block:: bash
+
+  az aks show -g <resource-group> -n <cluster-name> --query identityProfile.kubeletidentity.clientId -o tsv
 
 2. In your generated_values.yaml file add the following environment variables from the previous step.
 
@@ -94,5 +110,5 @@ We will now create a Managed Identity and assign permissions to it so Robusta ca
    c. Select Monitoring Data Reader and select Next.
    d. For Assign access to, select Managed identity.
    e. Select + Select members.
-   f. Select the Managed Identity you created on step 1
+   f. Select the Managed Identity you got from step 1
    g. Select Review + assign to save the configuration.


### PR DESCRIPTION
Along with Service Principal Authentication, here is the support for Managed Identities. Implementation is sending a request to the Azure Instance Metadata Service (IMDS) to get the access token. No client secret is required. 
Managed Identity still needs Monitoring Data Reader role on the Azure Monitor Workspace to be able to query the prometheus metrics.

Other changes in the code were triggered by Black, Flake8 or PyRight.

closes #848