### PR TITLE
feature/custom-cr-roles - Adds Custom Cluster Roles rules for runner service account

### DIFF
--- a/helm/robusta/templates/runner-service-account.yaml
+++ b/helm/robusta/templates/runner-service-account.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ .Release.Name }}-runner-cluster-role
   namespace : {{ .Release.Namespace }}
 rules:
-  {{- if .Values.runner.customClusterRole.enabled }}
-{{ toYaml .Values.runner.customClusterRole.rules | indent 2 }}
+  {{- if .Values.runner.customClusterRoleRules }}
+{{ toYaml .Values.runner.customClusterRoleRules | indent 2 }}
   {{- end }}
   - apiGroups:
       - ""

--- a/helm/robusta/templates/runner-service-account.yaml
+++ b/helm/robusta/templates/runner-service-account.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Release.Name }}-runner-cluster-role
   namespace : {{ .Release.Namespace }}
 rules:
+  {{- if .Values.runner.customClusterRole.enabled }}
+{{ toYaml .Values.runner.customClusterRole.rules | indent 2 }}
+  {{- end }}
   - apiGroups:
       - ""
     resources:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -462,6 +462,9 @@ runner:
   tolerations: []
   annotations: {}
   nodeSelector: ~
+  customClusterRole:
+    enabled: false
+    rules: []
 
 kube-prometheus-stack:
   alertmanager:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -462,9 +462,7 @@ runner:
   tolerations: []
   annotations: {}
   nodeSelector: ~
-  customClusterRole:
-    enabled: false
-    rules: []
+  customClusterRoleRules: []
 
 kube-prometheus-stack:
   alertmanager:


### PR DESCRIPTION
## Description
- [x] Adds Custom Cluster Roles rules for Robusta runner service account

## Related Issue

- #1002 

## Motivation and Context
- Adds custom cluster roles rules in order to interact with custom Kubernetes objects in Robusta Runner

## How Has This Been Tested?
Installed robusta in a k3d cluster using the [custom k8s object playbook](https://github.com/moraesjeremias/custom-k8s-objects-robusta-playbook/tree/main).

## Contract changes
- This adds `runner.customClusterRole` field. Find below an usage example:
```diff
runner:
+  customClusterRole:
+    enabled: true
+    rules:
+      - apiGroups:
+          - wgpolicyk8s.io
+        resources:
+          - policyreports
+        verbs:
+          - get
+          - list
+          - watch
```

## Robusta logs:
```py
2023-07-22 21:56:43.093 INFO     Cloning git repo https://github.com/moraesjeremias/custom-k8s-objects-robusta-playbook.git. repo name custom-k8s-objects-robusta-playbook
Processing ./robusta-git/custom-k8s-objects-robusta-playbook
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: custom-k8s-objects
  Building wheel for custom-k8s-objects (pyproject.toml): started
  Building wheel for custom-k8s-objects (pyproject.toml): finished with status 'done'
  Created wheel for custom-k8s-objects: filename=custom_k8s_objects-0.0.1-py3-none-any.whl size=1517 sha256=968b62c6a7c7ccd64546f0ccbbdd9191d01f5387c36bd4344c60110ee90a040a
  Stored in directory: /root/.cache/pip/wheels/93/f6/87/1ae7ccc3fb8149aa05e6a75f878ebb06bcb1dc51634a15a8af
Successfully built custom-k8s-objects
Installing collected packages: custom-k8s-objects
Successfully installed custom-k8s-objects-0.0.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.1.2 -> 23.2
[notice] To update, run: pip install --upgrade pip
2023-07-22 21:56:45.868 INFO     Importing actions package robusta.core.playbooks.internal
2023-07-22 21:56:45.868 INFO     importing actions from robusta.core.playbooks.internal.discovery_events
2023-07-22 21:56:47.150 INFO     Importing actions package robusta_playbooks

2023-07-22 21:56:47.737 INFO     Importing actions package custom_k8s_objects
2023-07-22 21:56:47.737 INFO     importing actions from custom_k8s_objects.custom_k8s_objects

2023-07-22 21:56:48.041 INFO     created jobs states configmap scheduled-jobs default
2023-07-22 21:56:48.087 INFO     scheduling job ccd8a1d0b5f86859fdfbdd6575bd3a5e params cron_expression='*/2 * * * *' will run in 120
2023-07-22 21:56:48.088 INFO     Initialized task queue: 20 workers. Max size 500
2023-07-22 21:56:48.091 INFO     Initialized task queue: 20 workers. Max size 500
 * Serving Flask app 'robusta.runner.web'
 * Debug mode: off
2023-07-22 21:58:48.087 INFO     running scheduled job ccd8a1d0b5f86859fdfbdd6575bd3a5e
2023-07-22 21:58:48.101 INFO     These are all policy reports[{'apiVersion': 'wgpolicyk8s.io/v1alpha2', 'kind': 'PolicyReport', 'metadata': {'creationTimestamp': '2023-07-22T21: 54: 14Z', 'generation': 6, 'labels': {'app.kubernetes.io/managed-by': 'kyverno', 'cpol.kyverno.io/disallow-capabilities': '1187'}, 'managedFields': [{'apiVersion': 'wgpolicyk8s.io/v1alpha2', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:labels': {'.': {}, 'f:app.kubernetes.io/managed-by': {}, 'f:cpol.kyverno.io/disallow-capabilities': {}}}, 'f:results': {}, 'f:summary': {'.': {}, 'f:error': {}, 'f:fail': {}, 'f:pass': {}, 'f:skip': {}, 'f:warn': {}}}, 'manager': 'reports-controller', 'operation': 'Update', 'time': '2023-07-22T21: 57: 19Z'}], 'name': 'cpol-disallow-capabilities', 'namespace': 'default', 'resourceVersion': '3322', 'uid': 'be100ed6-b4c5-4e0f-9b99-51d62cb2b4d3'}, 'results': [{'category': 'Pod Security Standards (Baseline)', 'message': "validation rule 'autogen-adding-capabilities' passed.", 'policy': 'disallow-capabilities', 'resources': [{'apiVersion': 'apps/v1', 'kind': 'Deployment', 'name': 'robusta-runner', 'namespace': 'default', 'uid': 'd8c4f209-7848-422e-ae6c-5f6bff981e86'}], 'result': 'pass', 'rule': 'autogen-adding-capabilities', 'scored': True, 'severity': 'medium', 'source': 'kyverno', 'timestamp': {'nanos': 0, 'seconds': 1690062949}}], 'summary': {'error': 0, 'fail': 0, 'pass': 7, 'skip': 0, 'warn': 0}}]
```

