### PR TITLE
make template_enricher support prometheus alert annotations (#1422)

### DIFF
--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -331,6 +331,7 @@ def template_enricher(event: KubernetesResourceEvent, params: TemplateParams):
     labels: Dict[str, Any] = defaultdict(lambda: "<missing>")
     if isinstance(event, PrometheusKubernetesAlert):
         labels.update(event.alert.labels)
+        labels.update(event.alert.annotations)
         labels.update(vars(event.get_alert_subject()))
         labels["kind"] = labels["subject_type"].value
     elif isinstance(event, KubernetesResourceEvent):


### PR DESCRIPTION
Current template_enricher only support prometheus alert.labels, make it support alert.annotations.
The same feature already exists in mention_enricher