### PR TITLE
MAIN-1737 Warning events improved

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -432,7 +432,7 @@ platformPlaybooks:
   actions:
   - warning_events_report:
       warning_event_groups:
-        - aggregation_key: PodLifecycleWarnings
+        - aggregation_key: PodLifecycleWarning
           matchers:
             - FailedCreatePodSandBox
             - FailedToRetrieveImagePullSecret
@@ -443,7 +443,7 @@ platformPlaybooks:
             - ExceededGracePeriod
             - Evicted
           description: "A PodLifecycle related WarningEvent was fired for $kind $name in namespace $namespace"
-        - aggregation_key: NodeHealthWarnings
+        - aggregation_key: NodeHealthWarning
           matchers:
             - InvalidDiskCapacity
             - NodeNotReady
@@ -463,17 +463,17 @@ platformPlaybooks:
             - ScaleUpFailed
             - ScaleDownFailed
           description: "A NodeHealth related WarningEvent was fired for Node $node"
-        - aggregation_key: ProbeFailures
+        - aggregation_key: ProbeFailure
           matchers:
             - Unhealthy
             - ProbeError
             - ProbeWarning
           description: "A Probe related WarningEvent was fired for $kind $name in namespace $namespace"
-        - aggregation_key: PolicyViolations
+        - aggregation_key: PolicyViolation
           matchers:
             - PolicyViolation
           description: "A PolicyViolation related WarningEvent was fired for $kind $name in namespace $namespace"
-        - aggregation_key: ScaleWarnings
+        - aggregation_key: ScaleWarning
           matchers:
             - FailedGetResourceMetric
             - FailedComputeMetricsReplicas
@@ -483,11 +483,11 @@ platformPlaybooks:
             - ScaledObjectCheckFailed
             - FailedGetObjectMetric
           description: "A Scaling related WarningEvent fired for $kind $name in namespace $namespace"
-        - aggregation_key: SchedulingWarnings
+        - aggregation_key: SchedulingWarning
           matchers:
             - FailedScheduling
           description: "Scheduling related WarningEvent fired for $kind $name in namespace $namespace"
-        - aggregation_key: VolumeWarnings
+        - aggregation_key: VolumeWarning
           matchers:
             - FailedMount
             - FailedAttachVolume

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -442,7 +442,6 @@ platformPlaybooks:
             - FailedPreStopHook
             - ExceededGracePeriod
             - Evicted
-          description: "A PodLifecycle related WarningEvent was fired for $kind $name in namespace $namespace"
         - aggregation_key: NodeHealthWarning
           matchers:
             - InvalidDiskCapacity
@@ -462,17 +461,14 @@ platformPlaybooks:
             - Drain
             - ScaleUpFailed
             - ScaleDownFailed
-          description: "A NodeHealth related WarningEvent was fired for Node $node"
         - aggregation_key: ProbeFailure
           matchers:
             - Unhealthy
             - ProbeError
             - ProbeWarning
-          description: "A Probe related WarningEvent was fired for $kind $name in namespace $namespace"
         - aggregation_key: PolicyViolation
           matchers:
             - PolicyViolation
-          description: "A PolicyViolation related WarningEvent was fired for $kind $name in namespace $namespace"
         - aggregation_key: ScaleWarning
           matchers:
             - FailedGetResourceMetric
@@ -482,17 +478,14 @@ platformPlaybooks:
             - FailedGetExternalMetric
             - ScaledObjectCheckFailed
             - FailedGetObjectMetric
-          description: "A Scaling related WarningEvent fired for $kind $name in namespace $namespace"
         - aggregation_key: SchedulingWarning
           matchers:
             - FailedScheduling
-          description: "Scheduling related WarningEvent fired for $kind $name in namespace $namespace"
         - aggregation_key: VolumeWarning
           matchers:
             - FailedMount
             - FailedAttachVolume
             - VolumeFailedDelete
-          description: "Volume related WarningEvent fired for $kind $name"
   - event_resource_events: {}
   sinks:
     - "robusta_ui_sink"

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -442,7 +442,7 @@ platformPlaybooks:
             - FailedPreStopHook
             - ExceededGracePeriod
             - Evicted
-          title: "A PodLifecycle related WarningEvent was fired for $kind $name in namespace $namespace"
+          description: "A PodLifecycle related WarningEvent was fired for $kind $name in namespace $namespace"
         - aggregation_key: NodeHealthWarnings
           matchers:
             - InvalidDiskCapacity
