### PR TITLE
helm: configurable Service annotations

### DIFF
--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -218,6 +218,10 @@ metadata:
   labels:
     app: {{ include "robusta.fullname" . }}-runner
     target: {{ include "robusta.fullname" . }}-runner
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     app: {{ include "robusta.fullname" . }}-runner

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -218,9 +218,9 @@ metadata:
   labels:
     app: {{ include "robusta.fullname" . }}-runner
     target: {{ include "robusta.fullname" . }}-runner
-{{- if .Values.service.annotations }}
+{{- if .Values.runner.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{ toYaml .Values.runner.service.annotations | indent 4 }}
 {{- end }}
 spec:
   selector:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -35,6 +35,11 @@ globalConfig:
   custom_annotations: []
   custom_severity_map: {}
 
+# k8s service config
+service:
+  # service annotations
+  annotations: {}
+
 # see https://docs.robusta.dev/master/user-guide/configuration/additional-settings.html#relabel-prometheus-alerts
 alertRelabel: []
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -35,11 +35,6 @@ globalConfig:
   custom_annotations: []
   custom_severity_map: {}
 
-# k8s service config
-service:
-  # service annotations
-  annotations: {}
-
 # see https://docs.robusta.dev/master/user-guide/configuration/additional-settings.html#relabel-prometheus-alerts
 alertRelabel: []
 
@@ -685,6 +680,10 @@ runner:
   imagePullSecrets: []
   extraVolumes: []
   extraVolumeMounts: []
+  # k8s service config
+  service:
+    # custom service annotations
+    annotations: {}
   serviceMonitor:
     path: /metrics
   securityContext:


### PR DESCRIPTION
Hi guys,
In our infrastructure, we need to add custom annotations to k8s services in order to configure load balancers. Currently we have to patch Service resource after installing Robusta which is not very convenient.
As it seems to be a common case, I think it would be worthwhile to add the corresponding helm values into the chart.