### PR TITLE
Sink stop feature

### DIFF
--- a/docs/configuration/configuring-sinks.rst
+++ b/docs/configuration/configuring-sinks.rst
@@ -17,6 +17,7 @@ Sinks are defined in Robusta's Helm chart, using the ``sinksConfig`` value:
     - ms_teams_sink:                  # sink type
         name: my_teams_sink           # arbitrary name
         webhook_url: <placeholder>    # a sink-specific parameter
+        stop: false                   # optional (see `Routing Alerts to only one Sink`)
         match: {}                     # optional routing rules (see below)
         default: true                 # optional (see below)
 
@@ -25,6 +26,28 @@ To add a sink, update ``sinksConfig`` according to the instructions in :ref:`Sin
 Configure as many sinks as you like.
 
 .. _sink-matchers:
+
+
+Routing Alerts to only one Sink
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, alerts are sent to all sinks that matches the alerts.
+
+To prevent sending alerts to more sinks after the current one, you can specify ``stop: true``
+
+The sinks evaluation order, is the order defined in ``generated_values.yaml``.
+
+.. code-block:: yaml
+
+    sinksConfig:
+    - slack_sink:
+        name: production_sink
+        slack_channel: production-notifications
+        api_key: secret-key
+        match:
+          namespace: production
+        stop: true
+
 
 Routing Alerts to Specific Sinks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -156,15 +179,6 @@ To prevent a sink from receiving most notifications, you can set ``default: fals
 routed to the sink only from :ref:`customPlaybooks that explicitly name this sink <Alternative Routing Methods>`.
 
 Here too, matchers apply as usual and perform further filtering.
-
-Execution order & stopping it
-*********************************
-
-Findings are sent to sinks that accept them synchronously (ie one is sent only after
-sending the previous is finished). The order in which they are sent is determined by
-the order of sinks being defined in your `generated_values.yaml` file. For each sink
-definition, you can add a `stop: true` field in this yaml file, which will cause the
-sending process to stop as soon as this sink is matched and findings are sent to it.
 
 Examples
 ^^^^^^^^^^^

--- a/docs/configuration/configuring-sinks.rst
+++ b/docs/configuration/configuring-sinks.rst
@@ -157,6 +157,15 @@ routed to the sink only from :ref:`customPlaybooks that explicitly name this sin
 
 Here too, matchers apply as usual and perform further filtering.
 
+Execution order & stopping it
+*********************************
+
+Findings are sent to sinks that accept them synchronously (ie one is sent only after
+sending the previous is finished). The order in which they are sent is determined by
+the order of sinks being defined in your `generated_values.yaml` file. For each sink
+definition, you can add a `stop: true` field in this yaml file, which will cause the
+sending process to stop as soon as this sink is matched and findings are sent to it.
+
 Examples
 ^^^^^^^^^^^
 

--- a/src/robusta/cli/main.py
+++ b/src/robusta/cli/main.py
@@ -217,9 +217,10 @@ def gen_config(
         token = json.loads(base64.b64decode(robusta_api_key))
         account_id = token.get("account_id", account_id)
 
-        sinks_config.append(
+        # Make sure the UI sink (if enabled) is the first one. See MAIN-1088.
+        sinks_config = [
             RobustaSinkConfigWrapper(robusta_sink=RobustaSinkParams(name="robusta_ui_sink", token=robusta_api_key))
-        )
+        ] + sinks_config
         enable_platform_playbooks = True
         disable_cloud_routing = False
 

--- a/src/robusta/core/playbooks/playbooks_event_handler_impl.py
+++ b/src/robusta/core/playbooks/playbooks_event_handler_impl.py
@@ -307,10 +307,8 @@ class PlaybooksEventHandlerImpl(PlaybooksEventHandler):
                         # Each sink has a different findings, but enrichments are shared
                         finding_copy = copy.deepcopy(finding)
                         sink.write_finding(finding_copy, self.registry.get_sinks().platform_enabled)
-
-                        sink_info = sinks_info[sink_name]
-                        sink_info.type = sink.__class__.__name__
-                        sink_info.findings_count += 1
+                        if sink.params.stop:
+                            return
 
                 except Exception:  # Failure to send to one sink shouldn't fail all
                     logging.error(f"Failed to publish finding to sink {sink_name}", exc_info=True)

--- a/src/robusta/core/sinks/sink_base_params.py
+++ b/src/robusta/core/sinks/sink_base_params.py
@@ -11,6 +11,7 @@ class SinkBaseParams(BaseModel):
     send_svg: bool = False
     default: bool = True
     match: dict = {}
+    stop: bool = False  # Stop processing if this sink has been matched
 
     @root_validator
     def env_values_validation(cls, values: Dict):


### PR DESCRIPTION
A feature that allows the sink to be configured as stopping the further dissemination of findings, if a finding is able to be delivered via that sink.