### PR TITLE
Fix invalid adaptive card body for Webex sink

### DIFF
--- a/src/robusta/integrations/webex/sender.py
+++ b/src/robusta/integrations/webex/sender.py
@@ -75,7 +75,7 @@ class WebexSender:
                     {
                         "type": "Column",
                         "width": "stretch",
-                        "items": [{"type": "TextBlock", "text": header, "wrap": "true"}],
+                        "items": [{"type": "TextBlock", "text": header, "wrap": True}],
                     }
                 )
             # seperating each row to add below headers of column
@@ -87,7 +87,7 @@ class WebexSender:
                         {
                             "type": "Column",
                             "width": "stretch",
-                            "items": [{"type": "TextBlock", "text": text, "wrap": "true"}],
+                            "items": [{"type": "TextBlock", "text": text, "wrap": True}],
                         }
                     )
                 container["items"].append(row_json)
@@ -98,8 +98,8 @@ class WebexSender:
         message_content_container = {
             "type": "Container",
             "items": [
-                {"type": "TextBlock", "text": message_content, "wrap": "true"},
-                {"type": "TextBlock", "text": description, "wrap": "true"},
+                {"type": "TextBlock", "text": message_content, "wrap": True},
+                {"type": "TextBlock", "text": description, "wrap": True},
             ],
         }
         return message_content_container


### PR DESCRIPTION
This PR fixes an issue with the currently used adaptive card body for the Webex sink. I installed the latest Robusta version 0.10.30 in a test environment of mine and noticed an issue once I configured a Webex sink, specifically that the notification messages only show up properly in the web client for Cisco Webex. When attempting to view the messages in the desktop clients (Windows / macOS), the app only showed the placeholder text message (`.`) without any other data.

**Screenshot from Webex Web:**
<img width="513" alt="image" src="https://github.com/robusta-dev/robusta/assets/1204969/453d891d-0806-4fca-9e47-013e10089a5e">

**Screenshot from Webex Desktop (macOS):**
<img width="284" alt="image" src="https://github.com/robusta-dev/robusta/assets/1204969/49a1b6fc-b7ce-47c8-bcec-f598e758e358">

So I started analysing this issue by dumping the adaptive card data into a file and messing around with it, until I discovered that the sent payload is violating the official Adaptive Cards v1.2 spec as the property `wrap` is set as a string with a boolean inside, instead of an actual boolean. So the JSON body should contain `"wrap": true`, not `"wrap": "true"` like it does today.

While the Webex web client still properly displays such semi-broken cards, the desktop client straight up refuses without any useful information. Simply switching out the couple lines of code to pass `True` instead of `"true"` fully fixes the issue on both platforms.