### PR TITLE
Allow overriding INITIAL_SCHEDULE_DELAY_SEC via environemt variable

### DIFF
--- a/src/robusta/core/schedule/scheduler.py
+++ b/src/robusta/core/schedule/scheduler.py
@@ -14,7 +14,7 @@ from robusta.core.schedule.model import DynamicDelayRepeat, JobStatus, Scheduled
 # for a short time there are two runners running (old+new version) and they both
 # see the new scheduled playbook. we add a delay so that only the new runner ends up
 # running the scheduled playbook
-INITIAL_SCHEDULE_DELAY_SEC = os.environ.get("INITIAL_SCHEDULE_DELAY_SEC", 120)
+INITIAL_SCHEDULE_DELAY_SEC = int(os.environ.get("INITIAL_SCHEDULE_DELAY_SEC", 120))
 
 
 class Scheduler:


### PR DESCRIPTION
environment variables are always string, we need to parse/cast it to int before using it