### PR TITLE
Update prometheus docs

### DIFF
--- a/docs/configuration/alertmanager-integration/index.rst
+++ b/docs/configuration/alertmanager-integration/index.rst
@@ -20,9 +20,12 @@ Integrating with Prometheus
 
 
 
-Robusta can :ref:`enhance Prometheus alerts<Enhanced Prometheus Alerts>` with CPU/Memory graphs, Pod logs, Kubernetes events and more. To set this up, follow the guides below.
+Robusta works best when integrated with Prometheus and AlertManager. When properly setup, Robusta will:
 
-If you installed Robusta's :ref:`Embedded Prometheus Stack`, no setup necessary.
+1. Show your existing Prometheus alerts in Robusta, enriched with extra information
+2. Fetch relevant metrics from Prometheus and surface them in the context of related alerts
+
+If you installed Robusta's :ref:`Embedded Prometheus Stack`, then everything is pre-integrated and not setup is necessary. If not, you will need follow a guide below.
 
 
 Setup Instructions

--- a/docs/configuration/alertmanager-integration/index.rst
+++ b/docs/configuration/alertmanager-integration/index.rst
@@ -23,7 +23,8 @@ Integrating with Prometheus
 Robusta works best when integrated with Prometheus and AlertManager. When properly setup, Robusta will:
 
 1. Show your existing Prometheus alerts in Robusta, enriched with extra information
-2. Fetch relevant metrics from Prometheus and surface them in the context of related alerts
+2. Fetch relevant metrics from Prometheus and show them on related alerts
+3. Fetch metrics from Prometheus and show them in the Robusta UI (optional, only relevant for UI users)
 
 If you installed Robusta's :ref:`Embedded Prometheus Stack`, then everything is pre-integrated and not setup is necessary. If not, you will need follow a guide below.
 


### PR DESCRIPTION
@pavangudiwada can you please review?

@arikalon1 FYI.

Motivation for this change: we link to this page from the UI when Prometheus/AlertManager are not configured properly. The existing contents made a little less sense in that context. (Users who visit this page that way don't care about enriching alerts - they're trying to fix the error in the UI.) This change makes the page more understandable in that context, while still keeping it useful for users arriving directly from the docs.