### PR TITLE
[MAIN-1938] added optional annotations on default playbook

### DIFF
--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -58,12 +58,12 @@ class SeverityParams(ActionParams):
 
 class DefaultEnricherParams(ActionParams):
     """
-    :var show_alert_annotations: will add the alert annotations to the default alerts if true
+    :var alert_annotations_enrichment: will add the alert annotations to the default alerts if true
 
     :example severity: warning
     """
 
-    show_alert_annotations: bool = False
+    alert_annotations_enrichment: bool = False
 
 
 @action
@@ -228,7 +228,7 @@ def default_enricher(alert: PrometheusKubernetesAlert, params: DefaultEnricherPa
         title="Alert labels"
     )
 
-    if not params.show_alert_annotations:
+    if not params.alert_annotations_enrichment:
         return
 
     annotations = alert.alert.annotations

--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -56,6 +56,16 @@ class SeverityParams(ActionParams):
     severity: str = "none"
 
 
+class DefaultEnricherParams(ActionParams):
+    """
+    :var show_alert_annotations: will add the alert annotations to the default alerts if true
+
+    :example severity: warning
+    """
+
+    show_alert_annotations: bool = False
+
+
 @action
 def severity_silencer(alert: PrometheusKubernetesAlert, params: SeverityParams):
     """
@@ -197,7 +207,7 @@ def alert_explanation_enricher(alert: PrometheusKubernetesAlert, params: AlertEx
 
 
 @action
-def default_enricher(alert: PrometheusKubernetesAlert):
+def default_enricher(alert: PrometheusKubernetesAlert, params: DefaultEnricherParams):
     """
     Enrich an alert with the original message and labels.
 
@@ -217,6 +227,28 @@ def default_enricher(alert: PrometheusKubernetesAlert):
         enrichment_type=EnrichmentType.alert_labels,
         title="Alert labels"
     )
+
+    if not params.show_alert_annotations:
+        return
+
+    annotations = alert.alert.annotations
+    if not annotations:
+        return
+
+    alert.add_enrichment(
+        [
+            TableBlock(
+                [[k, v] for (k, v) in annotations.items()],
+                ["label", "value"],
+                table_format=TableBlockFormat.vertical,
+                table_name="*Alert annotations*",
+            ),
+        ],
+        annotations={SlackAnnotations.ATTACHMENT: True},
+        enrichment_type=EnrichmentType.alert_labels,
+        title="Alert annotations"
+    )
+
 
 
 @action

--- a/playbooks/robusta_playbooks/common_actions.py
+++ b/playbooks/robusta_playbooks/common_actions.py
@@ -73,11 +73,12 @@ def create_finding(event: ExecutionBaseEvent, params: FindingFields):
     Create a new notification message. This is the primary way that custom playbooks generate messages.
     """
     subject = event.get_subject()
+    aggregation_key = format_event_templated_string(subject, params.aggregation_key) if params.aggregation_key else None
     event.add_finding(
         Finding(
             title=format_event_templated_string(subject, params.title),
             description=format_event_templated_string(subject, params.description) if params.description else None,
-            aggregation_key=params.aggregation_key,
+            aggregation_key=aggregation_key,
             severity=FindingSeverity.from_severity(params.severity),
             subject=event.get_subject(),
             source=event.get_source(),

--- a/playbooks/robusta_playbooks/common_actions.py
+++ b/playbooks/robusta_playbooks/common_actions.py
@@ -73,12 +73,11 @@ def create_finding(event: ExecutionBaseEvent, params: FindingFields):
     Create a new notification message. This is the primary way that custom playbooks generate messages.
     """
     subject = event.get_subject()
-    aggregation_key = format_event_templated_string(subject, params.aggregation_key) if params.aggregation_key else None
     event.add_finding(
         Finding(
             title=format_event_templated_string(subject, params.title),
             description=format_event_templated_string(subject, params.description) if params.description else None,
-            aggregation_key=aggregation_key,
+            aggregation_key=params.aggregation_key,
             severity=FindingSeverity.from_severity(params.severity),
             subject=event.get_subject(),
             source=event.get_source(),


### PR DESCRIPTION
Some users wanted alert annotations in all their prometheus alerts, so it is added by enabling 
```
globalConfig:
  show_alert_annotations: true
```
<img width="832" alt="Screen Shot 2024-08-01 at 10 18 30" src="https://github.com/user-attachments/assets/3681419f-62dc-48fd-9a3d-2c24ae63c4ab">
<img width="851" alt="Screen Shot 2024-08-01 at 10 18 47" src="https://github.com/user-attachments/assets/30e4606b-f3db-4930-893b-7e0dade8255c">

also fixed aggregation key in create_finding so it parametizes it for this specific use case ( see pictures above for example)
```
customPlaybooks:
- triggers:
  - on_prometheus_alert:
      status: "all"
  actions:
  - create_finding:
      description: 'Eng-Dev-EKS - $annotations.description'
      aggregation_key: '$labels.alertname'
```