### PR TITLE
Count pods in running state in discovery

### DIFF
--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -452,11 +452,12 @@ class SupabaseDal:
             self.handle_supabase_error()
             raise
 
-    def publish_cluster_nodes(self, node_count: int):
+    def publish_cluster_nodes(self, node_count: int, pod_count: int):
         data = {
             "_account_id": self.account_id,
             "_cluster_id": self.cluster,
             "_node_count": node_count,
+            "_pod_count": pod_count,
         }
         try:
             self.__rpc_patch(UPDATE_CLUSTER_NODE_COUNT, data)


### PR DESCRIPTION
Add pod count to cluster nodes tables

Using discovery and not remaining_item_count  in this case

<img width="1027" alt="image" src="https://github.com/robusta-dev/robusta/assets/20162469/9f3d702c-d002-418b-a3a0-80c60654596c">
