### PR TITLE
Minor fix for helm template generation to avoid double doc separators

### DIFF
--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -107,8 +107,8 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 2112
----
 {{ if and (.Values.enableServiceMonitors) (or (.Values.enablePrometheusStack) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") ) }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -143,4 +143,3 @@ spec:
   targetLabels:
     - target
 {{ end }}
----


### PR DESCRIPTION
Similar to another PR I've opened before:
https://github.com/robusta-dev/robusta/pull/1553