### PR TITLE
Extensible Kafka Auth Config

### DIFF
--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -16,6 +16,21 @@ Configuring the Kafka sink
             kafka_url: "localhost:9092"
             topic: "robusta-playbooks"
 
+.. admonition:: Add this to your generated_values.yaml if configuring with authentication
+
+   .. code-block:: yaml
+
+        sinksConfig:
+        - kafka_sink:
+            name: kafka_sink
+            kafka_url: "localhost:9096"
+            topic: "robusta-playbooks"
+            auth:
+                sasl_mechanism: SCRAM-SHA-512
+                security_protocol: SASL_SSL
+                sasl_plain_username: robusta
+                sasl_plain_password: password
+
 Save the file and run
 
 .. code-block:: bash

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -18,6 +18,8 @@ Configuring the Kafka sink
 
 .. admonition:: Add this to your generated_values.yaml if configuring with authentication
 
+   `additional auth options <https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html#kafkaproducer>`_
+
    .. code-block:: yaml
 
         sinksConfig:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,20 +1,31 @@
-apiVersion: skaffold/v2beta20
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: robusta
 build:
   artifacts:
-  - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-    context: .
-    docker:
-      dockerfile: Dockerfile
-  local:
-    concurrency: 0
+    - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+      context: .
+      docker:
+        dockerfile: Dockerfile
   # this is very important. we need to use inputDigest so that different developers don't build the same tags
   # and interfere with one another's work (e.g. when building and then running pytest you want to test the version
   # you built and not a version someone else built with the same tag)
   tagPolicy:
     inputDigest: {}
+  local:
+    concurrency: 0
+
+manifests:
+  helm:
+    releases:
+      - name: robusta
+        chartPath: helm/robusta
+        valuesFiles:
+          - deployment/generated_values.yaml
+        setValueTemplates:
+          runner.image: '{{.IMAGE_FULLY_QUALIFIED_us_central1_docker_pkg_dev_genuine_flight_317411_devel_robusta_runner}}'
+
 deploy:
   helm:
     releases:
@@ -22,46 +33,45 @@ deploy:
         chartPath: helm/robusta
         valuesFiles:
           - deployment/generated_values.yaml
-        artifactOverrides:
-          runner.image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+        setValueTemplates:
+          runner.image: '{{.IMAGE_FULLY_QUALIFIED_us_central1_docker_pkg_dev_genuine_flight_317411_devel_robusta_runner}}'
 
 portForward:
-- resourceType: deployment
-  resourceName: robusta-runner
-  port: 5000
-  localPort: 5000
-
+  - resourceType: deployment
+    resourceName: robusta-runner
+    port: 5000
+    localPort: 5000
 
 profiles:
-- name: apple-m1-dev
-  build:
-    artifacts:
-      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-        context: .
-        custom:
-          buildCommand: ./build_on_apple_m1.sh
-    local:
-      concurrency: 0
-- name: arm
-  build:
-    artifacts:
-      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-        context: .
-        custom:
-          buildCommand: ./build_with_arm.sh
-- name: gcloud-build
-  build:
-    googleCloudBuild:
+  - name: apple-m1-dev
+    build:
+      artifacts:
+        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+          context: .
+          custom:
+            buildCommand: ./build_on_apple_m1.sh
+      local:
+        concurrency: 0
+  - name: arm
+    build:
+      artifacts:
+        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+          context: .
+          custom:
+            buildCommand: ./build_with_arm.sh
+  - name: gcloud-build
+    build:
+      artifacts:
+        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+          context: .
+          docker:
+            dockerfile: Dockerfile
+      googleCloudBuild:
         projectId: genuine-flight-317411
-    artifacts:
-      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-        context: .
-        docker:
-          dockerfile: Dockerfile
-- name: release
-  build:
-    artifacts:
-      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-        context: .
-        custom:
-          buildCommand: ./build_release.sh
+  - name: release
+    build:
+      artifacts:
+        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+          context: .
+          custom:
+            buildCommand: ./build_release.sh

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,31 +1,20 @@
-apiVersion: skaffold/v4beta6
+apiVersion: skaffold/v2beta20
 kind: Config
 metadata:
   name: robusta
 build:
   artifacts:
-    - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-      context: .
-      docker:
-        dockerfile: Dockerfile
+  - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+    context: .
+    docker:
+      dockerfile: Dockerfile
+  local:
+    concurrency: 0
   # this is very important. we need to use inputDigest so that different developers don't build the same tags
   # and interfere with one another's work (e.g. when building and then running pytest you want to test the version
   # you built and not a version someone else built with the same tag)
   tagPolicy:
     inputDigest: {}
