### PR TITLE
Slack sink: possibility to disable investigate links/buttons (MAIN-1857)

### DIFF
--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -24,6 +24,7 @@ Alternatively, generate a key by running ``robusta integrations slack`` and set 
          slack_channel: MY SLACK CHANNEL
          max_log_file_limit_kb: <Optional> # (Default: 1000) The maximum allowed file size for "snippets" (in kilobytes) uploaded to the Slack channel. Larger files can be sent to Slack, but they may not be viewable directly within the Slack.
          channel_override: DYNAMIC SLACK CHANNEL OVERRIDE (Optional)
+         investigate_link: true/false # optional, if false no investigate links/buttons will be included in Slack messages
 
 Then do a :ref:`Helm Upgrade <Simple Upgrade>`.
 

--- a/src/robusta/core/sinks/slack/slack_sink.py
+++ b/src/robusta/core/sinks/slack/slack_sink.py
@@ -23,7 +23,7 @@ class SlackSink(SinkBase):
             self.slack_sender.send_finding_to_slack(finding, self.params, platform_enabled)
 
     def handle_notification_grouping(self, finding: Finding, platform_enabled: bool) -> None:
-        # There is a lock over the whole of the method to account:
+        # There is a lock over the whole of the method:
         # 1) to prevent concurrent modifications to group accounting data structures
         # 2) to make sure two threads with identical group_key don't create
         #    two identical messages (of which one would eventually be orphaned and

--- a/src/robusta/core/sinks/slack/slack_sink_params.py
+++ b/src/robusta/core/sinks/slack/slack_sink_params.py
@@ -11,6 +11,7 @@ class SlackSinkParams(SinkBaseParams):
     api_key: str
     channel_override: Optional[str] = None
     max_log_file_limit_kb: int = 1000
+    investigate_link: bool = True
 
     @classmethod
     def _supports_grouping(cls):

--- a/src/robusta/integrations/slack/sender.py
+++ b/src/robusta/integrations/slack/sender.py
@@ -328,7 +328,9 @@ class SlackSender:
             }
         )
 
-    def __create_finding_header(self, finding: Finding, status: FindingStatus, platform_enabled: bool) -> MarkdownBlock:
+    def __create_finding_header(
+        self, finding: Finding, status: FindingStatus, platform_enabled: bool, include_investigate_link: bool
+    ) -> MarkdownBlock:
         title = finding.title.removeprefix("[RESOLVED] ")
         sev = finding.severity
         if finding.source == FindingSource.PROMETHEUS:
@@ -341,21 +343,22 @@ class SlackSender:
             status_name: str = "👀 *K8s event detected*"
         else:
             status_name: str = "👀 *Notification*"
-        if platform_enabled:
+        if platform_enabled and include_investigate_link:
             title = f"<{finding.get_investigate_uri(self.account_id, self.cluster_name)}|*{title}*>"
         return MarkdownBlock(
             f"""{status_name} {sev.to_emoji()} *{sev.name.capitalize()}*
 {title}"""
         )
 
-    def __create_links(self, finding: Finding):
+    def __create_links(self, finding: Finding, include_investigate_link: bool):
         links: List[LinkProp] = []
-        links.append(
-            LinkProp(
-                text="Investigate 🔎",
-                url=finding.get_investigate_uri(self.account_id, self.cluster_name),
+        if include_investigate_link:
+            links.append(
+                LinkProp(
+                    text="Investigate 🔎",
+                    url=finding.get_investigate_uri(self.account_id, self.cluster_name),
+                )
             )
-        )
 
         if finding.add_silence_url:
             links.append(
@@ -484,10 +487,10 @@ class SlackSender:
             FindingStatus.RESOLVED if finding.title.startswith("[RESOLVED]") else FindingStatus.FIRING
         )
         if finding.title:
-            blocks.append(self.__create_finding_header(finding, status, platform_enabled))
+            blocks.append(self.__create_finding_header(finding, status, platform_enabled, sink_params.investigate_link))
 
         if platform_enabled:
-            blocks.append(self.__create_links(finding))
+            blocks.append(self.__create_links(finding, sink_params.investigate_link))
 
         if HOLMES_ENABLED:
             blocks.append(self.__create_holmes_callback(finding))
@@ -579,17 +582,18 @@ class SlackSender:
                             "type": "mrkdwn",
                             "text": source_txt,
                         },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Investigate 🔎",
-                            },
-                            "url": investigate_uri,
-                        },
                     }
                 ]
             )
+            if sink_params.investigate_link:
+                blocks[-1]["accessory"] = {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Investigate 🔎",
+                    },
+                    "url": investigate_uri,
+                }
         else:
             blocks.append(MarkdownBlock(text=source_txt))
 


### PR DESCRIPTION
Tests performed: setting `investigate_link` to `true`/`false` (and unset) for both grouping and normal Slack message sending and observing the results.