### PR TITLE
Update bash_enrichments.py - add sshexecutor

### DIFF
--- a/playbooks/robusta_playbooks/bash_enrichments.py
+++ b/playbooks/robusta_playbooks/bash_enrichments.py
@@ -40,3 +40,39 @@ def node_bash_enricher(event: NodeEvent, params: BashParams):
     block_list.append(MarkdownBlock(f"Command results for *{params.bash_command}:*"))
     block_list.append(MarkdownBlock(exec_result))
     event.add_enrichment(block_list)
+
+
+@action
+def generic_bash_enricher(event: ExecutionBaseEvent, params):
+    """
+    Run any bash command on the runner (can include SSH to remote hosts if desired).
+    Params:
+      bash_command: List of command args (recommended), or string for shell execution.
+    """
+    bash_command = params.get("bash_command")
+    if not bash_command:
+        event.add_enrichment([MarkdownBlock(":warning: `bash_command` param is required!")])
+        return
+
+    try:
+        if isinstance(bash_command, str):
+            result = subprocess.run(bash_command, shell=True, capture_output=True, text=True)
+        else:
+            result = subprocess.run(bash_command, capture_output=True, text=True)
+        output = result.stdout.strip()
+        error = result.stderr.strip()
+        status = result.returncode
+    except Exception as e:
+        output = ""
+        error = str(e)
+        status = 1
+
+    message = (
+        f"**Generic Bash Enricher**\n"
+        f"Command: `{bash_command}`\n"
+        f"Return code: `{status}`\n"
+        f"---\n"
+        f"**STDOUT:**\n```\n{output}\n```\n"
+        f"**STDERR:**\n```\n{error}\n```"
+    )
+    event.add_enrichment([MarkdownBlock(message)])


### PR DESCRIPTION
This function allows to execute commands via SSH, usually when you have VMs or servers outside Kubernetes !

How to use ?

```customPlaybooks:
  - triggers:
      - on_prometheus_alert:
          alert_name: Solana-Service-Down
    actions:
      - generic_bash_enricher:
          bash_command:
            - ssh
            - -i
            - /mnt/ssh/id_rsa
            - -o
            - StrictHostKeyChecking=no
            - root@your-remote-ip
            - ls /tmp```