### PR TITLE
Added name and namespace for K8sJobFailure

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -526,7 +526,7 @@ platformPlaybooks:
   actions:
   - create_finding:
       aggregation_key: "JobFailure"
-      title: "Job Failed"
+      title: "Job $name on namespace $namespace failed"
   - job_info_enricher: {}
   - job_events_enricher: {}
   - job_pod_enricher: {}


### PR DESCRIPTION
Changed `K8sJobFailure` title to `title: "Job $name on namespace $namespace failed"`