### PR TITLE
fix(labels): drops image label in container_memory_working_set_bytes metric

### DIFF
--- a/src/robusta/core/playbooks/prometheus_enrichment_utils.py
+++ b/src/robusta/core/playbooks/prometheus_enrichment_utils.py
@@ -479,7 +479,7 @@ def create_resource_enrichment(
             values_format=ChartValuesFormat.CPUUsage,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Pod): ChartOptions(
-            query='sum(container_memory_working_set_bytes{namespace="$namespace", pod=~"$pod", container!="", image!=""}) by (pod, job)',
+            query='sum(container_memory_working_set_bytes{namespace="$namespace", pod=~"$pod", container!=""}) by (pod, job)',
             values_format=ChartValuesFormat.Bytes,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Node): ChartOptions(
@@ -487,7 +487,7 @@ def create_resource_enrichment(
             values_format=ChartValuesFormat.Percentage,
         ),
         (ResourceChartResourceType.Memory, ResourceChartItemType.Container): ChartOptions(
-            query='sum(container_memory_working_set_bytes{namespace="$namespace", pod=~"$pod", container=~"$container", image!=""}) by (container, pod, job)',
+            query='sum(container_memory_working_set_bytes{namespace="$namespace", pod=~"$pod", container=~"$container"}) by (container, pod, job)',
             values_format=ChartValuesFormat.Bytes,
         ),
         (ResourceChartResourceType.Disk, ResourceChartItemType.Pod): None,


### PR DESCRIPTION
In according to [documentation](https://kubernetes.io/docs/reference/instrumentation/metrics/), `container_memory_working_set_bytes` has only three labels (by default): 
- container
- pod
- namespace

Thus, `image` label was deleted from query due to its possible absence