### PR TITLE
fix: add missing _get_sink_type method to zulip sink

### DIFF
--- a/src/robusta/core/sinks/zulip/zulip_sink_params.py
+++ b/src/robusta/core/sinks/zulip/zulip_sink_params.py
@@ -16,6 +16,10 @@ class ZulipSinkParams(SinkBaseParams):
     topic_override: Optional[str] = None
     log_preview_char_limit: int = 500
 
+    @classmethod
+    def _get_sink_type(cls):
+        return "zulip"
+
     @validator("topic_override")
     def validate_topic_override(cls, v: str):
         return ChannelTransformer.validate_channel_override(v)


### PR DESCRIPTION
Without the method the runner fails on startup:
```
sinks_config -> 0 -> zulip_sink
  Can't instantiate abstract class ZulipSinkParams with abstract method _get_sink_type (type=type_error)
```