### PR TITLE
Remove chart flag from create source helm

### DIFF
--- a/docs/setup-robusta/gitops/flux.rst
+++ b/docs/setup-robusta/gitops/flux.rst
@@ -73,6 +73,7 @@ Now lets use the HelmRepository to create a HelmRelease of Robusta.
 .. code-block:: bash
 
         flux create helmrelease robusta \
+            --namespace robusta \
             --chart=robusta \
             --source=HelmRepository/robusta \
             --chart-version="VERSION" \

--- a/docs/setup-robusta/gitops/flux.rst
+++ b/docs/setup-robusta/gitops/flux.rst
@@ -60,7 +60,6 @@ Run the following command to add Robusta Helm chart as a Flux HelmRepository.
         flux create source helm robusta \
             --url https://robusta-charts.storage.googleapis.com \
             --namespace robusta \
-            --chart robusta \
             --export > robusta-helm.yaml
 
 - **--namespace:** Specified namespace should be present in the cluster.


### PR DESCRIPTION
`flux create source helm ...` should not have a `--chart` flag, it throws an error...

```
└─(05:22:49 on main ✹ ✭)──> flux create source helm robusta \                                                                                          ──(Thu,Sep07)─┘
   --url https://robusta-charts.storage.googleapis.com \
   --namespace robusta \
   --chart robusta \
   --export >> robusta.yaml
✗ unknown flag: --chart```

Also --namespace flag is missing in command