@@ -462,17 +462,17 @@ platformPlaybooks:
             - Drain
             - ScaleUpFailed
             - ScaleDownFailed
-          title: "A NodeHealth related WarningEvent was fired for Node $node"
+          description: "A NodeHealth related WarningEvent was fired for Node $node"
         - aggregation_key: ProbeFailures
           matchers:
             - Unhealthy
             - ProbeError
             - ProbeWarning
-          title: "A Probe related WarningEvent was fired for $kind $name in namespace $namespace"
+          description: "A Probe related WarningEvent was fired for $kind $name in namespace $namespace"
         - aggregation_key: PolicyViolations
           matchers:
             - PolicyViolation
-          title: "A PolicyViolation related WarningEvent was fired for $kind $name in namespace $namespace"
+          description: "A PolicyViolation related WarningEvent was fired for $kind $name in namespace $namespace"
         - aggregation_key: ScaleWarnings
           matchers:
             - FailedGetResourceMetric
@@ -482,17 +482,17 @@ platformPlaybooks:
             - FailedGetExternalMetric
             - ScaledObjectCheckFailed
             - FailedGetObjectMetric
-          title: "A Scaling related WarningEvent fired for $kind $name in namespace $namespace"
+          description: "A Scaling related WarningEvent fired for $kind $name in namespace $namespace"
         - aggregation_key: SchedulingWarnings
           matchers:
             - FailedScheduling
-          title: "Scheduling related WarningEvent fired for $kind $name in namespace $namespace"
+          description: "Scheduling related WarningEvent fired for $kind $name in namespace $namespace"
         - aggregation_key: VolumeWarnings
           matchers:
             - FailedMount
             - FailedAttachVolume
             - VolumeFailedDelete
-          title: "Volume related WarningEvent fired for $kind $name"
+          description: "Volume related WarningEvent fired for $kind $name"
   - event_resource_events: {}
   sinks:
     - "robusta_ui_sink"

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -430,7 +430,17 @@ platformPlaybooks:
   - on_kubernetes_warning_event_create:
       exclude: ["NodeSysctlChange"]
   actions:
-  - event_report: {}
+  - warning_events_report:
+      warning_event_groups:
+        - matchers: ["Failed", "BackOff", "FailedScheduling"]
+          aggregation_key: PodLifecycleWarnings
+          title: "Issue with pod"
+        - matchers: ["BackoffLimitExceeded"]
+          aggregation_key: JobLifecycleWarnings
+          title: "issue with job"
+        - matchers: ["Unhealthy"]
+          aggregation_key: ProbeFailures
+          title: "issue with probes"
   - event_resource_events: {}
   sinks:
     - "robusta_ui_sink"

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -432,15 +432,67 @@ platformPlaybooks:
   actions:
   - warning_events_report:
       warning_event_groups:
-        - matchers: ["Failed", "BackOff", "FailedScheduling"]
-          aggregation_key: PodLifecycleWarnings
-          title: "Issue with pod"
-        - matchers: ["BackoffLimitExceeded"]
-          aggregation_key: JobLifecycleWarnings
-          title: "issue with job"
-        - matchers: ["Unhealthy"]
-          aggregation_key: ProbeFailures
-          title: "issue with probes"
+        - aggregation_key: PodLifecycleWarnings
+          matchers:
+            - FailedCreatePodSandBox
+            - FailedToRetrieveImagePullSecret
+            - BackOff
+            - FailedDaemonPod
+            - FailedKillPod
+            - FailedPreStopHook
+            - ExceededGracePeriod
+            - Evicted
+          title: "A PodLifecycle related WarningEvent was fired for $kind $name in namespace $namespace"
+        - aggregation_key: NodeHealthWarnings
+          matchers:
+            - InvalidDiskCapacity
+            - NodeNotReady
+            - NodeRegistrationCheckerStart
+            - WorkflowNodeFailed
+            - OOMKilling
+            - FailedDraining
+            - PreemptScheduled
+            - NodeRegistrationCheckerDidNotRunChecks
+            - NodeShutdown
+            - TerminateScheduled
+            - FreeDiskSpaceFailed
+            - NodeSysctlChange
+            - SystemOOM
+            - NodeStartupFailed
+            - Drain
+            - ScaleUpFailed
+            - ScaleDownFailed
+          title: "A NodeHealth related WarningEvent was fired for Node $node"
+        - aggregation_key: ProbeFailures
+          matchers:
+            - Unhealthy
+            - ProbeError
+            - ProbeWarning
+          title: "A Probe related WarningEvent was fired for $kind $name in namespace $namespace"
+        - aggregation_key: PolicyViolations
+          matchers:
+            - PolicyViolation
+          title: "A PolicyViolation related WarningEvent was fired for $kind $name in namespace $namespace"
+        - aggregation_key: ScaleWarnings
+          matchers:
+            - FailedGetResourceMetric
+            - FailedComputeMetricsReplicas
+            - KEDAScalerFailed
+            - FailedGetContainerResourceMetric
+            - FailedGetExternalMetric
+            - ScaledObjectCheckFailed
+            - FailedGetObjectMetric
+          title: "A Scaling related WarningEvent fired for $kind $name in namespace $namespace"
+        - aggregation_key: SchedulingWarnings
+          matchers:
+            - FailedScheduling
+          title: "Scheduling related WarningEvent fired for $kind $name in namespace $namespace"
+        - aggregation_key: VolumeWarnings
+          matchers:
+            - FailedMount
+            - FailedAttachVolume
+            - VolumeFailedDelete
+          title: "Volume related WarningEvent fired for $kind $name"
   - event_resource_events: {}
   sinks:
     - "robusta_ui_sink"

