### PR TITLE
Add `nameOverride` and `fullnameOverride` in helm chart

### DIFF
--- a/helm/robusta/templates/_helpers.tpl
+++ b/helm/robusta/templates/_helpers.tpl
@@ -14,12 +14,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm/robusta/templates/_helpers.tpl
+++ b/helm/robusta/templates/_helpers.tpl
@@ -7,7 +7,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 63 }}
 {{- end }}
 {{- end }}
 

--- a/helm/robusta/templates/_helpers.tpl
+++ b/helm/robusta/templates/_helpers.tpl
@@ -1,3 +1,28 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "robusta.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "robusta.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{ define "robusta.configfile" -}}
 playbook_repos:
 {{ toYaml .Values.playbookRepos | indent 2 }}

--- a/helm/robusta/templates/_helpers.tpl
+++ b/helm/robusta/templates/_helpers.tpl
@@ -1,11 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "robusta.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/helm/robusta/templates/forwarder-service-account.yaml
+++ b/helm/robusta/templates/forwarder-service-account.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-forwarder-cluster-role
+  name: {{ include "robusta.fullname" . }}-forwarder-cluster-role
   namespace : {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -108,13 +108,13 @@ rules:
     verbs:
     - use
     resourceNames:
-    - {{ if .Values.openshift.createScc }}"{{ .Release.Name }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
+    - {{ if .Values.openshift.createScc }}"{{ include "robusta.fullname" . }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
 {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-forwarder-service-account
+  name: {{ include "robusta.fullname" . }}-forwarder-service-account
   namespace: {{ .Release.Namespace }}
   {{- if .Values.kubewatch.serviceAccount.annotations }}
   annotations:
@@ -126,12 +126,12 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-forwarder-cluster-role-binding
+  name: {{ include "robusta.fullname" . }}-forwarder-cluster-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-forwarder-cluster-role
+  name: {{ include "robusta.fullname" . }}-forwarder-cluster-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-forwarder-service-account
+    name: {{ include "robusta.fullname" . }}-forwarder-service-account
     namespace: {{ .Release.Namespace }}

--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-forwarder
+  name: {{ include "robusta.fullname" . }}-forwarder
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-forwarder
+      app: {{ include "robusta.fullname" . }}-forwarder
   replicas: 1
   template:
     metadata:
@@ -17,12 +17,12 @@ spec:
         {{- if .Values.globalConfig.custom_annotations }} {{ toYaml .Values.globalConfig.custom_annotations | nindent 8 }}
         {{- end }}
       labels:
-        app: {{ .Release.Name }}-forwarder
+        app: {{ include "robusta.fullname" . }}-forwarder
         {{- with .Values.kubewatch.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ .Release.Name }}-forwarder-service-account
+      serviceAccountName: {{ include "robusta.fullname" . }}-forwarder-service-account
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.kubewatch.imagePullSecrets }}
       imagePullSecrets:
@@ -69,7 +69,7 @@ spec:
       volumes:
         - name:  robusta-kubewatch-config
           configMap:
