### PR TITLE
Added HTTP PUT custom playbook action

### DIFF
--- a/playbooks/robusta_playbooks/http_actions.py
+++ b/playbooks/robusta_playbooks/http_actions.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional, Union
 from urllib.error import HTTPError, URLError
 
 import requests
@@ -92,7 +92,7 @@ class HTTP_POST(ActionParams):
     """
 
     url: str
-    data: dict = None  # type: ignore
+    data: Union[dict, str, bytes, List[tuple]] = None  # type: ignore
     headers: dict = None
     get_response: Optional[bool] = False
 
@@ -161,7 +161,7 @@ class HTTP_PUT(ActionParams):
     """
 
     url: str
-    data: dict = None  # type: ignore
+    data: Union[dict, str, bytes, List[tuple]] = None  # type: ignore
     headers: dict = None
     get_response: Optional[bool] = False
 


### PR DESCRIPTION
we need to support also HTTP PUT custom playbook action in addition to existing HTTP GET and HTTP POST. 
It can very useful when we need to use REST API webhooks.