--- a/playbooks/robusta_playbooks/common_actions.py
+++ b/playbooks/robusta_playbooks/common_actions.py
@@ -32,11 +32,11 @@ def customise_finding(event: ExecutionBaseEvent, params: FindingOverrides):
     actions
     """
     severity: Optional[FindingSeverity] = FindingSeverity[params.severity] if params.severity else None
+    subject = event.get_subject()
+    title = format_event_templated_string(subject, params.title) if params.title else None
+    description = format_event_templated_string(subject, params.description) if params.description else None
 
-    title = format_event_templated_string(event, params.title) if params.title else None
-    description = format_event_templated_string(event, params.description) if params.description else None
-
-    aggregation_key = format_event_templated_string(event, params.aggregation_key) if params.aggregation_key else None
+    aggregation_key = format_event_templated_string(subject, params.aggregation_key) if params.aggregation_key else None
 
     event.override_finding_attributes(title, description, severity, aggregation_key)
 
@@ -70,10 +70,11 @@ def create_finding(event: ExecutionBaseEvent, params: FindingFields):
     """
     Create a new notification message. This is the primary way that custom playbooks generate messages.
     """
+    subject = event.get_subject()
     event.add_finding(
         Finding(
-            title=format_event_templated_string(event, params.title),
-            description=format_event_templated_string(event, params.description) if params.description else None,
+            title=format_event_templated_string(subject, params.title),
+            description=format_event_templated_string(subject, params.description) if params.description else None,
             aggregation_key=params.aggregation_key,
             severity=FindingSeverity.from_severity(params.severity),
             subject=event.get_subject(),

--- a/playbooks/robusta_playbooks/common_actions.py
+++ b/playbooks/robusta_playbooks/common_actions.py
@@ -3,20 +3,7 @@ from string import Template
 from typing import Dict, Optional
 
 from robusta.api import ActionParams, ExecutionBaseEvent, Finding, FindingSeverity, action
-
-
-def _get_templating_labels(event: ExecutionBaseEvent) -> Dict:
-    subject = event.get_subject()
-    labels: Dict[str, str] = defaultdict(lambda: "<missing>")
-    labels.update(
-        {
-            "name": subject.name,
-            "kind": subject.subject_type.value,
-            "namespace": subject.namespace if subject.namespace else "<missing>",
-            "node": subject.node if subject.node else "<missing>",
-        }
-    )
-    return labels
+from robusta.utils.parsing import format_event_templated_string
 
 
 class FindingOverrides(ActionParams):
@@ -46,12 +33,10 @@ def customise_finding(event: ExecutionBaseEvent, params: FindingOverrides):
     """
     severity: Optional[FindingSeverity] = FindingSeverity[params.severity] if params.severity else None
 
-    labels = _get_templating_labels(event)
+    title = format_event_templated_string(event, params.title) if params.title else None
+    description = format_event_templated_string(event, params.description) if params.description else None
 
-    title = Template(params.title).safe_substitute(labels) if params.title else None
-    description = Template(params.description).safe_substitute(labels) if params.description else None
-
-    aggregation_key = Template(params.aggregation_key).safe_substitute(labels) if params.aggregation_key else None
+    aggregation_key = format_event_templated_string(event, params.aggregation_key) if params.aggregation_key else None
 
     event.override_finding_attributes(title, description, severity, aggregation_key)
 
