### PR TITLE
feat: runner binding address configurable using env variable

### DIFF
--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -88,7 +88,7 @@ SERVICE_CACHE_TTL_SEC = int(os.environ.get("SERVICE_CACHE_TTL_SEC", 900))
 SERVICE_CACHE_MAX_SIZE = int(os.environ.get("SERVICE_CACHE_MAX_SIZE", 1000))
 
 PORT = int(os.environ.get("PORT", 5000))  # PORT
-RUNNER_BIND_ADDR = os.environ.get("RUNNER_BIND_ADDR", "127.0.0.1")  # Listen address for runner
+RUNNER_BIND_ADDR = os.environ.get("RUNNER_BIND_ADDR", "0.0.0.0")  # Listen address for runner
 
 # additional certificate to verify, base64 encoded.
 ADDITIONAL_CERTIFICATE: str = os.environ.get("CERTIFICATE", "")

--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -88,6 +88,7 @@ SERVICE_CACHE_TTL_SEC = int(os.environ.get("SERVICE_CACHE_TTL_SEC", 900))
 SERVICE_CACHE_MAX_SIZE = int(os.environ.get("SERVICE_CACHE_MAX_SIZE", 1000))
 
 PORT = int(os.environ.get("PORT", 5000))  # PORT
+RUNNER_BIND_ADDR = os.environ.get("RUNNER_BIND_ADDR", "127.0.0.1")  # Listen address for runner
 
 # additional certificate to verify, base64 encoded.
 ADDITIONAL_CERTIFICATE: str = os.environ.get("CERTIFICATE", "")

--- a/src/robusta/runner/web.py
+++ b/src/robusta/runner/web.py
@@ -11,7 +11,7 @@ from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from robusta.clients.robusta_client import fetch_runner_info
 from robusta.core.model.env_vars import NUM_EVENT_THREADS, PORT, TRACE_INCOMING_ALERTS, TRACE_INCOMING_REQUESTS, \
-    PROCESSED_ALERTS_CACHE_TTL, PROCESSED_ALERTS_CACHE_MAX_SIZE, RUNNER_VERSION
+    PROCESSED_ALERTS_CACHE_TTL, PROCESSED_ALERTS_CACHE_MAX_SIZE, RUNNER_VERSION, RUNNER_BIND_ADDR
 from robusta.core.playbooks.playbooks_event_handler import PlaybooksEventHandler
 from robusta.core.triggers.helm_releases_triggers import HelmReleasesTriggerEvent, IncomingHelmReleasesEventPayload
 from robusta.integrations.kubernetes.base_triggers import IncomingK8sEventPayload, K8sTriggerEvent
@@ -68,7 +68,7 @@ class Web:
 
     @staticmethod
     def run():
-        app.run(host="0.0.0.0", port=PORT, use_reloader=False)
+        app.run(host=RUNNER_BIND_ADDR, port=PORT, use_reloader=False)
 
     @classmethod
     def _relabel_alert(cls, alert: PrometheusAlert) -> PrometheusAlert:


### PR DESCRIPTION
Hi, 

On AWS EKS, you have the ability to create Kubernetes cluster with IPV6 stack only. 
This behavior prevent robusta runner to be reachable by the forwarder since it listen to an IPV4 address.

This PR allow the user to change the bind address for the runner. The default behavior of the runner is unchanged.