### PR TITLE
[helm] add extraVolumeMounts and extraVolumes on Forwarder

### DIFF
--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -48,6 +48,9 @@ spec:
         volumeMounts:
           - name: robusta-kubewatch-config
             mountPath: /config
+          {{- with .Values.kubewatch.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities: {}
@@ -65,6 +68,9 @@ spec:
         - name:  robusta-kubewatch-config
           configMap:
             name: {{ .Release.Name }}-kubewatch-config
+        {{- with .Values.kubewatch.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.kubewatch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.kubewatch.nodeSelector | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
When automountServiceAccountToken is set to false, It is not possible to mount manually the service account token for the forwarder (It is possible with the runner).
I would like to add the possibility to mount the token volume.
```
    kubewatch:
      extraVolumes:
        - name: sa-token
          projected:
            sources:
              - serviceAccountToken:
                  path: token
                  expirationSeconds: 3607
              - configMap:
                  items:
                    - key: ca.crt
                      path: ca.crt
                  name: kube-root-ca.crt
              - downwardAPI:
                  items:
                    - fieldRef:
                        apiVersion: v1
                        fieldPath: metadata.namespace
                      path: namespace
      extraVolumeMounts:
        - name: sa-token
          mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
          readOnly: true
```
