### PR TITLE
Encode URL in `add_link`

### DIFF
--- a/src/robusta/core/reporting/base.py
+++ b/src/robusta/core/reporting/base.py
@@ -16,6 +16,7 @@ from robusta.core.discovery.top_service_resolver import TopServiceResolver
 from robusta.core.model.env_vars import ROBUSTA_UI_DOMAIN
 from robusta.core.reporting.consts import FindingSource, FindingSubjectType, FindingType
 from robusta.integrations.kubernetes.api_client_utils import get_namespace_labels
+from robusta.utils.common import encode_url
 from robusta.utils.scope import BaseScopeMatcher
 
 
@@ -361,6 +362,7 @@ class Finding(Filterable):
     def add_link(self, link: Link, suppress_warning: bool = False) -> None:
         if self.dirty and not suppress_warning:
             logging.warning("Updating a finding after it was added to the event is not allowed!")
+        link.url = encode_url(link.url)
         self.links.append(link)
 
     def add_video_link(self, video_link: Link, suppress_warning: bool = False) -> None:

--- a/src/robusta/core/sinks/transformer.py
+++ b/src/robusta/core/sinks/transformer.py
@@ -1,11 +1,12 @@
 import logging
 import re
-import urllib.parse
 from typing import List, Optional, Union
 
 import markdown2
 from fpdf import FPDF
 from fpdf.fonts import FontFace
+
+from robusta.utils.common import encode_url
 
 try:
     from tabulate import tabulate
@@ -122,9 +123,8 @@ class Transformer:
             # take only the data between the first '<' and last '>'
             splits = match[1:-1].split("|")
             if len(splits) == 2:  # don't replace unexpected strings
-                parsed_url = urllib.parse.urlparse(splits[0])
-                parsed_url = parsed_url._replace(path=urllib.parse.quote_plus(parsed_url.path, safe="/"))
-                replacement = f"[{splits[1]}]({OPENING_ANGULAR}{parsed_url.geturl()}{CLOSING_ANGULAR})"
+                encoded_url = encode_url(splits[0])
+                replacement = f"[{splits[1]}]({OPENING_ANGULAR}{encoded_url}{CLOSING_ANGULAR})"
                 markdown_data = markdown_data.replace(match, replacement)
         return re.sub(r"\*([^\*]*)\*", r"**\1**", markdown_data)
 

--- a/src/robusta/utils/common.py
+++ b/src/robusta/utils/common.py
@@ -1,4 +1,5 @@
 import re
+import urllib.parse
 from typing import List
 
 from hikaru import DiffDetail, HikaruBase
@@ -41,3 +42,23 @@ def duplicate_without_fields(obj: HikaruBase, omitted_fields: List[str]):
             pass  # in case the field doesn't exist on this object
 
     return duplication
+
+
+def encode_url(url: str) -> str:
+    """
+    Encode a URL so that it can be safely used in contexts where special characters must be escaped.
+    """
+    if not url:
+        return ""
+
+    parsed_url = urllib.parse.urlsplit(url)
+
+    encoded_path = urllib.parse.quote(parsed_url.path)
+    encoded_query = urllib.parse.quote_plus(parsed_url.query, safe="=&")
+    encoded_fragment = urllib.parse.quote(parsed_url.fragment, safe="")
+
+    return parsed_url._replace(
+        path=encoded_path,
+        query=encoded_query,
+        fragment=encoded_fragment
+    ).geturl()


### PR DESCRIPTION
This PR includes URL encoding/quoting before adding a link to a finding.

The original motivation for this PR is a problem I've encountered with Slack links (which I'll describe promptly), but I guess non-encoded URLs may cause an issue with other sinks as well, so a general solution is preferred.

The mentioned Slack problem is as follows:
Robusta produces a "View Graph" button with a URL including unescaped braces, but these characters don't behave nicely with Slack.
Specifically, on the Slack android app, clicking the "View Graph" button will do nothing. (But it works just fine from a browser.)
<details>
<summary>Here are Slack blocks to demonstrate the problem</summary>

```json
{
	"blocks": [
		{
			"type": "actions",
			"elements": [
				{
					"type": "button",
					"text": {
						"type": "plain_text",
						"text": "Won't work from Android app"
					},
					"url": "https://google.com?q={",
					"action_id": "actionId-0"
				}
			]
		},
		{
			"type": "actions",
			"elements": [
				{
					"type": "button",
					"text": {
						"type": "plain_text",
						"text": "Works from Android app"
					},
					"url": "https://google.com?q=",
					"action_id": "actionId-1"
				}
			]
		}
	]
}
```
</details>

As mentioned above, the specific Slack problem is not the main point (you could even say it's an issue in Slack), but it would be good practice to encode the URL before sending it to a sink.