### PR TITLE
chore(helm): define pod probes

### DIFF
--- a/docs/playbook-reference/prometheus-examples/link-alert-enrichment.rst
+++ b/docs/playbook-reference/prometheus-examples/link-alert-enrichment.rst
@@ -32,6 +32,7 @@ Below there are three alternatives ways to enrich the alert with links. Apply th
     - button_enricher:
         button_text: "Playbook for ${team}"
         button_url: "https://playbook-url/team/${team}"
+        required_label: "team"
 
 
 .. code-annotations::

--- a/playbooks/robusta_playbooks/alerts_integration.py
+++ b/playbooks/robusta_playbooks/alerts_integration.py
@@ -419,9 +419,13 @@ class TemplatedButtonParams(ActionParams):
     """
     :var button_text: The templated text of the button
     :var button_url: The templated URL of the button
+    :var required_label: Optional label name that must exist and have a non-empty
+                         value for the button to be added. When not set, the
+                         button is evaluated for every alert.
     """
     button_text: str
     button_url: str
+    required_label: Optional[str] = None
 
 
 @action
@@ -437,10 +441,18 @@ def button_enricher(event: KubernetesResourceEvent, params: TemplatedButtonParam
 
     If the button_url is empty, then the button will not be added.
 
+    When params.required_label is set, the button will only be added if that
+    label exists in the alert/event labels and has a non-empty value. This can
+    be used to conditionally show buttons based on alert metadata.
+
     Check example for adding a template link.
 
     """
     labels = _get_labels(event, default_value="")
+    if params.required_label:
+        label_value = labels.get(params.required_label, "")
+        if label_value is None or (isinstance(label_value, str) and label_value.strip() == ""):
+            return
     button_text = Template(params.button_text).safe_substitute(labels)
     button_url = Template(params.button_url).safe_substitute(labels)
     if button_url.strip() != "":


### PR DESCRIPTION
## Description

When robusta starts, the pod becomes healthy immediately. After a few seconds, it loads the config and the pydantic validations run on those configs. If there's an error, the container can immediately fail leaving no running robusta pod behind (not good).

If we want to make sure the rolling our a new version is graceful, we can define a readiness probe or even just a bit of a delay (to wait a few seconds until robusta loads the configs, making sure there's no validation error here).

## Testing

Currently in progress