### PR TITLE
Pass along container status message

### DIFF
--- a/playbooks/robusta_playbooks/k8s_resource_enrichments.py
+++ b/playbooks/robusta_playbooks/k8s_resource_enrichments.py
@@ -48,7 +48,8 @@ class RelatedContainer(BaseModel):
     status: Optional[str] = None
     created: Optional[str] = None
     ports: List[Any] = []
-    statusDetails: Optional[str] = None
+    statusMessage: Optional[str] = None
+    statusReason: Optional[str] = None
 
 
 class RelatedPod(BaseModel):
@@ -149,7 +150,6 @@ def get_pod_containers(pod: Pod) -> List[RelatedContainer]:
                 if state is not None:
                     stateStr = s
                     break
-        status_details = getattr(state, "messsage", None) if state else None
 
         containers.append(
             RelatedContainer(
@@ -160,7 +160,8 @@ def get_pod_containers(pod: Pod) -> List[RelatedContainer]:
                 memoryRequest=requests.memory,
                 restarts=getattr(containerStatus, "restartCount", 0),
                 status=stateStr,
-                statusDetails=status_details,
+                statusMessage=getattr(state, "messsage", None) if state else None,
+                statusReason=getattr(state, "reason", None) if state else None,
                 created=getattr(state, "startedAt", None),
                 ports=[port.to_dict() for port in container.ports] if container.ports else [],
             )

--- a/playbooks/robusta_playbooks/k8s_resource_enrichments.py
+++ b/playbooks/robusta_playbooks/k8s_resource_enrichments.py
@@ -48,7 +48,7 @@ class RelatedContainer(BaseModel):
     status: Optional[str] = None
     created: Optional[str] = None
     ports: List[Any] = []
-    status_details: Optional[str] = None
+    statusDetails: Optional[str] = None
 
 
 class RelatedPod(BaseModel):
@@ -65,7 +65,7 @@ class RelatedPod(BaseModel):
     addresses: str
     containers: List[RelatedContainer]
     status: Optional[str] = None
-    status_reason: Optional[str] = None
+    statusReason: Optional[str] = None
 
 
 supported_resources = ["Deployment", "DaemonSet", "ReplicaSet", "Pod", "StatefulSet", "Job", "Node"]
@@ -130,7 +130,7 @@ def to_pod_obj(pod: Pod, cluster: str) -> RelatedPod:
         addresses=addresses,
         containers=get_pod_containers(pod),
         status=pod.status.phase,
-        status_reason=pod.status.reason,
+        statusReason=pod.status.reason,
     )
 
 
@@ -160,7 +160,7 @@ def get_pod_containers(pod: Pod) -> List[RelatedContainer]:
                 memoryRequest=requests.memory,
                 restarts=getattr(containerStatus, "restartCount", 0),
                 status=stateStr,
-                status_details=status_details,
+                statusDetails=status_details,
                 created=getattr(state, "startedAt", None),
                 ports=[port.to_dict() for port in container.ports] if container.ports else [],
             )


### PR DESCRIPTION
Adds the container status message to the data computed in `robusta.playbooks.robusta_playbooks.k8s_resource_enrichment.get_pod_containers`

Additionally collects the status `reason` for `Pod` objects.

Note it will require some work on the UI side in order to show this new data (Slack tabular data should work already though).