### PR TITLE
Fix secrets interpolation for KRR

### DIFF
--- a/playbooks/robusta_playbooks/krr.py
+++ b/playbooks/robusta_playbooks/krr.py
@@ -199,7 +199,7 @@ def _generate_krr_env_vars(
 def _generate_additional_env_args(krr_secrets: Optional[List[KRRSecret]]) -> str:
     if not krr_secrets:
         return ""
-    return " ".join(f"{secret.command_flag} '${secret.env_var_name}'" for secret in krr_secrets)
+    return " ".join(f"{secret.command_flag} '$({secret.env_var_name})'" for secret in krr_secrets)
 
 
 def _generate_cmd_line_args(prom_config: PrometheusConfig) -> str:


### PR DESCRIPTION
The syntax for kubernetes is `$(ENV_NAME)` and not `$ENV_NAME`