### PR TITLE
fix: issue extra details on opsgenie sink

### DIFF
--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -5,6 +5,12 @@ Robusta can report issues and events in your Kubernetes cluster to the OpsGenie 
 
 To configure OpsGenie, We need an OpsGenie API key. It can be configured using the OpsGenie team integration.
 
+Customizing Opsgenie Extra Details
+------------------------------------------------
+
+We can add Prometheus alert labels into Opsgenie alert extra details by setting `extra_details_labels` to `true` in the `sinksConfig` section.
+
+
 Configuring the OpsGenie sink
 ------------------------------------------------
 
@@ -21,6 +27,7 @@ Configuring the OpsGenie sink
             - "sre"
             tags:
             - "prod a"
+            extra_details_labels: false # optional, default is false
 
 Save the file and run
 

--- a/src/robusta/core/sinks/opsgenie/opsgenie_sink.py
+++ b/src/robusta/core/sinks/opsgenie/opsgenie_sink.py
@@ -24,6 +24,7 @@ class OpsGenieSink(SinkBase):
         self.api_key = sink_config.opsgenie_sink.api_key
         self.teams = sink_config.opsgenie_sink.teams
         self.tags = sink_config.opsgenie_sink.tags
+        self.extra_details_labels = sink_config.opsgenie_sink.extra_details_labels
 
         opsgenie_sdk.configuration.Configuration.set_default(None)
         self.conf = opsgenie_sdk.configuration.Configuration()
@@ -31,9 +32,6 @@ class OpsGenieSink(SinkBase):
 
         if sink_config.opsgenie_sink.host is not None:
             self.conf.host = sink_config.opsgenie_sink.host
-
-        if sink_config.opsgenie_sink.extra_details_labels is not None:
-            self.conf.extra_details_labels = sink_config.opsgenie_sink.extra_details_labels
 
         self.api_client = opsgenie_sdk.api_client.ApiClient(configuration=self.conf)
         self.alert_api = opsgenie_sdk.AlertApi(api_client=self.api_client)
@@ -105,9 +103,9 @@ class OpsGenieSink(SinkBase):
         lower_details_key = [k.lower() for k in details.keys()]
         # If there are extra details labels in the config extra_details_labels,
         # add them without altering the already existing details.
-        if self.conf.extra_details_labels:
+        if self.extra_details_labels:
             for key, value in finding.subject.labels:
-                if key in self.conf.extra_details_labels and not key in lower_details_key:
+                if not key in lower_details_key:
                     details[key] = value
         return details
 

--- a/src/robusta/core/sinks/opsgenie/opsgenie_sink_params.py
+++ b/src/robusta/core/sinks/opsgenie/opsgenie_sink_params.py
@@ -9,7 +9,7 @@ class OpsGenieSinkParams(SinkBaseParams):
     teams: List[str] = []
     tags: List[str] = []
     host: Optional[str] = None  # NOTE: If None, the default value will be used from opsgenie_sdk
-    extra_details_labels: Optional[bool] = None
+    extra_details_labels: Optional[bool] = False
 
     @classmethod
     def _get_sink_type(cls):


### PR DESCRIPTION
Fix for https://github.com/robusta-dev/robusta/issues/1635 

- Wrong assignment of `extra_details_labels` property
- condition was not valid from `extra_details_labels` paramater type