### PR TITLE
add support for extra volumes and volume mounts

### DIFF
--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -87,6 +87,9 @@ spec:
           - name: persistent-playbooks-storage
             mountPath: /etc/robusta/playbooks/storage
           {{- end }}
+          {{- with .Values.runner.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         lifecycle:
           preStop:
             exec:
@@ -129,6 +132,9 @@ spec:
         - name: persistent-playbooks-storage
           persistentVolumeClaim:
             claimName: persistent-playbooks-pv-claim
+        {{- end }}
+        {{- with .Values.runner.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- if .Values.runner.nodeSelector }}
       nodeSelector: {{ toYaml .Values.runner.nodeSelector | nindent 8 }}

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -479,6 +479,8 @@ runner:
   nodeSelector: ~
   customClusterRoleRules: []
   imagePullSecrets: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 kube-prometheus-stack:
   alertmanager:


### PR DESCRIPTION
Add support for extra volumes and volume mounts to the runner.

We need to use extra volumes for setting up a scratch/temp directory. We run our k8s pods in clusters that require a readonly filesystem and `Matplotlib` library requires a temp directory it can write to. By adding support for additional volumes and mounts we are able to create an `emptyDir`, mount it to the runner container and then we set the `TMPDIR` env var to the `emptyDir` mount point.