-            name: {{ .Release.Name }}-kubewatch-config
+            name: {{ include "robusta.fullname" . }}-kubewatch-config
         {{- with .Values.kubewatch.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -50,7 +50,7 @@ spec:
           {{ toYaml .Values.kubewatch.additional_env_vars | nindent 10 }}
           {{- end }}
         volumeMounts:
-          - name: robusta-kubewatch-config
+          - name: {{ include "robusta.fullname" . }}-kubewatch-config
             mountPath: /config
           {{- with .Values.kubewatch.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
@@ -67,7 +67,7 @@ spec:
             memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else if .Values.kubewatch.resources.limits.memory }}{{ .Values.kubewatch.resources.limits.memory | quote }}{{ else }}{{ .Values.kubewatch.resources.requests.memory | quote }}{{ end }}
             {{ if .Values.kubewatch.resources.limits.cpu }}cpu: {{ .Values.kubewatch.resources.limits.cpu | quote }}{{ end }}
       volumes:
-        - name:  robusta-kubewatch-config
+        - name:  {{ include "robusta.fullname" . }}-kubewatch-config
           configMap:
             name: {{ include "robusta.fullname" . }}-kubewatch-config
         {{- with .Values.kubewatch.extraVolumes }}

--- a/helm/robusta/templates/kubewatch-configmap.yaml
+++ b/helm/robusta/templates/kubewatch-configmap.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-kubewatch-config
+  name: {{ include "robusta.fullname" . }}-kubewatch-config
   namespace: {{ .Release.Namespace }}
 data:
   .kubewatch.yaml: |-
     handler:
       cloudevent:
-        url: "http://{{ .Release.Name }}-runner:80/api/handle"
+        url: "http://{{ include "robusta.fullname" . }}-runner:80/api/handle"
 {{ toYaml .Values.kubewatch.config | indent 4 }}

--- a/helm/robusta/templates/openshift-scc-baseline.yaml
+++ b/helm/robusta/templates/openshift-scc-baseline.yaml
@@ -2,11 +2,11 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ .Release.Name }}-scc
+  name: {{ include "robusta.fullname" . }}-scc
   labels:
-    app: {{ .Release.Name }}
+    app: {{ include "robusta.fullname" . }}
   annotations:
-    kubernetes.io/description: {{ .Release.Name }}-scc provides the features required to run robusta
+    kubernetes.io/description: {{ include "robusta.fullname" . }}-scc provides the features required to run robusta
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false

--- a/helm/robusta/templates/openshift-scc-privileged.yaml
+++ b/helm/robusta/templates/openshift-scc-privileged.yaml
@@ -2,11 +2,11 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ .Release.Name }}-scc-privileged
+  name: {{ include "robusta.fullname" . }}-scc-privileged
   labels:
-    app: {{ .Release.Name }}
+    app: {{ include "robusta.fullname" . }}
   annotations:
-    kubernetes.io/description: {{ .Release.Name }}-scc provides the features required to run robusta enhanced debuggers for Java, Python, and node host capabilities
+    kubernetes.io/description: {{ include "robusta.fullname" . }}-scc provides the features required to run robusta enhanced debuggers for Java, Python, and node host capabilities
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false

--- a/helm/robusta/templates/runner-service-account.yaml
+++ b/helm/robusta/templates/runner-service-account.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-runner-cluster-role
+  name: {{ include "robusta.fullname" . }}-runner-cluster-role
   namespace : {{ .Release.Namespace }}
 rules:
   {{- if .Values.runner.customClusterRoleRules }}
@@ -242,7 +242,7 @@ rules:
     verbs:
     - use
     resourceNames:
-    - {{ if .Values.openshift.createScc }}"{{ .Release.Name }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
+    - {{ if .Values.openshift.createScc }}"{{ include "robusta.fullname" . }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
   - apiGroups:
     - monitoring.coreos.com
     resources:
@@ -261,7 +261,7 @@ rules:
     - delete
     - deletecollection
 {{- if .Values.openshift.createPrivilegedScc }}
-    - {{ .Release.Name }}-scc-privileged
+    - {{ include "robusta.fullname" . }}-scc-privileged
 {{- end }}
 {{- if .Values.openshift.privilegedSccName }}
     - {{ .Values.openshift.privilegedSccName }}
@@ -283,7 +283,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-runner-service-account
+  name: {{ include "robusta.fullname" . }}-runner-service-account
   namespace: {{ .Release.Namespace }}
   {{- if .Values.runnerServiceAccount.annotations }}
   annotations:
@@ -299,12 +299,12 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-runner-cluster-role-binding
+  name: {{ include "robusta.fullname" . }}-runner-cluster-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-runner-cluster-role
+  name: {{ include "robusta.fullname" . }}-runner-cluster-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-runner-service-account
+    name: {{ include "robusta.fullname" . }}-runner-service-account
     namespace: {{ .Release.Namespace }}

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -101,7 +101,7 @@ spec:
           {{- end }}
         envFrom:
         - secretRef:
