### PR TITLE
fix(docs): fixing typo in playbook-reference

### DIFF
--- a/docs/playbook-reference/index.rst
+++ b/docs/playbook-reference/index.rst
@@ -260,7 +260,7 @@ By default, Robusta has a default set of ``playbooks`` configured. These are use
 
 You can disable any of the ``default playbooks``, or change the configuration of a given ``playbook``.
 
-In order to disable a default playbook, add the playbook name to the ``disabledPlayooks`` helm value (Playbook name is in the ``name`` attribute of each playbook)
+In order to disable a default playbook, add the playbook name to the ``disabledPlaybooks`` helm value (Playbook name is in the ``name`` attribute of each playbook)
 
 For example, to disable the ``ImagePullBackOff`` playbook, use:
 


### PR DESCRIPTION
Tiny fix in the docs.

I blindly copy-pasted this string and then debugged for hours why some playbooks were not disabled anyways.