@@ -85,12 +70,10 @@ def create_finding(event: ExecutionBaseEvent, params: FindingFields):
     """
     Create a new notification message. This is the primary way that custom playbooks generate messages.
     """
-    labels = _get_templating_labels(event)
-
     event.add_finding(
         Finding(
-            title=Template(params.title).safe_substitute(labels),
-            description=Template(params.description).safe_substitute(labels) if params.description else None,
+            title=format_event_templated_string(event, params.title),
+            description=format_event_templated_string(event, params.description) if params.description else None,
             aggregation_key=params.aggregation_key,
             severity=FindingSeverity.from_severity(params.severity),
             subject=event.get_subject(),

--- a/playbooks/robusta_playbooks/event_enrichments.py
+++ b/playbooks/robusta_playbooks/event_enrichments.py
@@ -93,7 +93,8 @@ def warning_events_report(event: EventChangeEvent, params: WarningEventReportPar
         if event.obj.reason not in event_group_param.matchers:
             continue
         aggregation_key = event_group_param.aggregation_key
-        description = format_event_templated_string(event, event_group_param.description)
+        subject = event.obj.regarding
+        description = format_event_templated_string(subject, event_group_param.description)
         break
     finding = create_event_finding(event=event, aggregation_key=aggregation_key, description=description)
     event.add_finding(finding)

--- a/playbooks/robusta_playbooks/event_enrichments.py
+++ b/playbooks/robusta_playbooks/event_enrichments.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from hikaru.model.rel_1_26 import Job, Node
 from pydantic import BaseModel
@@ -59,7 +59,7 @@ class ExtendedEventEnricherParams(EventEnricherParams):
 class WarningEventGroupParams(BaseModel):
     matchers: List[str]
     aggregation_key: str
-    description: str
+    description: Optional[str]
 
 
 class WarningEventReportParams(ActionParams):
@@ -94,7 +94,8 @@ def warning_events_report(event: EventChangeEvent, params: WarningEventReportPar
             continue
         aggregation_key = event_group_param.aggregation_key
         subject = event.obj.regarding
-        description = format_event_templated_string(subject, event_group_param.description)
+        if event_group_param.description:
+            description = format_event_templated_string(subject, event_group_param.description)
         break
     finding = create_event_finding(event=event, aggregation_key=aggregation_key, description=description)
     event.add_finding(finding)

--- a/playbooks/robusta_playbooks/event_enrichments.py
+++ b/playbooks/robusta_playbooks/event_enrichments.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from hikaru.model.rel_1_26 import Job, Node
 from pydantic import BaseModel
+
 from robusta.api import (
     ActionException,
     ActionParams,
@@ -29,7 +30,6 @@ from robusta.api import (
     ReplicaSet,
     SlackAnnotations,
     StatefulSet,
-    TableBlock,
     VideoEnricherParams,
     VideoLink,
     action,
@@ -87,7 +87,7 @@ def create_event_finding(event, aggregation_key, description):
 
 @action
 def warning_events_report(event: EventChangeEvent, params: WarningEventReportParams):
-    aggregation_key=f"Kubernetes{event.obj.type}Event"
+    aggregation_key = f"Kubernetes{event.obj.type}Event"
     description = event.obj.note
     for event_group_param in params.warning_event_groups:
         if event.obj.reason not in event_group_param.matchers:
@@ -106,8 +106,7 @@ def event_report(event: EventChangeEvent):
     """
     Create finding based on the kubernetes event
     """
-    k8s_obj = event.obj.regarding
-    aggregation_key=f"Kubernetes{event.obj.type}Event"
+    aggregation_key = f"Kubernetes{event.obj.type}Event"
     finding = create_event_finding(event=event, aggregation_key=aggregation_key, description=event.obj.note)
     event.add_finding(finding)
 
@@ -132,7 +131,7 @@ def event_resource_events(event: EventChangeEvent):
             [events_table],
             {SlackAnnotations.ATTACHMENT: True},
             enrichment_type=EnrichmentType.k8s_events,
-            title="Related Events"
+            title="Related Events",
         )
 
 
@@ -143,7 +142,17 @@ def resource_events_enricher(event: KubernetesResourceEvent, params: ExtendedEve
     """
 
     resource = event.get_resource()
-    if resource.kind not in ["Pod", "Deployment", "DaemonSet", "ReplicaSet", "StatefulSet", "Job", "Node", "DeploymentConfig", "Rollout"]:
+    if resource.kind not in [
+        "Pod",
+        "Deployment",
+        "DaemonSet",
+        "ReplicaSet",
+        "StatefulSet",
+        "Job",
+        "Node",
+        "DeploymentConfig",
+        "Rollout",
+    ]:
         raise ActionException(
             ErrorCodes.RESOURCE_NOT_SUPPORTED, f"Resource events enricher is not supported for resource {resource.kind}"
         )
@@ -158,7 +167,15 @@ def resource_events_enricher(event: KubernetesResourceEvent, params: ExtendedEve
     )
 
     # append related pod data as well
-    if params.dependent_pod_mode and kind in ["Deployment", "DaemonSet", "ReplicaSet", "StatefulSet", "Job", "DeploymentConfig", "Rollout"]:
+    if params.dependent_pod_mode and kind in [
+        "Deployment",
+        "DaemonSet",
+        "ReplicaSet",
+        "StatefulSet",
+        "Job",
+        "DeploymentConfig",
+        "Rollout",
+    ]:
         pods = []
         if kind == "Job":
             pods = get_job_all_pods(resource) or []
@@ -224,7 +241,7 @@ def resource_events_enricher(event: KubernetesResourceEvent, params: ExtendedEve
             ],
             {SlackAnnotations.ATTACHMENT: True},
             enrichment_type=EnrichmentType.k8s_events,
-            title="Resource Events"
+            title="Resource Events",
         )
 
 
@@ -247,8 +264,12 @@ def pod_events_enricher(event: PodEvent, params: EventEnricherParams):
         max_events=params.max_events,
     )
     if events_table_block:
-        event.add_enrichment([events_table_block], {SlackAnnotations.ATTACHMENT: True},
-                             enrichment_type=EnrichmentType.k8s_events, title="Pod Events")
+        event.add_enrichment(
+            [events_table_block],
+            {SlackAnnotations.ATTACHMENT: True},
+            enrichment_type=EnrichmentType.k8s_events,
+            title="Pod Events",
+        )
 
 
 @action
@@ -277,12 +298,17 @@ def deployment_events_enricher(event: DeploymentEvent, params: ExtendedEventEnri
                     max_events=params.max_events,
                 )
                 if events_table_block:
-                    event.add_enrichment([events_table_block], {SlackAnnotations.ATTACHMENT: True},
-                                         enrichment_type=EnrichmentType.k8s_events, title="Deployment Events")
+                    event.add_enrichment(
+                        [events_table_block],
+                        {SlackAnnotations.ATTACHMENT: True},
+                        enrichment_type=EnrichmentType.k8s_events,
+                        title="Deployment Events",
+                    )
     else:
         available_replicas = dep.status.availableReplicas if dep.status.availableReplicas else 0
         event.add_enrichment(
-            [MarkdownBlock(f"*Replicas: Desired ({dep.spec.replicas}) --> Running ({available_replicas})*")])
+            [MarkdownBlock(f"*Replicas: Desired ({dep.spec.replicas}) --> Running ({available_replicas})*")]
+        )
 
         events_table_block = get_resource_events_table(
             "*Deployment events:*",
@@ -293,8 +319,12 @@ def deployment_events_enricher(event: DeploymentEvent, params: ExtendedEventEnri
             max_events=params.max_events,
         )
         if events_table_block:
-            event.add_enrichment([events_table_block], {SlackAnnotations.ATTACHMENT: True},
-                                 enrichment_type=EnrichmentType.k8s_events, title="Deployment Events")
+            event.add_enrichment(
+                [events_table_block],
+                {SlackAnnotations.ATTACHMENT: True},
+                enrichment_type=EnrichmentType.k8s_events,
+                title="Deployment Events",
+            )
 
 
 @action

--- a/playbooks/robusta_playbooks/event_enrichments.py
+++ b/playbooks/robusta_playbooks/event_enrichments.py
@@ -44,6 +44,7 @@ from robusta.api import (
 from robusta.core.reporting import EventRow, EventsBlock
 from robusta.core.reporting.base import EnrichmentType
 from robusta.core.reporting.custom_rendering import render_value
+from robusta.utils.parsing import format_event_templated_string
 
 
 class ExtendedEventEnricherParams(EventEnricherParams):
@@ -88,11 +89,12 @@ def warning_events_report(event: EventChangeEvent, params: WarningEventReportPar
     k8s_obj = event.obj.regarding
     title = f"{event.obj.reason} {event.obj.type} for {k8s_obj.kind} {k8s_obj.namespace}/{k8s_obj.name}"
     aggregation_key=f"Kubernetes{event.obj.type}Event"
+
     for event_group_param in params.warning_event_groups:
         if event.obj.reason not in event_group_param.matchers:
             continue
-        aggregation_key=event_group_param.aggregation_key
-        title=event_group_param.title
+        aggregation_key = event_group_param.aggregation_key
+        title = format_event_templated_string(event, event_group_param.title)
         break
     finding = create_event_finding(event=event, aggregation_key=aggregation_key,title=title)
     event.add_finding(finding)

--- a/src/robusta/utils/parsing.py
+++ b/src/robusta/utils/parsing.py
@@ -21,7 +21,7 @@ def format_event_templated_string(subject: Union[FindingSubject, ObjectReference
             "name": subject.name,
             "kind": kind,
             "namespace": subject.namespace if subject.namespace else "<missing>",
-            "node": subject.node if subject.node else "<missing>",
+            "node": subject.node if isinstance(subject, FindingSubject) and subject.node else "<missing>",
         }
     )
     return Template(string_to_substitute).safe_substitute(labels)

--- a/src/robusta/utils/parsing.py
+++ b/src/robusta/utils/parsing.py
@@ -5,14 +5,15 @@ from collections import defaultdict
 from string import Template
 from typing import Any, Dict, Union
 
-from robusta.core.model.events import ExecutionBaseEvent
+from hikaru.model import ObjectReference
+
+from robusta.core.reporting import FindingSubject
 
 
-def format_event_templated_string(event: ExecutionBaseEvent, string_to_substitute) -> str:
+def format_event_templated_string(subject: Union[FindingSubject, ObjectReference], string_to_substitute) -> str:
     """
         For templating strings based on event subjects
     """
-    subject = event.get_subject()
     labels: Dict[str, str] = defaultdict(lambda: "<missing>")
     labels.update(
         {

--- a/src/robusta/utils/parsing.py
+++ b/src/robusta/utils/parsing.py
@@ -15,10 +15,11 @@ def format_event_templated_string(subject: Union[FindingSubject, ObjectReference
         For templating strings based on event subjects
     """
     labels: Dict[str, str] = defaultdict(lambda: "<missing>")
+    kind = subject.kind if isinstance(subject, ObjectReference) else subject.subject_type.value
     labels.update(
         {
             "name": subject.name,
-            "kind": subject.subject_type.value,
+            "kind": kind,
             "namespace": subject.namespace if subject.namespace else "<missing>",
             "node": subject.node if subject.node else "<missing>",
         }

--- a/src/robusta/utils/parsing.py
+++ b/src/robusta/utils/parsing.py
@@ -1,8 +1,28 @@
 import datetime
 import json
 import logging
-from typing import Any, Union
+from collections import defaultdict
+from string import Template
+from typing import Any, Dict, Union
 
+from robusta.core.model.events import ExecutionBaseEvent
+
+
+def format_event_templated_string(event: ExecutionBaseEvent, string_to_substitute) -> str:
+    """
+        For templating strings based on event subjects
+    """
+    subject = event.get_subject()
+    labels: Dict[str, str] = defaultdict(lambda: "<missing>")
+    labels.update(
+        {
+            "name": subject.name,
+            "kind": subject.subject_type.value,
+            "namespace": subject.namespace if subject.namespace else "<missing>",
+            "node": subject.node if subject.node else "<missing>",
+        }
+    )
+    return Template(string_to_substitute).safe_substitute(labels)
 
 def load_json(s: Union[str, bytes]) -> Any:
     """

--- a/src/robusta/utils/parsing.py
+++ b/src/robusta/utils/parsing.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from string import Template
 from typing import Any, Dict, Union
 
-from hikaru.model import ObjectReference
+from hikaru.model.rel_1_26 import ObjectReference
 
 from robusta.core.reporting import FindingSubject
 


### PR DESCRIPTION
We moved warning events to their own findings
you can see how they look in the timeline.
There is an option for a custom description for each warning event since it was spec-ed but we decided at this stage to not use it

<img width="823" alt="Screen Shot 2024-06-24 at 13 15 30" src="https://github.com/robusta-dev/robusta/assets/97387909/5e1e0b7e-300a-4407-a421-a813091de292">

<img width="1103" alt="Screen Shot 2024-06-24 at 13 15 09" src="https://github.com/robusta-dev/robusta/assets/97387909/74a74fc5-471d-4b84-bb1e-3cf1658735ae">

Kept action event_report for backward compatibility 
