### PR TITLE
feat(json-webhook): Add json option to webhook sink

### DIFF
--- a/src/robusta/core/sinks/webhook/webhook_sink_params.py
+++ b/src/robusta/core/sinks/webhook/webhook_sink_params.py
@@ -8,6 +8,7 @@ class WebhookSinkParams(SinkBaseParams):
     url: str
     size_limit: int = 4096
     authorization: SecretStr = None
+    format: str = "text"
 
 
 class WebhookSinkConfigWrapper(SinkConfigBase):


### PR DESCRIPTION
Option to send webhooks in JSON format for use it programatically.

In reference to: 
https://github.com/robusta-dev/robusta/issues/1116

