### PR TITLE
add support for setting pod / container security context

### DIFF
--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -28,10 +28,6 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.kubewatch.imagePullSecrets | nindent 6 }}
       {{- end }}
-      {{- if .Values.kubewatch.securityContext.pod }}
-      securityContext:
-      {{- toYaml .Values.kubewatch.securityContext.pod | nindent 6 }}
-      {{- end }}
       containers:
       - name: kubewatch
         # this is a custom version of kubewatch built from https://github.com/aantn/kubewatch
@@ -52,19 +48,9 @@ spec:
         volumeMounts:
           - name: robusta-kubewatch-config
             mountPath: /config
-          {{- with .Values.kubewatch.extraVolumeMounts }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- if .Values.kubewatch.securityContext.container }}
+        {{- if .Values.kubewatch.containerSecurityContext }}
         securityContext:
-        {{- toYaml .Values.kubewatch.securityContext.container | nindent 10 }}
-        {{ else }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities: {}
-          privileged: false
-          readOnlyRootFilesystem: false
-          runAsUser: 1000
+          {{- toYaml .Values.kubewatch.containerSecurityContext | nindent 10 }}
         {{- end }}
         resources:
           requests:
@@ -77,9 +63,6 @@ spec:
         - name:  robusta-kubewatch-config
           configMap:
             name: {{ .Release.Name }}-kubewatch-config
-        {{- with .Values.kubewatch.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
       {{- if .Values.kubewatch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.kubewatch.nodeSelector | nindent 8 }}
       {{- end }}
@@ -88,4 +71,8 @@ spec:
       {{- end }}
       {{- if .Values.kubewatch.tolerations }}
       tolerations:  {{ toYaml .Values.kubewatch.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubewatch.securityContext }}
+      securityContext:
+        {{- toYaml .Values.kubewatch.securityContext | nindent 8 }}
       {{- end }}

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -32,10 +32,6 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.runner.imagePullSecrets | nindent 6 }}
       {{- end }}
-      {{- if .Values.runner.securityContext.pod }}
-      securityContext:
-      {{- toYaml .Values.runner.securityContext.pod | nindent 6 }}
-      {{- end }}
       containers:
       - name: runner
         {{- if .Values.runner.image }}
@@ -44,15 +40,9 @@ spec:
         image: {{ .Values.image.registry }}/{{ .Values.runner.imageName }}
         {{- end }}
         imagePullPolicy: {{ .Values.runner.imagePullPolicy }}
-        {{- if .Values.runner.securityContext.container }}
+        {{- if .Values.runner.containerSecurityContext }}
         securityContext:
-        {{- toYaml .Values.runner.securityContext.container | nindent 10 }}
-        {{ else }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities: {}
-          privileged: false
-          readOnlyRootFilesystem: false
+          {{- toYaml .Values.runner.containerSecurityContext | nindent 10 }}
         {{- end }}
         env:
           - name: PLAYBOOKS_CONFIG_FILE_PATH
@@ -133,8 +123,10 @@ spec:
         image: {{ .Values.image.registry }}/{{ .Values.grafanaRenderer.imageName }}
         {{- end }}
         imagePullPolicy: {{ .Values.grafanaRenderer.imagePullPolicy }}
+        {{- if .Values.grafanaRenderer.containerSecurityContext }}
         securityContext:
-          privileged: false
+          {{- toYaml .Values.grafanaRenderer.containerSecurityContext | nindent 10 }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:
@@ -173,6 +165,10 @@ spec:
       {{- end }}
       {{- if .Values.runner.tolerations }}
       tolerations:  {{ toYaml .Values.runner.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.runner.securityContext }}
+      securityContext:
+        {{- toYaml .Values.runner.securityContext | nindent 8 }}
       {{- end }}
 {{- if .Values.playbooksPersistentVolume }}
 ---

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -479,9 +479,13 @@ kubewatch:
       event: true  # updated on kubewatch 2.5
       coreevent: false # added on kubewatch 2.5
       ingress: true # full support on kubewatch 2.4 (earlier versions have ingress bugs)
-  securityContext:
-    pod: ~
-    container: ~
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities: {}
+    privileged: false
+    readOnlyRootFilesystem: false
+    runAsUser: 1000
+  securityContext: {}
 
 # parameters for the renderer service used in robusta runner to render grafana graphs
 grafanaRenderer:
@@ -495,6 +499,8 @@ grafanaRenderer:
       memory: 512Mi
     limits:
       cpu: ~
+  containerSecurityContext:
+    privileged: false
 
 # parameters for the robusta runner service account
 runnerServiceAccount:
@@ -525,11 +531,14 @@ runner:
   imagePullSecrets: []
   extraVolumes: []
   extraVolumeMounts: []
-  securityContext:
-    pod: ~
-    container: ~
   serviceMonitor:
     path: /metrics
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities: {}
+    privileged: false
+    readOnlyRootFilesystem: false
+  securityContext: {}
 
 kube-prometheus-stack:
   alertmanager:


### PR DESCRIPTION
add support for setting pod / container security context

We use opa gatekeeper to enforce pod / container security policies in our clusters.  
To make the robusta deployments compliant we need to be able to set the pod / container security context.

https://open-policy-agent.github.io/gatekeeper/website/