### PR TITLE
[ROB-1458] solves match issues with prefix is other match

### DIFF
--- a/src/robusta/core/discovery/top_service_resolver.py
+++ b/src/robusta/core/discovery/top_service_resolver.py
@@ -62,10 +62,17 @@ class TopServiceResolver:
         if name is None or namespace is None:
             return None
 
-        for cached_resource in cls.__namespace_to_resource[namespace]:
+        longest_match = None
+        max_length = -1
+
+        for cached_resource in cls.__namespace_to_resource.get(namespace, []):
             if name.startswith(cached_resource.name):
-                return cached_resource
-        return None
+                match_length = len(cached_resource.name)
+                if match_length > max_length:
+                    longest_match = cached_resource
+                    max_length = match_length
+
+        return longest_match
 
     @classmethod
     def add_cached_resource(cls, resource: TopLevelResource):


### PR DESCRIPTION
aka
deployment-123-456 alerts wont resolve for deployment deployment-123 now
before change all alerts resolved for deployment verification, even. for verification-small
test 1-4 are all on different deployments
![Screenshot 2025-06-29 at 10 03 43](https://github.com/user-attachments/assets/03fdc5cf-e940-45cd-ae61-c8b90d9c37fd)
after change alerts resolved to actual subject
tests 5-8 are all on different deployments
![Screenshot 2025-06-29 at 10 05 24](https://github.com/user-attachments/assets/2fdef725-83b2-490b-8622-4ea8cc38c85d)
