### PR TITLE
Added `max_log_file_limit_kb` in `slack_sink`

### DIFF
--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -22,6 +22,7 @@ Alternatively, generate a key by running ``robusta integrations slack`` and set 
          name: main_slack_sink
          api_key: MY SLACK KEY
          slack_channel: MY SLACK CHANNEL
+         max_log_file_limit_kb: 1000 # (Optional) The maximum allowed file size for log files (in kilobytes) uploaded to the Slack channel. Default: 1000.
          channel_override: DYNAMIC SLACK CHANNEL OVERRIDE (Optional)
 
 Then do a :ref:`Helm Upgrade <Simple Upgrade>`.
@@ -53,7 +54,9 @@ For example:
          name: main_slack_sink
          api_key: xoxb-112...
          slack_channel: my-fallback-channel
+         max_log_file_limit_kb: 1000
          channel_override: "labels.slack"
+
 
 Using Private Channels
 -------------------------------------------------------------------

--- a/src/robusta/core/reporting/blocks.py
+++ b/src/robusta/core/reporting/blocks.py
@@ -76,6 +76,31 @@ class FileBlock(BaseBlock):
         """
         super().__init__(filename=filename, contents=contents)
 
+    def truncate_content(self,  max_file_size_bytes: int) -> bytes:
+        """
+        Truncates the log file by removing lines from the beginning until its size is within the given limit.
+        """
+        content_length = len(self.contents)
+
+        if content_length <= max_file_size_bytes:
+            return self.contents
+
+        lines = self.contents.decode('utf-8')
+        lines = lines.splitlines()
+        byte_length_newline = len('\n'.encode('utf-8'))
+
+        truncated_lines: List[str] = []
+        for idx, line in enumerate(lines):
+            line_content_length = len(line.encode('utf-8'))
+            line_content_length = line_content_length + byte_length_newline
+
+            content_length -= line_content_length
+            if (content_length + byte_length_newline) <= max_file_size_bytes:
+                truncated_lines = lines[idx:]
+                break
+
+        return "\n".join(truncated_lines).encode('utf-8')
+
 
 class HeaderBlock(BaseBlock):
     """

--- a/src/robusta/core/sinks/slack/slack_sink_params.py
+++ b/src/robusta/core/sinks/slack/slack_sink_params.py
@@ -14,6 +14,7 @@ class SlackSinkParams(SinkBaseParams):
     slack_channel: str
     api_key: str
     channel_override: Optional[str] = None
+    max_log_file_limit_kb: int = 1000
 
     @validator("channel_override")
     def valid_channel_override(cls, v: str):


### PR DESCRIPTION
Added `max_log_file_limit_kb` in `slack_sink`

max_log_file_limit_kb: 1000 # (Optional) The maximum allowed file size for log files (in kilobytes) uploaded to the Slack channel. Default: 1000.