-  local:
-    concurrency: 0
-
-manifests:
-  helm:
-    releases:
-      - name: robusta
-        chartPath: helm/robusta
-        valuesFiles:
-          - deployment/generated_values.yaml
-        setValueTemplates:
-          runner.image: '{{.IMAGE_FULLY_QUALIFIED_us_central1_docker_pkg_dev_genuine_flight_317411_devel_robusta_runner}}'
-
 deploy:
   helm:
     releases:
@@ -33,45 +22,46 @@ deploy:
         chartPath: helm/robusta
         valuesFiles:
           - deployment/generated_values.yaml
-        setValueTemplates:
-          runner.image: '{{.IMAGE_FULLY_QUALIFIED_us_central1_docker_pkg_dev_genuine_flight_317411_devel_robusta_runner}}'
+        artifactOverrides:
+          runner.image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
 
 portForward:
-  - resourceType: deployment
-    resourceName: robusta-runner
-    port: 5000
-    localPort: 5000
+- resourceType: deployment
+  resourceName: robusta-runner
+  port: 5000
+  localPort: 5000
+
 
 profiles:
-  - name: apple-m1-dev
-    build:
-      artifacts:
-        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-          context: .
-          custom:
-            buildCommand: ./build_on_apple_m1.sh
-      local:
-        concurrency: 0
-  - name: arm
-    build:
-      artifacts:
-        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-          context: .
-          custom:
-            buildCommand: ./build_with_arm.sh
-  - name: gcloud-build
-    build:
-      artifacts:
-        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-          context: .
-          docker:
-            dockerfile: Dockerfile
-      googleCloudBuild:
+- name: apple-m1-dev
+  build:
+    artifacts:
+      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+        context: .
+        custom:
+          buildCommand: ./build_on_apple_m1.sh
+    local:
+      concurrency: 0
+- name: arm
+  build:
+    artifacts:
+      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+        context: .
+        custom:
+          buildCommand: ./build_with_arm.sh
+- name: gcloud-build
+  build:
+    googleCloudBuild:
         projectId: genuine-flight-317411
-  - name: release
-    build:
-      artifacts:
-        - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
-          context: .
-          custom:
-            buildCommand: ./build_release.sh
+    artifacts:
+      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+        context: .
+        docker:
+          dockerfile: Dockerfile
+- name: release
+  build:
+    artifacts:
+      - image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta-runner
+        context: .
+        custom:
+          buildCommand: ./build_release.sh

--- a/src/robusta/core/playbooks/playbook_utils.py
+++ b/src/robusta/core/playbooks/playbook_utils.py
@@ -29,6 +29,10 @@ def replace_env_vars_values(values: Dict) -> Dict:
             env_var_value = get_env_replacement(value.get_secret_value())
             if env_var_value:
                 values[key] = SecretStr(env_var_value)
+        elif isinstance(value, dict):
+            env_var_value = replace_env_vars_values(value)
+            if env_var_value:
+                values[key] = env_var_value
 
     return values
 

--- a/src/robusta/core/sinks/kafka/kafka_sink.py
+++ b/src/robusta/core/sinks/kafka/kafka_sink.py
@@ -18,7 +18,11 @@ from robusta.core.sinks.sink_base import SinkBase
 class KafkaSink(SinkBase):
     def __init__(self, sink_config: KafkaSinkConfigWrapper, registry):
         super().__init__(sink_config.kafka_sink, registry)
-        self.producer = KafkaProducer(bootstrap_servers=sink_config.kafka_sink.kafka_url)
+
+        self.producer = KafkaProducer(
+            bootstrap_servers=sink_config.kafka_sink.kafka_url,
+            **sink_config.kafka_sink.auth,
+        )
         self.topic = sink_config.kafka_sink.topic
 
     def write_finding(self, finding: Finding, platform_enabled: bool):

--- a/src/robusta/core/sinks/kafka/kafka_sink_params.py
+++ b/src/robusta/core/sinks/kafka/kafka_sink_params.py
@@ -5,6 +5,7 @@ from robusta.core.sinks.sink_config import SinkConfigBase
 class KafkaSinkParams(SinkBaseParams):
     kafka_url: str
     topic: str
+    auth: dict = {}
 
 
 class KafkaSinkConfigWrapper(SinkConfigBase):


### PR DESCRIPTION
Current kafka sink does not support authentication which makes it difficult to adopt or use in many situations. This PR allows the kafka sink to behave as it is but to have an auth block added to easily cater to most if not all the supported authentications schemas of the python kafka package.

Tested With
* Apache kafka
* AWS MSK

Not Tested
* Confluent kafka


```yaml
  sinksConfig:
  - kafka_sink:
      name: kafka_sink
      kafka_url: "localhost:9096"
      topic: "robusta-playbooks"
      auth:
          sasl_mechanism: SCRAM-SHA-512
          security_protocol: SASL_SSL
          sasl_plain_username: robusta
          sasl_plain_password: password
```

additionally updated skaffold configs to the latest version, i can easily roll this back if its not wanted or needed.