### PR TITLE
Add prometheus discovery selector for standard k8s labels

### DIFF
--- a/src/robusta/integrations/prometheus/utils.py
+++ b/src/robusta/integrations/prometheus/utils.py
@@ -137,6 +137,7 @@ class PrometheusDiscovery(ServiceDiscovery):
             selectors=[
                 "app=kube-prometheus-stack-prometheus",
                 "app=prometheus,component=server,release!=kubecost",
+                "app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server",
                 "app=prometheus-server",
                 "app=prometheus-operator-prometheus",
                 "app=rancher-monitoring-prometheus",


### PR DESCRIPTION
Add's Prometheus auto discovery for `prometheus-community/prometheus` Helm chart 

<img width="2964" height="155" alt="CleanShot 2025-07-24 at 11 30 53@2x" src="https://github.com/user-attachments/assets/5beacb41-0e31-4b42-9408-fd4859699605" />

<img width="2630" height="1632" alt="CleanShot 2025-07-24 at 11 46 13@2x" src="https://github.com/user-attachments/assets/c53c82bc-405e-4b9e-beee-4b1b0e9679d1" />
