### PR TITLE
using v2 alertmanager api for simulate alerts

### DIFF
--- a/playbooks/robusta_playbooks/prometheus_simulation.py
+++ b/playbooks/robusta_playbooks/prometheus_simulation.py
@@ -219,10 +219,10 @@ def alertmanager_alert(event: ExecutionBaseEvent, action_params: AlertmanagerAle
 
     try:
         requests.post(
-            f"{alertmanager_url}/api/v1/alerts",
+            f"{alertmanager_url}/api/v2/alerts",
             data=json.dumps(alerts),
             headers=headers,
-        )
+        ).raise_for_status()
     except Exception:
         logging.exception(f"Failed to create alertmanager alerts {alerts}")
         raise ActionException(ErrorCodes.ALERT_MANAGER_REQUEST_FAILED)


### PR DESCRIPTION
v2 api is supported since 0.16 - year 2019 and it removed since 0.28 - year 2024