### PR TITLE
[helm] fix about volume auth-config-secret definition if .rsa is nil

### DIFF
--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -145,7 +145,8 @@ spec:
             optional: true
         - name: auth-config-secret
           secret:
-            secretName: {{ default "robusta-auth-config-secret" .Values.rsa.existingSecret }}
+            {{- $subBloc := .Values.rsa | default dict }}
+            secretName: {{ default "robusta-auth-config-secret" $subBloc.existingSecret }}
             optional: true
         {{- if .Values.playbooksPersistentVolume }}
         - name: persistent-playbooks-storage


### PR DESCRIPTION
commit https://github.com/robusta-dev/robusta/commit/6ee8d1fdcaae5ef6b6c632cda2a76327e9a2f819 introduced .Values.rsa.existingSecret.  
It is not possible anymore to install the chart without defining rsa.

As .Values.rsa is nil by default,  and it is a parent of existingSecret, the following change (runner.yaml) fails.
```
secretName: {{ default "robusta-auth-config-secret" .Values.rsa.existingSecret }}
```