### PR TITLE
Update _alertmanager-config.rst

### DIFF
--- a/docs/configuration/alertmanager-integration/_alertmanager-config.rst
+++ b/docs/configuration/alertmanager-integration/_alertmanager-config.rst
@@ -6,7 +6,7 @@
           - name: 'robusta'
             webhook_configs:
               - url: 'http://robusta-runner.default.svc.cluster.local/api/alerts' # (2)
-                send_resolved: true # (4)
+                sendResolved: true # (4)
 
         route: # (1)
           routes:


### PR DESCRIPTION
the `send_resolved` is going to fail.

```shell
Error from server (BadRequest): error when creating "robusta-alert-config.yaml": AlertmanagerConfig in version "v1alpha1" cannot be handled as a AlertmanagerConfig: strict decoding error: unknown field "spec.receivers[0].webhookConfigs[0].send_resolved"
```

It should be `sendResolved`

---

```shell
$ k explain alertmanagerconfig.spec.receivers.webhookConfigs
GROUP:      monitoring.coreos.com
KIND:       AlertmanagerConfig
VERSION:    v1alpha1

FIELD: webhookConfigs <[]Object>

DESCRIPTION:
    List of webhook configurations.
    WebhookConfig configures notifications via a generic receiver supporting the
    webhook payload. See
    https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
    
FIELDS:
  httpConfig	<Object>
    HTTP client configuration.

  maxAlerts	<integer>
    Maximum number of alerts to be sent per webhook message. When 0, all alerts
    are included.

  sendResolved	<boolean>
    Whether or not to notify about resolved alerts.

  url	<string>
    The URL to send HTTP POST requests to. `urlSecret` takes precedence over
    `url`. One of `urlSecret` and `url` should be defined.

  urlSecret	<Object>
    The secret's key that contains the webhook URL to send HTTP requests to.
    `urlSecret` takes precedence over `url`. One of `urlSecret` and `url` should
    be defined. The secret needs to be in the same namespace as the
    AlertmanagerConfig object and accessible by the Prometheus Operator.
```
