### PR TITLE
Add custom labels on pods

### DIFF
--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -18,6 +18,9 @@ spec:
         {{- end }}
       labels:
         app: {{ .Release.Name }}-forwarder
+        {{- with .Values.kubewatch.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-forwarder-service-account
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: {{ .Release.Name }}-runner
         robustaComponent: "runner"
+        {{- with .Values.runner.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if or .Values.runner.annotations .Values.globalConfig.custom_annotations }}
       annotations:
         {{- if .Values.runner.annotations}} {{ toYaml .Values.runner.annotations | nindent 8 }}


### PR DESCRIPTION
We would like to add custom labels on forwarder and runner pods. We will use them in order to show which team is responsible for this pods. 
