### PR TITLE
add k8s version info in discovery

### DIFF
--- a/src/robusta/core/discovery/discovery.py
+++ b/src/robusta/core/discovery/discovery.py
@@ -409,6 +409,12 @@ class Discovery:
         except Exception:
             logging.error("Failed to count jobs", exc_info=True)
 
+        k8s_version: str = None
+        try:
+            k8s_version = client.VersionApi().get_code().git_version
+        except Exception:
+            logging.exception("Failed to get k8s server version")
+
         return ClusterStats(
             deployments=deploy_count,
             statefulsets=sts_count,
@@ -418,6 +424,7 @@ class Discovery:
             nodes=node_count,
             jobs=job_count,
             provider=cluster_provider.get_cluster_provider(),
+            k8s_version=k8s_version
         )
 
 

--- a/src/robusta/core/model/cluster_status.py
+++ b/src/robusta/core/model/cluster_status.py
@@ -10,6 +10,7 @@ class ClusterStats(BaseModel):
     nodes: int
     jobs: int
     provider: str
+    k8s_version: Optional[str] = None
 
 
 class ActivityStats(BaseModel):


### PR DESCRIPTION
Added the git version as its more verbose (contains patch and more)
example EKS
 provider': 'EKS', 'k8s_version': 'v1.25.11-eks-a5565ad'
example AKS
'provider': 'AKS', 'k8s_version': 'v1.25.6'