-            name: robusta-runner-secret
+            name: {{ include "robusta.fullname" . }}-runner-secret
             optional: true
         {{- if .Values.runner.additional_env_froms }}
         {{ toYaml .Values.runner.additional_env_froms | nindent 8 }}
@@ -205,7 +205,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "robusta.fullname" . }}-runner
-    target: robusta-runner
+    target: {{ include "robusta.fullname" . }}-runner
 spec:
   selector:
     app: {{ include "robusta.fullname" . }}-runner
@@ -256,7 +256,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: robusta-runner-secret
+  name: {{ include "robusta.fullname" . }}-runner-secret
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-runner
+  name: {{ include "robusta.fullname" . }}-runner
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-runner
+    app: {{ include "robusta.fullname" . }}-runner
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-runner
+      app: {{ include "robusta.fullname" . }}-runner
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-runner
+        app: {{ include "robusta.fullname" . }}-runner
         robustaComponent: "runner"
         {{- with .Values.runner.labels }}
         {{- toYaml . | nindent 8 }}
@@ -26,7 +26,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Release.Name }}-runner-service-account
+      serviceAccountName: {{ include "robusta.fullname" . }}-runner-service-account
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.runner.imagePullSecrets }}
       imagePullSecrets:
@@ -52,7 +52,7 @@ spec:
           - name: PLAYBOOKS_CONFIG_FILE_PATH
             value: /etc/robusta/config/active_playbooks.yaml
           - name: RELEASE_NAME
-            value: {{ .Release.Name | quote }}
+            value: {{ include "robusta.fullname" .| quote }}
           - name: PROMETHEUS_ENABLED
             value: {{ .Values.enablePrometheusStack | quote}}
           - name: MANAGED_CONFIGURATION_ENABLED
@@ -201,14 +201,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-runner
+  name: {{ include "robusta.fullname" . }}-runner
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-runner
+    app: {{ include "robusta.fullname" . }}-runner
     target: robusta-runner
 spec:
   selector:
-    app: {{ .Release.Name }}-runner
+    app: {{ include "robusta.fullname" . }}-runner
   ports:
     - name: http
       protocol: TCP
@@ -222,7 +222,7 @@ metadata:
   name: robusta-runner-service-monitor
   labels:
     # this label is how the Prometheus installed with Robusta finds ServiceMonitors
-    release: {{ .Release.Name }}
+    release: {{ include "robusta.fullname" . }}
     {{- with .Values.runner.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -247,7 +247,7 @@ spec:
       {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-runner
+      app: {{ include "robusta.fullname" . }}-runner
   targetLabels:
     - target
 {{ end }}

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -3,6 +3,12 @@
 
 # NOTE: Do not use this file to install Robusta. It has missing values that need to be filled in. See the installation instructions instead https://docs.robusta.dev/master/installation.html
 
+# -- (string) Override the name of the chart.
+nameOverride: ""
+
+# -- (string) Override the full name of the chart.
+fullnameOverride: ""
+
 # playbook repositories
 playbookRepos: {}
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -3,9 +3,6 @@
 
 # NOTE: Do not use this file to install Robusta. It has missing values that need to be filled in. See the installation instructions instead https://docs.robusta.dev/master/installation.html
 
-# -- (string) Override the name of the chart.
-nameOverride: ""
-
 # -- (string) Override the full name of the chart.
 fullnameOverride: ""
 


### PR DESCRIPTION
Add possibility to overwrite naming in helm chart adding `nameOverride` and `fullnameOverride` helpers. 

These are commonly used helpers and helpful in scenarios where the robusta helm chart is used as a subchart. Without the opportunity to override the naming -> the robusta manifest will be enriched with the release name of the parent chart. 