### PR TITLE
[ROB-1529] httpx.RemoteProtocolError: Server disconnected

### DIFF
--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -94,7 +94,6 @@ class SupabaseDal(AccountResourceFetcher):
         # This is somewhat hacky.
         def execute_with_retry(_self):
             try:
-                self.client = create_client(self.url, self.key, self.options)
                 return self._original_execute(_self)
             except PostgrestAPIError as exc:
                 message = exc.message or ""

--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -76,7 +76,6 @@ class SupabaseDal(AccountResourceFetcher):
         self.key = key
         self.account_id = account_id
         self.cluster = cluster_name
-        self.client = create_client(url, key, options)
         self.options = ClientOptions(postgrest_client_timeout=SUPABASE_TIMEOUT_SECONDS, auto_refresh_token=True)
         self.client = create_client(url, key, self.options)
         self.patch_postgrest_execute()

--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -110,7 +110,7 @@ class SupabaseDal(AccountResourceFetcher):
                 # We close the session to force a new connection, then retry the request once.
                 logging.warning(f"RemoteProtocolError: {exc} — reconnecting and retrying once.")
                 try:
-                    self.client.auth.session.close()  # 🧹 Clears stale connection pool
+                    self.client.postgrest.session.close()  # 🧹 Clears stale connection pool
                 except Exception as close_exc:
                     logging.warning(f"Failed to close session cleanly: {close_exc}")
                 return self._original_execute(_self)

--- a/src/robusta/core/sinks/robusta/dal/supabase_dal.py
+++ b/src/robusta/core/sinks/robusta/dal/supabase_dal.py
@@ -107,9 +107,9 @@ class SupabaseDal(AccountResourceFetcher):
             except RemoteProtocolError as exc:
                 # A RemoteProtocolError occurs when httpx tries to reuse a stale HTTP/2 connection
                 # that the Supabase server has silently closed (e.g., after keep-alive timeout).
-                # We close the session to force a new connection, then retry the request once.
-                logging.warning(f"RemoteProtocolError: {exc} — recreating client and retrying.")
-                self.client = create_client(self.url, self.key, self.options)
+                # We recreate the client to force a new connection, then retry the request again.
+                logging.warning(f"RemoteProtocolError: {exc} — signing in to Supabase again.")
+                self.sign_in()
                 return self._original_execute(_self)
 
         self._original_execute = SyncQueryRequestBuilder.execute


### PR DESCRIPTION
**Workaround for `RemoteProtocolError` on Supabase client (httpx/http2):**

This change doesn't prevent the `RemoteProtocolError` from happening, but it mitigates its impact until Supabase or the underlying libraries release a proper fix.

Supabase support pointed users with the same issue to [this open issue](https://github.com/supabase/supabase-py/issues/1064#issuecomment-2808524885), which traces the problem to how the `httpx` client handles HTTP/2 connections. Specifically, HTTP/2 reuses long-lived connections, but if the Supabase server silently closes an idle connection (e.g., after a keep-alive timeout), `httpx` may attempt to reuse the now-dead connection, triggering a `RemoteProtocolError`.

To work around this:

* We catch the `RemoteProtocolError` and insert a short delay (`sleep`) before retrying.
* This gives `httpx` time to recognize and discard the stale connection, so the retry creates a fresh one.
⚠️ Note: If the original request was processed successfully on the server but the client disconnected before receiving the response, retrying may lead to duplicate inserts or unique constraint violations. This occurs in over 30% of retries when inserting findings—an acceptable outcome, as it confirms the finding was already stored.

References:

* [https://github.com/supabase/supabase-py/issues/1064](https://github.com/supabase/supabase-py/issues/1064)
* [https://github.com/encode/httpx/issues/2983](https://github.com/encode/httpx/issues/2983)
* [https://github.com/encode/httpx/discussions/2056](https://github.com/encode/httpx/discussions/2056)
