### PR TITLE
fix: issue with OOM not being reported due to being captured downstream

### DIFF
--- a/src/robusta/core/sinks/robusta/robusta_sink.py
+++ b/src/robusta/core/sinks/robusta/robusta_sink.py
@@ -331,13 +331,15 @@ class RobustaSink(SinkBase, EventHandler):
 
         except Exception:
             # we had an error during discovery. Reset caches to align the data with the storage
-            if Discovery.out_of_memory_detected and "ERROR_DISCOVERY_OOM" not in self.__errors:
-               self.__errors.append("ERROR_DISCOVERY_OOM")
             self.__reset_caches()
             logging.error(
                 f"Failed to run publish discovery for {self.sink_name}",
                 exc_info=True,
             )
+        finally:
+            if Discovery.out_of_memory_detected and "ERROR_DISCOVERY_OOM" not in self.__errors:
+                self.__errors.append("ERROR_DISCOVERY_OOM")
+
 
     def __publish_new_nodes(self, current_nodes: List[NodeInfo]):
         # convert to map


### PR DESCRIPTION
The code in [this PR](https://github.com/robusta-dev/robusta/pull/1604) is incorrect. The discovery process captures the error and simply restart. This means the `__discover_resources` function call should not rely on an exception being raised by `Discovery.discover_resources()`  to check the oom flag

## Front end payload example:

![image](https://github.com/user-attachments/assets/41754473-71a5-4ed6-afcb-e9d3146670f8)
