### PR TITLE
Overide for title in foreign_logs_enricher.

### DIFF
--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -8,7 +8,6 @@ import requests
 from hikaru.model.rel_1_26 import Node
 from kubernetes import client
 from kubernetes.client import V1Pod, V1PodList, exceptions
-
 from robusta.api import (
     ActionException,
     ActionParams,
@@ -437,6 +436,7 @@ class ForeignLogParams(LogEnricherParams):
     """
 
     label_selectors: List[str]
+    title_override: Optional[str]
 
 
 @action
@@ -473,7 +473,7 @@ def foreign_logs_enricher(event: ExecutionBaseEvent, params: ForeignLogParams):
     for matching_pod in matching_pods:
         pod = RobustaPod().read(matching_pod.metadata.name, matching_pod.metadata.namespace)
 
-        start_log_enrichment(event=event, params=params, pod=pod)
+        start_log_enrichment(event=event, params=params, pod=pod, title_override=params.title_override)
 
 
 logs_enricher = action(logs_enricher)

--- a/src/robusta/core/playbooks/oom_killer_utils.py
+++ b/src/robusta/core/playbooks/oom_killer_utils.py
@@ -1,9 +1,10 @@
 import logging
 import time
+from typing import Optional
 
 from robusta.api import (
-    ExecutionBaseEvent,
     EmptyFileBlock,
+    ExecutionBaseEvent,
     FileBlock,
     LogEnricherParams,
     MarkdownBlock,
@@ -19,6 +20,7 @@ def start_log_enrichment(
     event: ExecutionBaseEvent,
     params: LogEnricherParams,
     pod: RobustaPod,
+    title_override: Optional[str] = None
 ):
     if pod is None:
         if params.warn_on_missing_label:
@@ -77,9 +79,9 @@ def start_log_enrichment(
         )
     else:
         log_block = FileBlock(filename=f"{pod.metadata.name}.log", contents=log_data.encode())
-
+    title = "Logs" if not title_override else title_override
     event.add_enrichment([log_block],
-                         enrichment_type=EnrichmentType.text_file, title="Logs")
+                         enrichment_type=EnrichmentType.text_file, title=title)
 
 
 def logs_enricher(event: PodEvent, params: LogEnricherParams):


### PR DESCRIPTION
Doesnt impact slack, slack uploads a file with the pod name,
this is for the UI since it only uses the title Logs.
example:
<img width="629" alt="Screen Shot 2024-10-14 at 14 13 01" src="https://github.com/user-attachments/assets/4a3170d7-fc38-4fb7-a926-e5c41a72dc26">

```
customPlaybooks:
  - triggers:
    - on_prometheus_alert:
        alert_name: TestAlert
    actions:
    - foreign_logs_enricher:
        title_override: "Pod $name/$namespace Logs"
        label_selectors:
        - app=robusta-runner
```