### PR TITLE
Display generic (reason+message) errors for image pull backoff errors

### DIFF
--- a/playbooks/robusta_playbooks/image_pull_backoff_enricher.py
+++ b/playbooks/robusta_playbooks/image_pull_backoff_enricher.py
@@ -67,5 +67,5 @@ def image_pull_backoff_reporter(event: PodEvent, action_params: RateLimitParams)
     finding.add_enrichment(blocks)
     message, reason = get_pod_issue_message_and_reason(pod)
     if reason:
-        finding.add_enrichment([MarkdownBlock(f"{message}: {reason}")])
+        finding.add_enrichment([MarkdownBlock(f"{reason}: {message}")])
     event.add_finding(finding)

--- a/playbooks/robusta_playbooks/image_pull_backoff_enricher.py
+++ b/playbooks/robusta_playbooks/image_pull_backoff_enricher.py
@@ -55,6 +55,8 @@ def image_pull_backoff_reporter(event: PodEvent, action_params: RateLimitParams)
     pod_name = pod.metadata.name
     namespace = pod.metadata.namespace
 
+    blocks: List[BaseBlock] = get_image_pull_backoff_blocks(pod)
+
     finding = Finding(
         title=f"Failed to pull at least one image in pod {pod_name} in namespace {namespace}",
         source=FindingSource.KUBERNETES_API_SERVER,
@@ -62,6 +64,7 @@ def image_pull_backoff_reporter(event: PodEvent, action_params: RateLimitParams)
         aggregation_key="image_pull_backoff_reporter",
         subject=PodFindingSubject(pod),
     )
+    finding.add_enrichment(blocks)
     message, reason = get_pod_issue_message_and_reason(pod)
     if reason:
         finding.add_enrichment([MarkdownBlock(f"{message}: {reason}")])

--- a/playbooks/robusta_playbooks/image_pull_backoff_enricher.py
+++ b/playbooks/robusta_playbooks/image_pull_backoff_enricher.py
@@ -15,7 +15,10 @@ from robusta.api import (
     action,
     get_image_pull_backoff_blocks,
 )
-from robusta.core.playbooks.pod_utils.imagepull_utils import get_image_pull_backoff_container_statuses
+from robusta.core.playbooks.pod_utils.imagepull_utils import (
+    get_image_pull_backoff_container_statuses,
+    get_pod_issue_message_and_reason,
+)
 from robusta.core.reporting import MarkdownBlock
 
 
@@ -52,22 +55,6 @@ def image_pull_backoff_reporter(event: PodEvent, action_params: RateLimitParams)
     pod_name = pod.metadata.name
     namespace = pod.metadata.namespace
 
-    blocks: List[BaseBlock] = get_image_pull_backoff_blocks(pod)
-
-    if not blocks:
-        # There have been no ImagePullBackoff statuses recorded. Display reason+message instead.
-        # Note the following call also pulls in containers with ErrImagePull statuses.
-        for container_status in get_image_pull_backoff_container_statuses(pod.status):
-            error_reason = container_status.state.waiting.reason
-            error_message = container_status.state.waiting.message
-            blocks.extend(
-                [
-                    MarkdownBlock(f"Error: {error_reason}"),
-                    MarkdownBlock(f"Error message: {error_message}"),
-                    MarkdownBlock(f"*Image:* {container_status.image}"),
-                ]
-            )
-
     finding = Finding(
         title=f"Failed to pull at least one image in pod {pod_name} in namespace {namespace}",
         source=FindingSource.KUBERNETES_API_SERVER,
@@ -75,5 +62,7 @@ def image_pull_backoff_reporter(event: PodEvent, action_params: RateLimitParams)
         aggregation_key="image_pull_backoff_reporter",
         subject=PodFindingSubject(pod),
     )
-    finding.add_enrichment(blocks)
+    message, reason = get_pod_issue_message_and_reason(pod)
+    if reason:
+        finding.add_enrichment([MarkdownBlock(f"{message}: {reason}")])
     event.add_finding(finding)

--- a/playbooks/robusta_playbooks/pod_investigator_enricher.py
+++ b/playbooks/robusta_playbooks/pod_investigator_enricher.py
@@ -18,6 +18,7 @@ from robusta.api import (
     get_pending_pod_blocks,
     parse_kubernetes_datetime_to_ms,
 )
+from robusta.core.playbooks.pod_utils.imagepull_utils import get_pod_issue_message_and_reason
 
 
 class PodIssue(str, Enum):
@@ -75,18 +76,6 @@ def detect_pod_issue(pod: Pod) -> PodIssue:
     elif is_pod_pending(pod):
         return PodIssue.Pending
     return PodIssue.NoneDetected
-
-
-def get_pod_issue_message_and_reason(pod: Pod) -> Tuple[Optional[str], Optional[str]]:
-    # Works/should work only or KubeContainerWaiting and KubePodNotReady
-    # Note: in line with the old code in pod_issue_investigator, we only get the message for
-    # the first of possibly many misbehaving containers.
-    if pod.status.containerStatuses:
-        if pod.status.containerStatuses[0].state.waiting:
-            return (
-                pod.status.containerStatuses[0].state.waiting.message,
-                pod.status.containerStatuses[0].state.waiting.reason,
-            )
 
 
 def is_pod_pending(pod: Pod) -> bool:
@@ -162,8 +151,6 @@ def report_pod_issue(
         event.add_enrichment(blocks)
 
     if reason:
-        if message is None:
-            message = "unknown"
         event.add_enrichment([MarkdownBlock(f"\n\n{reason}: {message}")])
 
 


### PR DESCRIPTION
Display generic (reason+message) texts if no ImagePullBackOff events are available

Includes a small `get_pod_issue_message_and_reason`-related refactoring