### PR TITLE
Fix Jira transition identification

### DIFF
--- a/src/robusta/integrations/jira/client.py
+++ b/src/robusta/integrations/jira/client.py
@@ -84,7 +84,7 @@ class JiraClient:
     def _get_transition_id(self, issue_id, status_name):
         transitions = self._get_transitions_for_issue(issue_id)
         for t in transitions:
-            if t.get("name", "").lower() == status_name.lower():
+            if self._get_nested_property(t, "to.name", "").lower() == status_name.lower():
                 return t.get("id", None)
         return None
 


### PR DESCRIPTION
There is no opened issue, I've directly opened this PR. I can create an issue if required :)

The [Jira sink documentation](https://docs.robusta.dev/master/configuration/sinks/jira.html) says that one is allowed to pass following params

> * doneStatusName : [Optional - default: 'Done'] The name of the "Done" status in Jira. Will be used to identify "Done" tasks in Jira.
>  * reopenStatusName : [Optional - default: 'To Do'] The name of the "To Do" status in Jira. Will be used to identify "To Do" tasks in Jira.
> 

So the user expects for Robusta to compare provided params (if any) with Jira **status** name, while the code instead compares that params with a **transition** name, and _it's wrong._

So the PR fixes that, it makes Robusta compare a transition "TO" status' name with a target status name, which is provided by the user