### PR TITLE
fix: ensure sink names are unique

### DIFF
--- a/src/robusta/core/model/runner_config.py
+++ b/src/robusta/core/model/runner_config.py
@@ -84,7 +84,6 @@ class RunnerConfig(BaseModel):
 
     @root_validator()
     def ensure_unique_sink_name(cls, val: Dict) -> Dict:
-        print(f"validating {val}")
         if val.get('sinks_config'):
             value_set = set()
             sinksConfig = cast(List[SinkConfigBase], val.get('sinks_config'))

--- a/src/robusta/core/model/runner_config.py
+++ b/src/robusta/core/model/runner_config.py
@@ -91,8 +91,8 @@ class RunnerConfig(BaseModel):
                 sink_name = sink_config.get_name()
                 if sink_name in value_set:
                     raise ValueError(f"Sink name \"{sink_name}\" is already defined. Sink names must be unique.")
-                else:
-                    value_set.add(sink_name)
+
+                value_set.add(sink_name)
         return val
 
     @validator("playbook_repos")

--- a/src/robusta/core/model/runner_config.py
+++ b/src/robusta/core/model/runner_config.py
@@ -29,7 +29,7 @@ from robusta.core.sinks.zulip.zulip_sink_params import ZulipSinkConfigWrapper
 from robusta.model.alert_relabel_config import AlertRelabel
 from robusta.model.playbook_definition import PlaybookDefinition
 from robusta.utils.base64_utils import is_base64_encoded
-from src.robusta.core.sinks.sink_config import SinkConfigBase
+from robusta.core.sinks.sink_config import SinkConfigBase
 
 
 class PlaybookRepo(BaseModel):

--- a/tests/file_fixtures/config_validation/invalid_dupl_sink_names.yaml
+++ b/tests/file_fixtures/config_validation/invalid_dupl_sink_names.yaml
@@ -1,0 +1,22 @@
+playbook_repos:
+  chatgpt_robusta_actions:
+    url: "file:///path/to/kubernetes-chatgpt-bot"
+sinks_config:
+  - slack_sink:
+      name: my_sink1
+      slack_channel: my-alert-channel
+      api_key: "foobar"
+      scope:
+        include:
+          - labels:
+              - "severity=high"
+              - "severity=critical"
+
+  - slack_sink:
+      name: my_sink1
+      slack_channel: my-notification-channel
+      api_key: "foobar"
+      scope:
+        include:
+          - labels:
+              - "severity=warning"

--- a/tests/file_fixtures/config_validation/valid_config.yaml
+++ b/tests/file_fixtures/config_validation/valid_config.yaml
@@ -1,0 +1,22 @@
+playbook_repos:
+  chatgpt_robusta_actions:
+    url: "file:///path/to/kubernetes-chatgpt-bot"
+sinks_config:
+  - slack_sink:
+      name: my_sink1
+      slack_channel: my-alert-channel
+      api_key: "foobar"
+      scope:
+        include:
+          - labels:
+              - "severity=high"
+              - "severity=critical"
+
+  - slack_sink:
+      name: my_sink2
+      slack_channel: my-notification-channel
+      api_key: "foobar"
+      scope:
+        include:
+          - labels:
+              - "severity=warning"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -20,5 +20,4 @@ class TestSinkValidation:
             yaml_content = yaml.safe_load(file)
             with pytest.raises(ValidationError) as validation_error:
                 config = RunnerConfig(**yaml_content)
-            assert "sink name".casefold() in str(validation_error).casefold()
-            assert "unique".casefold() in str(validation_error).casefold()
+            assert f'Sink name "my_sink1" is already defined. Sink names must be unique.' in str(validation_error)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,24 @@
+import pytest
+import yaml
+import os
+from pydantic import ValidationError
+from robusta.core.model.runner_config import RunnerConfig
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "file_fixtures", "config_validation")
+FIXTURE_VALID_CONFIG_FILE_PATH = os.path.join(FIXTURES, "valid_config.yaml")
+FIXTURE_DUPL_SINKS_NAME_FILE_PATH = os.path.join(FIXTURES, "invalid_dupl_sink_names.yaml")
+
+class TestSinkValidation:
+
+    def test_valid_sink_config(self):
+        with open(FIXTURE_VALID_CONFIG_FILE_PATH) as file:
+            yaml_content = yaml.safe_load(file)
+            config = RunnerConfig(**yaml_content)
+
+    def test_duplicate_sink_names(self):
+        with open(FIXTURE_DUPL_SINKS_NAME_FILE_PATH) as file:
+            yaml_content = yaml.safe_load(file)
+            with pytest.raises(ValidationError) as validation_error:
+                config = RunnerConfig(**yaml_content)
+            assert "sink name".casefold() in str(validation_error).casefold()
+            assert "unique".casefold() in str(validation_error).casefold()


### PR DESCRIPTION
This ensures sink names are unique. For example the following sink configuration would throw a validation error because the sink name `my_sink1` is used more than once.

```yaml
sinks_config:
  - slack_sink:
      name: my_sink1
      slack_channel: my-alert-channel
      api_key: "foobar"
      scope:
        include:
          - labels:
              - "severity=high"
              - "severity=critical"

  - slack_sink:
      name: my_sink1
      slack_channel: my-notification-channel
      api_key: "foobar"
      scope:
        include:
          - labels:
              - "severity=warning"

```