### PR TITLE
Add ability to set Assignee and Epic on Jira sink 

### DIFF
--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -26,8 +26,8 @@ Optional Settings
 * ``dedups`` : [Optional - default: ``fingerprint``] Tickets deduplication parameter. By default, Only one issue per ``fingerprint`` will be created. There can be more than one value to use. Possible values are: fingerprint, cluster_name, title, node, type, source, namespace, creation_date etc
 * ``project_type_id_override`` : [Optional - default: None] If available, will override the ``project_name`` configuration. Follow these `instructions <https://confluence.atlassian.com/jirakb/how-to-get-project-id-from-the-jira-user-interface-827341414.html>`__ to get your project id.
 * ``issue_type_id_override`` : [Optional - default: None] If available, will override the ``issue_type`` configuration. Follow these `instructions <https://confluence.atlassian.com/jirakb/finding-the-id-for-issue-types-646186508.html>`__ to get your issue id.
-* ``assignee`` : [Optional - default: ``None``] Jira ID of the person that the issue is assigned to.
-* ``epic`` : [Optional - default: ``None``] Jira ID of the epic that the issue is linked to.
+* ``assignee`` : [Optional - default: None] Jira ID of the person that the issue is assigned to.
+* ``epic`` : [Optional - default: None] Jira ID of the epic that the issue is linked to.
 
 Following optional settings only work for Prometheus alerts:
 

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -26,6 +26,8 @@ Optional Settings
 * ``dedups`` : [Optional - default: ``fingerprint``] Tickets deduplication parameter. By default, Only one issue per ``fingerprint`` will be created. There can be more than one value to use. Possible values are: fingerprint, cluster_name, title, node, type, source, namespace, creation_date etc
 * ``project_type_id_override`` : [Optional - default: None] If available, will override the ``project_name`` configuration. Follow these `instructions <https://confluence.atlassian.com/jirakb/how-to-get-project-id-from-the-jira-user-interface-827341414.html>`__ to get your project id.
 * ``issue_type_id_override`` : [Optional - default: None] If available, will override the ``issue_type`` configuration. Follow these `instructions <https://confluence.atlassian.com/jirakb/finding-the-id-for-issue-types-646186508.html>`__ to get your issue id.
+* ``assignee`` : [Optional - default: ``None``] Jira ID of the person that the issue is assigned to.
+* ``epic`` : [Optional - default: ``None``] Jira ID of the epic that the issue is linked to.
 
 Following optional settings only work for Prometheus alerts:
 
@@ -54,6 +56,8 @@ Configuring the Jira sink
             api_key: api_key
             dedups: (OPTIONAL)
               - fingerprint
+            assignee: user_id of the assignee(OPTIONAL)
+            epic: epic_id(OPTIONAL)
             project_name: project_name
             scope:
               include:

--- a/src/robusta/core/sinks/jira/jira_sink_params.py
+++ b/src/robusta/core/sinks/jira/jira_sink_params.py
@@ -18,6 +18,9 @@ class JiraSinkParams(SinkBaseParams):
     doneStatusName: Optional[str] = "Done"
     reopenStatusName: Optional[str] = "To Do"
     noReopenResolution: Optional[str] = ""
+    epic: Optional[str] = ""
+    assignee: Optional[str] = ""
+
 
     @classmethod
     def _get_sink_type(cls):

--- a/src/robusta/integrations/jira/client.py
+++ b/src/robusta/integrations/jira/client.py
@@ -230,8 +230,19 @@ class JiraClient:
         url = self._get_full_jira_url(endpoint)
 
         payload = {
-            "fields": {"summary": summary, "description": description, "assignee": self.assignee, "parent": self.epic},
+            "fields": {
+                "summary": summary,
+                "description": description,
+            }
         }
+
+        # Only add assignee if defined
+        if hasattr(self, 'assignee') and self.assignee:
+            payload["fields"]["assignee"] = {"id": self.assignee}
+
+        # Only add parent if epic is defined
+        if hasattr(self, 'epic') and self.epic:
+            payload["fields"]["parent"] = {"key": self.epic}
 
         logging.debug(f"Update issue '{issue_id}' with payload: {payload}")
         response = self._call_jira_api(url, http_method=HttpMethod.PUT, json=payload) or {}

--- a/src/robusta/integrations/jira/client.py
+++ b/src/robusta/integrations/jira/client.py
@@ -34,6 +34,13 @@ class JiraClient:
         else:
             self.default_issue_type_id = self._get_default_issue_type()
 
+        if jira_params.epic:
+            self.epic = jira_params.epic
+        
+        if jira_params.assignee:
+            self.assignee = jira_params.assignee
+
+
         if jira_params.project_type_id_override:
             self.default_project_id = jira_params.project_type_id_override
         else:
@@ -223,7 +230,7 @@ class JiraClient:
         url = self._get_full_jira_url(endpoint)
 
         payload = {
-            "fields": {"summary": summary, "description": description},
+            "fields": {"summary": summary, "description": description, "assignee": self.assignee, "parent": self.epic},
         }
 
         logging.debug(f"Update issue '{issue_id}' with payload: {payload}")


### PR DESCRIPTION
Added the ability to set the assignee and Epic (link) in the JIra sink config