### PR TITLE
[MAIN-1885] bumped java-toolkit

### DIFF
--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -42,7 +42,7 @@ T = TypeVar("T")
 
 # TODO: import these from the python-tools project
 PYTHON_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/debug-toolkit:v6.0"
-JAVA_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/java-toolkit:v1.0.1"
+JAVA_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/java-toolkit:v1.0.2"
 
 
 class Process(BaseModel):


### PR DESCRIPTION
there are CVE's that have been removed in the python:3.12-slim base image, 
I rebuilt the docker file with the newer base image and it removed the vunerabilities