### PR TITLE
fix: deployment resources.limits.cpu referencing wrong value

### DIFF
--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -41,13 +41,13 @@ spec:
           capabilities: {}
           privileged: false
           readOnlyRootFilesystem: false
-          runAsUser: 1000    
+          runAsUser: 1000
         resources:
           requests:
             cpu: {{ .Values.kubewatch.resources.requests.cpu }}
             memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else }}{{ .Values.kubewatch.resources.requests.memory | quote }}{{ end }}
           limits:
-            memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else }}{{ .Values.kubewatch.resources.requests.memory | quote }}{{ end }}
+            memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else }}{{ .Values.kubewatch.resources.limits.memory | quote }}{{ end }}
             {{ if .Values.kubewatch.resources.limits.cpu }}cpu: {{ .Values.kubewatch.resources.limits.cpu | quote }}{{ end }}
       volumes:
         - name:  robusta-kubewatch-config


### PR DESCRIPTION
Currently forwarder resources are defined as below: 
```
resources:
  requests:
    cpu: {{ .Values.kubewatch.resources.requests.cpu }}
    memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else }}{{ .Values.kubewatch.resources.requests.memory | quote }}{{ end }}
  limits:
    memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else }}{{ .Values.kubewatch.resources.requests.memory | quote }}{{ end }}
    {{ if .Values.kubewatch.resources.limits.cpu }}cpu: {{ .Values.kubewatch.resources.limits.cpu | quote }}{{ end }}
```
`Values.kubewatch.resources.requests.memory` is used both for requests and for limits, which isn't a desired behavior