### PR TITLE
Python debugging tools update and deprecation

### DIFF
--- a/playbooks/robusta_playbooks/pod_troubleshooting.py
+++ b/playbooks/robusta_playbooks/pod_troubleshooting.py
@@ -68,7 +68,7 @@ def python_profiler(event: PodEvent, action_params: StartProfilingParams):
     # This should use ephemeral containers, but they aren't in GA yet. To enable them on GCP for example,
     # you need to create a brand new cluster. Therefore we're sticking with regular containers for now
     pod = event.get_pod()
-    logging.warning(f"The python_profiler playbook is deprecated and will be removed in future versions.")
+    logging.warning(f"The python_profiler action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"python_profiler - pod not found for event: {event}")
         return
@@ -180,7 +180,7 @@ def python_memory(event: PodEvent, params: MemoryTraceParams):
     Use this to track memory leaks in your Python application on Kubernetes.
     """
     pod = event.get_pod()
-    logging.warning(f"The python_memory playbook is deprecated and will be removed in future versions.")
+    logging.warning(f"The python_memory action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"python_memory - pod not found for event: {event}")
         return
@@ -296,7 +296,7 @@ def debugger_stack_trace(event: PodEvent, params: StackTraceParams):
     Create a finding with the stack trace results.
     """
     pod = event.get_pod()
-    logging.warning(f"The debugger_stack_trace playbook is deprecated and will be removed in future versions.")
+    logging.warning(f"The debugger_stack_trace action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"debugger_stack_trace - pod not found for event: {event}")
         return
@@ -382,7 +382,7 @@ def python_process_inspector(event: PodEvent, params: DebuggerParams):
 
     """
     pod = event.get_pod()
-    logging.warning(f"The python_process_inspector playbook is deprecated and will be removed in future versions.")
+    logging.warning(f"The python_process_inspector action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"advanced_debugging_options - pod not found for event: {event}")
         return
@@ -441,7 +441,7 @@ def python_debugger(event: PodEvent, params: DebuggerParams):
     Now you can use break points and log points in VSCode.
     """
     pod = event.get_pod()
-    logging.warning(f"The python_debugger playbook is deprecated and will be removed in future versions.")
+    logging.warning(f"The python_debugger action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"python_debugger - pod not found for event: {event}")
         return

--- a/playbooks/robusta_playbooks/pod_troubleshooting.py
+++ b/playbooks/robusta_playbooks/pod_troubleshooting.py
@@ -68,6 +68,7 @@ def python_profiler(event: PodEvent, action_params: StartProfilingParams):
     # This should use ephemeral containers, but they aren't in GA yet. To enable them on GCP for example,
     # you need to create a brand new cluster. Therefore we're sticking with regular containers for now
     pod = event.get_pod()
+    logging.warning(f"The python_profiler playbook is deprecated and will be removed in future versions.")
     if not pod:
         logging.info(f"python_profiler - pod not found for event: {event}")
         return
@@ -179,6 +180,7 @@ def python_memory(event: PodEvent, params: MemoryTraceParams):
     Use this to track memory leaks in your Python application on Kubernetes.
     """
     pod = event.get_pod()
+    logging.warning(f"The python_memory playbook is deprecated and will be removed in future versions.")
     if not pod:
         logging.info(f"python_memory - pod not found for event: {event}")
         return
@@ -294,6 +296,7 @@ def debugger_stack_trace(event: PodEvent, params: StackTraceParams):
     Create a finding with the stack trace results.
     """
     pod = event.get_pod()
+    logging.warning(f"The debugger_stack_trace playbook is deprecated and will be removed in future versions.")
     if not pod:
         logging.info(f"debugger_stack_trace - pod not found for event: {event}")
         return
@@ -379,6 +382,7 @@ def python_process_inspector(event: PodEvent, params: DebuggerParams):
 
     """
     pod = event.get_pod()
+    logging.warning(f"The python_process_inspector playbook is deprecated and will be removed in future versions.")
     if not pod:
         logging.info(f"advanced_debugging_options - pod not found for event: {event}")
         return
@@ -437,6 +441,7 @@ def python_debugger(event: PodEvent, params: DebuggerParams):
     Now you can use break points and log points in VSCode.
     """
     pod = event.get_pod()
+    logging.warning(f"The python_debugger playbook is deprecated and will be removed in future versions.")
     if not pod:
         logging.info(f"python_debugger - pod not found for event: {event}")
         return

--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 
 # TODO: import these from the python-tools project
-PYTHON_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/debug-toolkit:v5.0"
+PYTHON_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/debug-toolkit:v6.0"
 JAVA_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/java-toolkit-11:jattach"
 
 

--- a/src/robusta/integrations/kubernetes/process_utils.py
+++ b/src/robusta/integrations/kubernetes/process_utils.py
@@ -8,7 +8,7 @@ from robusta.integrations.kubernetes.custom_models import Process, RobustaPod
 
 
 class ProcessType(Enum):
-    PYTHON = "python"
+    PYTHON = "python3"
     JAVA = "java"
 
 


### PR DESCRIPTION
updating debugger tools image
only running on python3 processes since debugger tools does not seem to work on older python versions 
Additionally python debugging is now deprecated and will be removed in the future until the python debug-toolkit project is improved to return results more consistently.
https://github.com/robusta-dev/debug-toolkit/pull/5