### PR TITLE
Fix broken generator urls

### DIFF
--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -224,11 +224,11 @@ def minimal_default_enricher(alert: PrometheusKubernetesAlert):
 def is_valid_url(url: str) -> bool:
     """
     Check if a URL is valid for use in Slack messages.
-    Validates that the URL has both scheme and netloc components.
+    Validates that the URL has HTTP/HTTPS scheme and netloc components.
     """
     try:
         parsed = urlparse(url)
-        return bool(parsed.scheme and parsed.netloc)
+        return bool(parsed.scheme in ('http', 'https') and parsed.netloc)
     except Exception:
         return False
 

--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime
 from string import Template
 from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
 
 import requests
 from hikaru.model.rel_1_26 import Node
@@ -220,6 +221,18 @@ def minimal_default_enricher(alert: PrometheusKubernetesAlert):
     alert.add_enrichment([])
 
 
+def is_valid_url(url: str) -> bool:
+    """
+    Check if a URL is valid for use in Slack messages.
+    Validates that the URL has both scheme and netloc components.
+    """
+    try:
+        parsed = urlparse(url)
+        return bool(parsed.scheme and parsed.netloc)
+    except Exception:
+        return False
+
+
 @action
 def default_enricher(alert: PrometheusKubernetesAlert, params: DefaultEnricherParams):
     """
@@ -228,7 +241,10 @@ def default_enricher(alert: PrometheusKubernetesAlert, params: DefaultEnricherPa
     By default, this enricher is last in the processing order, so it will be added to all alerts, that aren't silenced.
     """
     if alert.alert.generatorURL and params.alert_generator_link:
-        alert.add_link(Link(url=alert.alert.generatorURL, name="View Graph", type=LinkType.PROMETHEUS_GENERATOR_URL))
+        if is_valid_url(alert.alert.generatorURL):
+            alert.add_link(Link(url=alert.alert.generatorURL, name="View Graph", type=LinkType.PROMETHEUS_GENERATOR_URL))
+        else:
+            logging.debug(f"Skipping invalid generator URL: {alert.alert.generatorURL}")
 
     labels = alert.alert.labels
     alert.add_enrichment(

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -1,0 +1,37 @@
+import pytest
+from playbooks.robusta_playbooks.alerts_integration import is_valid_url
+
+
+class TestUrlValidation:
+    """Test URL validation for alert generator URLs."""
+
+    @pytest.mark.parametrize("url,expected", [
+        # Valid URLs
+        ("https://prometheus.example.com/graph?g0.expr=up", True),
+        ("http://localhost:9090/graph?g0.expr=rate(http_requests_total[5m])", True),
+        ("https://grafana.com/d/dashboard", True),
+        ("http://mimir.monitoring.svc.cluster.local:9009/graph?g0.expr=up", True),
+        ("https://loki.example.com/graph?g0.expr=count(up)", True),
+        ("ftp://example.com/file", True),  # Valid URL with scheme and netloc
+        
+        # Invalid URLs that should be rejected by Slack
+        ("?g0.expr=up", False),  # Missing scheme and netloc
+        ("/graph?g0.expr=up", False),  # Missing scheme and netloc
+        ("graph?g0.expr=up", False),  # Missing scheme and netloc
+        ("invalid-url", False),  # No scheme or netloc
+        ("", False),  # Empty string
+        ("://invalid", False),  # Invalid format
+        ("http://", False),  # Incomplete URL
+        ("https://", False),  # Incomplete URL
+    ])
+    def test_is_valid_url(self, url, expected):
+        """Test URL validation with various URL formats."""
+        assert is_valid_url(url) == expected
+
+    def test_is_valid_url_handles_exceptions(self):
+        """Test that URL validation handles malformed URLs gracefully."""
+        # None input should return False (handled by exception catching)
+        assert is_valid_url(None) == False
+        
+        # Malformed URLs should return False without raising exceptions
+        assert is_valid_url("http://[invalid-ipv6") == False

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -12,7 +12,6 @@ class TestUrlValidation:
         ("https://grafana.com/d/dashboard", True),
         ("http://mimir.monitoring.svc.cluster.local:9009/graph?g0.expr=up", True),
         ("https://loki.example.com/graph?g0.expr=count(up)", True),
-        ("ftp://example.com/file", True),  # Valid URL with scheme and netloc
         
         # Invalid URLs that should be rejected by Slack
         ("?g0.expr=up", False),  # Missing scheme and netloc
@@ -23,6 +22,9 @@ class TestUrlValidation:
         ("://invalid", False),  # Invalid format
         ("http://", False),  # Incomplete URL
         ("https://", False),  # Incomplete URL
+        ("ftp://example.com/file", False),  # Non-HTTP/HTTPS scheme
+        ("ssh://server.com", False),  # Non-HTTP/HTTPS scheme
+        ("file:///path/to/file", False),  # Non-HTTP/HTTPS scheme
     ])
     def test_is_valid_url(self, url, expected):
         """Test URL validation with various URL formats."""


### PR DESCRIPTION
Fixes issues reported in Slack community:
- https://robustacommunity.slack.com/archives/C02R0LSAHNJ/p1748594478453029
- https://robustacommunity.slack.com/archives/C02R0LVANKY/p1749111472763279

Users were seeing Slack errors like "invalid_blocks" and "invalid url"
when alerts from Mimir/Loki contained relative generator URLs.

Please test before merging.