### PR TITLE
Resolve logger warnings

### DIFF
--- a/src/robusta/integrations/jira/client.py
+++ b/src/robusta/integrations/jira/client.py
@@ -150,7 +150,7 @@ class JiraClient:
 
         issue = issues.get("issues")[0]
         if issues.get("total", 0) > 1:
-            logging.warn(f"More than one issue found for query: '{query}', picking most recent one")
+            logging.warning(f"More than one issue found for query: '{query}', picking most recent one")
             logging.debug(f"Picked issue '{issue}'")
 
         return issue


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
