### PR TITLE
[MAIN-2678] Fixing missing slack sink workload

### DIFF
--- a/src/robusta/core/discovery/top_service_resolver.py
+++ b/src/robusta/core/discovery/top_service_resolver.py
@@ -1,7 +1,7 @@
 import threading
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic.main import BaseModel
 
@@ -65,6 +65,14 @@ class TopServiceResolver:
         for cached_resource in cls.__namespace_to_resource[namespace]:
             if name.startswith(cached_resource.name):
                 return cached_resource
+        return None
+
+    @classmethod
+    def guess_workload_from_labels(cls, labels: Dict[Any, Any] = None) -> Optional[TopLevelResource]:
+        relevant_label_keys = ["job_name", "deployment", "statefulset", "daemonset", "pod"]
+        for label in relevant_label_keys:
+            if label in labels:
+                return labels[label]
         return None
 
     @classmethod

--- a/src/robusta/core/reporting/base.py
+++ b/src/robusta/core/reporting/base.py
@@ -282,6 +282,7 @@ class Finding(Filterable):
         self.enrichments: List[Enrichment] = []
         self.links: List[Link] = []
         self.service = TopServiceResolver.guess_cached_resource(name=subject.name, namespace=subject.namespace)
+        self.backup_workload_name = TopServiceResolver.guess_workload_from_labels(labels=silence_labels)
         self.service_key = self.service.get_resource_key() if self.service else ""
         uri_path = f"services/{self.service_key}?tab=grouped" if self.service_key else "graphs"
         self.investigate_uri = f"{ROBUSTA_UI_DOMAIN}/{uri_path}"

--- a/src/robusta/core/sinks/slack/slack_sink.py
+++ b/src/robusta/core/sinks/slack/slack_sink.py
@@ -42,7 +42,7 @@ class SlackSink(SinkBase):
             investigate_uri = self.get_timeline_uri(self.account_id, self.cluster_name)
             finding_data = finding.attribute_map
             # The top level entity name (the owner of the pod etc)
-            finding_data["workload"] = finding.service.name if finding.service else None
+            finding_data["workload"] = finding.service.name if finding.service else finding.backup_workload_name
             finding_data["cluster"] = self.cluster_name
             resolved = finding.title.startswith("[RESOLVED]")
 
@@ -112,19 +112,13 @@ class SlackSink(SinkBase):
                     blocks[i] = {
                         "type": "section",
                         "block_id": block_id,
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": message_string
-                        }
+                        "text": {"type": "mrkdwn", "text": message_string},
                     }
                     break
 
             # Call the shorter update function
             return self.slack_sender.update_slack_message(
-                channel=channel_id,
-                ts=message_ts,
-                blocks=blocks,
-                text=message_string
+                channel=channel_id, ts=message_ts, blocks=blocks, text=message_string
             )
 
         except Exception as e:


### PR DESCRIPTION
if the workload does not exist, like the pod or deployment is deleted it falls back to using the prometheus labels for sinc matching