### PR TITLE
add support for setting pod / container security context

### DIFF
--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -28,9 +28,9 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.kubewatch.imagePullSecrets | nindent 6 }}
       {{- end }}
-      {{- if .Values.kubewatch.securityContext.pod }}
+      {{- with .Values.kubewatch.securityContext.pod }}
       securityContext:
-      {{- toYaml .Values.kubewatch.securityContext.pod | nindent 6 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: kubewatch
@@ -55,16 +55,9 @@ spec:
           {{- with .Values.kubewatch.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-        {{- if .Values.kubewatch.securityContext.container }}
+        {{- with .Values.kubewatch.securityContext.container }}
         securityContext:
-        {{- toYaml .Values.kubewatch.securityContext.container | nindent 10 }}
-        {{ else }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities: {}
-          privileged: false
-          readOnlyRootFilesystem: false
-          runAsUser: 1000
+        {{- toYaml . | nindent 12 }}
         {{- end }}
         resources:
           requests:

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -32,9 +32,9 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.runner.imagePullSecrets | nindent 6 }}
       {{- end }}
-      {{- if .Values.runner.securityContext.pod }}
+      {{- with .Values.runner.securityContext.pod }}
       securityContext:
-      {{- toYaml .Values.runner.securityContext.pod | nindent 6 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: runner
@@ -44,15 +44,9 @@ spec:
         image: {{ .Values.image.registry }}/{{ .Values.runner.imageName }}
         {{- end }}
         imagePullPolicy: {{ .Values.runner.imagePullPolicy }}
-        {{- if .Values.runner.securityContext.container }}
+        {{- with .Values.runner.securityContext.container }}
         securityContext:
-        {{- toYaml .Values.runner.securityContext.container | nindent 10 }}
-        {{ else }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities: {}
-          privileged: false
-          readOnlyRootFilesystem: false
+        {{- toYaml . | nindent 12 }}
         {{- end }}
         env:
           - name: PLAYBOOKS_CONFIG_FILE_PATH
@@ -133,8 +127,10 @@ spec:
         image: {{ .Values.image.registry }}/{{ .Values.grafanaRenderer.imageName }}
         {{- end }}
         imagePullPolicy: {{ .Values.grafanaRenderer.imagePullPolicy }}
+        {{- with .Values.grafanaRenderer.securityContext.container }}
         securityContext:
-          privileged: false
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -480,8 +480,13 @@ kubewatch:
       coreevent: false # added on kubewatch 2.5
       ingress: true # full support on kubewatch 2.4 (earlier versions have ingress bugs)
   securityContext:
-    pod: ~
-    container: ~
+    container:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+      privileged: false
+      readOnlyRootFilesystem: false
+      runAsUser: 1000
+    pod: {}
 
 # parameters for the renderer service used in robusta runner to render grafana graphs
 grafanaRenderer:
@@ -495,6 +500,9 @@ grafanaRenderer:
       memory: 512Mi
     limits:
       cpu: ~
+  securityContext:
+    container:
+      privileged: false
 
 # parameters for the robusta runner service account
 runnerServiceAccount:
@@ -525,11 +533,15 @@ runner:
   imagePullSecrets: []
   extraVolumes: []
   extraVolumeMounts: []
-  securityContext:
-    pod: ~
-    container: ~
   serviceMonitor:
     path: /metrics
+  securityContext:
+    container:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+      privileged: false
+      readOnlyRootFilesystem: false
+    pod: {}
 
 kube-prometheus-stack:
   alertmanager:


### PR DESCRIPTION
add support for setting pod / container security context

We use opa gatekeeper to enforce pod / container security policies in our clusters.
To make the robusta deployments compliant we need to be able to set the pod / container security context.

https://open-policy-agent.github.io/gatekeeper/website/