### PR TITLE
added override configs to query

### DIFF
--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -50,7 +50,7 @@ class OverrideGraph(BaseModel):
     resource_type: str
     item_type: str
     query: str
-    values_format: str
+    values_format: Optional[str]
 
 
 class ActionParams(DocumentedModel):

--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -38,6 +38,21 @@ class ResourceChartResourceType(Enum):
     Disk = auto()
 
 
+class OverrideGraph(BaseModel):
+    """
+    A class for overriding prometheus graphs
+    :var resource_type: one of: CPU, Memory, Disk (see ResourceChartResourceType)
+    :var item_type: one of: Pod, Node (see ResourceChartItemType)
+    :var query: the prometheusql query you want to run
+    :var values_format: Customize the y-axis labels with one of: Plain, Bytes, Percentage (see ChartValuesFormat)
+    """
+
+    resource_type: str
+    item_type: str
+    query: str
+    values_format: str
+
+
 class ActionParams(DocumentedModel):
     """
     Base class for all Action parameter classes.
@@ -117,6 +132,7 @@ class PrometheusParams(ActionParams):
     prometheus_url_query_string: Optional[str] = None
     prometheus_additional_labels: Optional[Dict[str, str]] = None
     add_additional_labels: bool = True
+    prometheus_graphs_overrides: Optional[List[OverrideGraph]] = None
 
     @validator("prometheus_url", allow_reuse=True)
     def validate_protocol(cls, v):

--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -258,6 +258,16 @@ def create_graph_enrichment(
     return FileBlock(svg_name, chart.render())
 
 
+def get_default_values_format(combination: ResourceKey) -> ChartValuesFormat:
+    if combination[1] == ResourceChartItemType.Node:
+        return ChartValuesFormat.Percentage
+    elif combination[0] == ResourceChartResourceType.CPU:
+        return ChartValuesFormat.CPUUsage
+    elif combination[0] == ResourceChartResourceType.Memory:
+        return ChartValuesFormat.Bytes
+    return ChartValuesFormat.Plain
+
+
 def __get_override_chart(prometheus_params: PrometheusParams, combination: ResourceKey) -> Optional[ChartOptions]:
     if not prometheus_params.prometheus_graphs_overrides:
         return
@@ -270,8 +280,12 @@ def __get_override_chart(prometheus_params: PrometheusParams, combination: Resou
 
     if len(combinations) == 0:
         return None
+    if not combinations[0].values_format:
+        values_format = get_default_values_format(combinations[0])
+    else:
+        values_format = ChartValuesFormat[combinations[0].values_format]
 
-    return ChartOptions(query=combinations[0].query, values_format=ChartValuesFormat[combinations[0].values_format])
+    return ChartOptions(query=combinations[0].query, values_format=values_format)
 
 
 def create_resource_enrichment(

--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -281,7 +281,7 @@ def __get_override_chart(prometheus_params: PrometheusParams, combination: Resou
     if len(combinations) == 0:
         return None
     if not combinations[0].values_format:
-        values_format = get_default_values_format(combinations[0])
+        values_format = get_default_values_format(combination)
     else:
         values_format = ChartValuesFormat[combinations[0].values_format]
 


### PR DESCRIPTION
example of override configuration

```
globalConfig:
...
  prometheus_graphs_overrides:
  - item_type: Container
    resource_type: CPU
    query: sum(irate(container_cpu_usage_seconds_total{namespace="$namespace", pod=~"$pod"}[5m])) by (pod)
```