### PR TITLE
[MAIN-2452] Disk tools security update

### DIFF
--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -106,7 +106,7 @@ MAX_ALLOWED_RULES_PER_CRD_ALERT = int(os.environ.get("MAX_ALLOWED_RULES_PER_CRD_
 IMAGE_REGISTRY = os.environ.get("IMAGE_REGISTRY", "robustadev")
 
 FIO_IMAGE = os.environ.get("FIO_IMAGE", "robusta-fio-benchmark:1.0")
-DISK_TOOLS_IMAGE = os.environ.get("DISK_TOOLS_IMAGE", "disk-tools:1.5")
+DISK_TOOLS_IMAGE = os.environ.get("DISK_TOOLS_IMAGE", "disk-tools:1.6")
 
 CLUSTER_DOMAIN = os.environ.get("CLUSTER_DOMAIN", "cluster.local")
 


### PR DESCRIPTION
removed the cves 
[python-3.12-base:3.12.3-r3]
[python-3.12:3.12.3-r3]