### PR TITLE
improved a bash enricher and added an action to run it in a new pod

### DIFF
--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -2,6 +2,7 @@ import logging
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Union
 
+from hikaru.model.rel_1_26 import Volume, VolumeMount
 from pydantic import BaseModel, SecretStr, validator
 
 from robusta.integrations import openshift
@@ -81,7 +82,6 @@ class ResourceInfo(BaseModel):
 
 
 class HolmesParams(ActionParams):
-
     holmes_url: Optional[str]
 
     @validator("holmes_url", allow_reuse=True)
@@ -250,6 +250,8 @@ class PodRunningParams(ActionParams):
     """
 
     custom_annotations: Optional[Dict[str, str]] = None
+    custom_volume_mounts: Optional[List[VolumeMount]]
+    custom_volumes: Optional[List[Volume]]
 
 
 class VideoEnricherParams(ActionParams):

--- a/src/robusta/integrations/kubernetes/custom_models.py
+++ b/src/robusta/integrations/kubernetes/custom_models.py
@@ -238,6 +238,8 @@ class RobustaPod(Pod):
         env: Optional[List[EnvVar]] = None,
         mount_host_root: bool = False,
         custom_annotations: Optional[Dict[str, str]] = None,
+        custom_volume_mounts: Optional[List[VolumeMount]] = None,
+        custom_volumes: Optional[List[Volume]] = None,
     ) -> "RobustaPod":
         """
         Creates a debugging pod with high privileges
@@ -248,6 +250,9 @@ class RobustaPod(Pod):
         if mount_host_root:
             volume_mounts = [VolumeMount(name="host-root", mountPath="/host")]
             volumes = [Volume(name="host-root", hostPath=HostPathVolumeSource(path="/", type="Directory"))]
+
+        volume_mounts = (volume_mounts or []) + (custom_volume_mounts or [])
+        volumes = (volumes or []) + (custom_volumes or [])
 
         debugger = RobustaPod(
             apiVersion="v1",
@@ -321,9 +326,16 @@ class RobustaPod(Pod):
         cmd,
         debug_image=PYTHON_DEBUGGER_IMAGE,
         custom_annotations: Optional[Dict[str, str]] = None,
+        custom_volume_mounts: Optional[List[VolumeMount]] = None,
+        custom_volumes: Optional[List[Volume]] = None,
     ) -> str:
         debugger = RobustaPod.create_debugger_pod(
-            pod_name, node_name, debug_image, custom_annotations=custom_annotations
+            pod_name,
+            node_name,
+            debug_image,
+            custom_annotations=custom_annotations,
+            custom_volume_mounts=custom_volume_mounts,
+            custom_volumes=custom_volumes,
         )
         try:
             return debugger.exec(cmd)


### PR DESCRIPTION
example config
```
customPlaybooks:
- triggers:
  - on_prometheus_alert:
      alert_name: PodNotReady
  actions:
  - bash_enricher:
      bash_command: cat /etc/secrets/hello.txt
      custom_volume_mounts:
        - name: hello-world-secret-volume
          mountPath: "/etc/secrets"
          readOnly: true
      custom_volumes:
        - name: hello-world-secret-volume
          secret:
            secretName: hello-world-secret
```
<img width="814" alt="Screen Shot 2025-01-20 at 11 58 05" src="https://github.com/user-attachments/assets/91273434-daa3-4b9c-987e-a986f3e28c3b" />
