### PR TITLE
Fixes minor issue with generated templates having double document separator

### DIFF
--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -226,8 +226,8 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 5000
----
 {{ if and (.Values.enableServiceMonitors) (or (.Values.enablePrometheusStack) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") ) }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -263,8 +263,8 @@ spec:
   targetLabels:
     - target
 {{ end }}
----
 {{ if .Values.runner.sentry_dsn }}
+---
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Moves the document separator into the if condition to avoid scenarios with multiple document separators with nothing in between. Some yaml tools cannot handle an empty doc e.g. checkov