### PR TITLE
ROB-1100: running krr on openshift, using prometheus auth 

### DIFF
--- a/playbooks/robusta_playbooks/krr.py
+++ b/playbooks/robusta_playbooks/krr.py
@@ -295,7 +295,8 @@ def krr_scan(event: ExecutionBaseEvent, params: KRRParams):
     env_var: List[EnvVar] = []
     secret: Optional[JobSecret] = None
 
-    if IS_OPENSHIFT:
+    if IS_OPENSHIFT and params.prometheus_auth is None:
+        # if openshift, and the user didn't define auth header, use openshift token
         python_command += " --openshift"
     else:
         # adding env var of auth token from Secret


### PR DESCRIPTION
support running krr on openshift, using prometheus auth provided by the user