### PR TITLE
Deprecating python tools

### DIFF
--- a/docs/playbook-reference/actions/python-troubleshooting.rst
+++ b/docs/playbook-reference/actions/python-troubleshooting.rst
@@ -21,6 +21,14 @@ These actions can be triggered automatically on Prometheus alerts, or :ref:`manu
 
 .. robusta-action:: playbooks.robusta_playbooks.pod_troubleshooting.python_profiler
 
+    This action has been deprecated. To enable it add the following to your generated_values.yaml
+
+    .. code-block:: bash
+        runner:
+          additional_env_vars:
+          - name: PYTHON_DEBUGGER_IMAGE
+            value: debug-toolkit:v6.0
+
     Manually trigger with:
 
     .. code-block:: bash

--- a/docs/playbook-reference/actions/python-troubleshooting.rst
+++ b/docs/playbook-reference/actions/python-troubleshooting.rst
@@ -11,6 +11,14 @@ These actions can be triggered automatically on Prometheus alerts, or :ref:`manu
 
 .. robusta-action:: playbooks.robusta_playbooks.pod_troubleshooting.python_debugger
 
+    This action has been deprecated. To enable it add the following to your generated_values.yaml
+
+    .. code-block:: bash
+        runner:
+          additional_env_vars:
+          - name: PYTHON_DEBUGGER_IMAGE
+            value: debug-toolkit:v6.0
+
 .. robusta-action:: playbooks.robusta_playbooks.pod_troubleshooting.python_profiler
 
     Manually trigger with:
@@ -20,6 +28,14 @@ These actions can be triggered automatically on Prometheus alerts, or :ref:`manu
         robusta playbooks trigger python_profiler name=podname namespace=default process_name=your-process seconds=5
 
 .. robusta-action:: playbooks.robusta_playbooks.pod_troubleshooting.python_memory
+
+    This action has been deprecated. To enable it add the following to your generated_values.yaml
+
+    .. code-block:: bash
+        runner:
+          additional_env_vars:
+          - name: PYTHON_DEBUGGER_IMAGE
+            value: debug-toolkit:v6.0
 
     Manually trigger with:
 

--- a/playbooks/robusta_playbooks/pod_troubleshooting.py
+++ b/playbooks/robusta_playbooks/pod_troubleshooting.py
@@ -27,6 +27,7 @@ from robusta.api import (
     TableBlock,
     action,
 )
+from robusta.integrations.kubernetes.custom_models import PYTHON_DEBUGGER_IMAGE
 from robusta.utils.parsing import load_json
 
 
@@ -68,6 +69,10 @@ def python_profiler(event: PodEvent, action_params: StartProfilingParams):
     # This should use ephemeral containers, but they aren't in GA yet. To enable them on GCP for example,
     # you need to create a brand new cluster. Therefore we're sticking with regular containers for now
     pod = event.get_pod()
+    if "debug-toolkit:v6.0" not in PYTHON_DEBUGGER_IMAGE:
+        logging.error(f"The python_profiler action is deprecated "
+                      f"to run set the PYTHON_DEBUGGER_IMAGE environment variable to debug-toolkit:v6.0.")
+        return
     logging.warning(f"The python_profiler action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"python_profiler - pod not found for event: {event}")
@@ -179,8 +184,11 @@ def python_memory(event: PodEvent, params: MemoryTraceParams):
 
     Use this to track memory leaks in your Python application on Kubernetes.
     """
+    if "debug-toolkit:v6.0" not in PYTHON_DEBUGGER_IMAGE:
+        logging.error(f"The python_memory action is deprecated and might not work on all platforms. "
+                      f"to enable it set the PYTHON_DEBUGGER_IMAGE environment variable to debug-toolkit:v6.0.")
+        return
     pod = event.get_pod()
-    logging.warning(f"The python_memory action is deprecated and might not work on all platforms.")
     if not pod:
         logging.info(f"python_memory - pod not found for event: {event}")
         return
@@ -296,7 +304,10 @@ def debugger_stack_trace(event: PodEvent, params: StackTraceParams):
     Create a finding with the stack trace results.
     """
     pod = event.get_pod()
-    logging.warning(f"The debugger_stack_trace action is deprecated and might not work on all platforms.")
+    if "debug-toolkit:v6.0" not in PYTHON_DEBUGGER_IMAGE:
+        logging.error(f"The debugger_stack_trace action is deprecated and might not work on all platforms. "
+                      f"to enable it set the PYTHON_DEBUGGER_IMAGE environment variable to debug-toolkit:v6.0.")
+        return
     if not pod:
         logging.info(f"debugger_stack_trace - pod not found for event: {event}")
         return
@@ -381,6 +392,10 @@ def python_process_inspector(event: PodEvent, params: DebuggerParams):
     Create a finding with alternative debugging options for received processes ; i.e. Stack-trace or Memory-trace.
 
     """
+    if "debug-toolkit:v6.0" not in PYTHON_DEBUGGER_IMAGE:
+        logging.error(f"The python_process_inspector action is deprecated and might not work on all platforms. "
+                      f"to enable it set the PYTHON_DEBUGGER_IMAGE environment variable to debug-toolkit:v6.0.")
+        return
     pod = event.get_pod()
     logging.warning(f"The python_process_inspector action is deprecated and might not work on all platforms.")
     if not pod:
@@ -440,6 +455,10 @@ def python_debugger(event: PodEvent, params: DebuggerParams):
 
     Now you can use break points and log points in VSCode.
     """
+    if "debug-toolkit:v6.0" not in PYTHON_DEBUGGER_IMAGE:
+        logging.error(f"The python_debugger action is deprecated and might not work on all platforms. "
+                      f"to enable it set the PYTHON_DEBUGGER_IMAGE environment variable to debug-toolkit:v6.0.")
+        return
     pod = event.get_pod()
     logging.warning(f"The python_debugger action is deprecated and might not work on all platforms.")
     if not pod:

--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -39,9 +40,9 @@ if TYPE_CHECKING:
 S = TypeVar("S")
 T = TypeVar("T")
 
-
+PYTHON_DEBUGGER_IMAGE_OVERRIDE = os.getenv("PYTHON_DEBUGGER_IMAGE", "debug-toolkit:v8.0")
 # TODO: import these from the python-tools project
-PYTHON_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/debug-toolkit:v6.0"
+PYTHON_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/{PYTHON_DEBUGGER_IMAGE_OVERRIDE}"
 JAVA_DEBUGGER_IMAGE = f"{IMAGE_REGISTRY}/java-toolkit:v1.0.2"
 
 


### PR DESCRIPTION
The python toolset image has additional cves due to gdb importing libpython3.11 
we are fully deprecating the python tools. 
They still can be used by adding the following to your generated_values.yaml

```
runner:
  additional_env_vars:
  - name: PYTHON_DEBUGGER_IMAGE
    value: debug-toolkit:v6.0
```