### PR TITLE
Usage of records definition instead of records itself

### DIFF
--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -483,7 +483,7 @@ def create_resource_enrichment(
             values_format=ChartValuesFormat.Bytes,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Node): ChartOptions(
-            query='instance:node_memory_utilisation:ratio{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} != 0',
+            query='1 - ((node_memory_MemAvailable_bytes{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} or (node_memory_Buffers_bytes{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} + node_memory_Cached_bytes{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} + node_memory_MemFree_bytes{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} + node_memory_Slab_bytes{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} ) ) / node_memory_MemTotal_bytes{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"}) != 0',
             values_format=ChartValuesFormat.Percentage,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Container): ChartOptions(

--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -471,7 +471,7 @@ def create_resource_enrichment(
             values_format=ChartValuesFormat.CPUUsage,
         ),
         (ResourceChartResourceType.CPU, ResourceChartItemType.Node): ChartOptions(
-            query='instance:node_cpu_utilisation:rate5m{job="node-exporter", instance=~"$node_internal_ip:[0-9]+"} != 0',
+            query='1 - avg without (cpu) ( sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", instance=~"$node_internal_ip:[0-9]+", mode=~"idle|iowait|steal"}[5m]))) != 0',
             values_format=ChartValuesFormat.Percentage,
         ),
         (ResourceChartResourceType.CPU, ResourceChartItemType.Container): ChartOptions(


### PR DESCRIPTION
Uses metrics definition instead of metrics record.

As was shown in #1168, those records could be absent on some Prometheus instances