### PR TITLE
Add docker bake config

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,9 @@
+variable "TAG" {
+  default = "$TAG"
+}
+
+target "default" {
+  dockerfile = "Dockerfile"
+  tags = ["us-central1-docker.pkg.dev/genuine-flight-317411/devel/${TAG}"]
+  context = "."
+}


### PR DESCRIPTION
Just a minor thing: `docker buildx` has a new feature called bake, where you can setup how to build and push an image

So, after adding this file it is possible to run this:

```
TAG=example-tag docker buildx bake --push
```

And it will build and push the image to the registry. (Also keep in mind, that regular `docker build` is now deprecated.

More info: https://docs.docker.com/build/bake/reference/