### PR TITLE
Username & subteam name representation changes to make them compatible with k8s labels

### DIFF
--- a/docs/configuration/defining-playbooks/creating-notifications.rst
+++ b/docs/configuration/defining-playbooks/creating-notifications.rst
@@ -64,6 +64,7 @@ We can automate this with Robusta:
     1. See :ref:`on_pod_oom_killed<on_pod_oom_killed>`
     2. See :ref:`pod_graph_enricher<pod_graph_enricher>`
     3. See :ref:`pod_oom_killer_enricher<pod_oom_killer_enricher>`
+    4. See :ref:`mention_enricher<mention_enricher>`
 
 Here is the result in Slack:
 

--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -445,11 +445,11 @@ logs_enricher = action(logs_enricher)
 
 class MentionParams(ActionParams):
     """
-    :var static_mentions: List of Slack user ids/groups ids to be mentioned
-    :var mentions_label: A alert label, or Kubernetes resource label, in which the value contains a comma separated ids to mention
+    :var static_mentions: List of Slack user ids/subteam ids to be mentioned
+    :var mentions_label: An alert label, or Kubernetes resource label, in which the value contains a dot separated ids to mention
     :var message_template: Optional. Custom mention message. Default: `"Hey: $mentions"`
 
-    :example static_mentions: ["<@U44V9P1JJ1Z>", "<!subteam^S22H3Q3Q111>"]
+    :example static_mentions: ["U44V9P1JJ1Z", "S22H3Q3Q111"]
     """
 
     static_mentions: Optional[List[str]]


### PR DESCRIPTION
The new format for representing users is Uxxxxx; subteams Txxxxxx; users+subteams via mention labels: Uaaa.Sbbb.Uccc.Sddd.