### PR TITLE
feat: Enable per-alert Incident Severity, metadata improvements

### DIFF
--- a/src/robusta/core/sinks/incidentio/incidentio_sink.py
+++ b/src/robusta/core/sinks/incidentio/incidentio_sink.py
@@ -1,3 +1,7 @@
+"""
+Incident.io sink for Robusta.
+"""
+
 import logging
 from typing import Optional, Dict, List, Any
 from robusta.core.sinks.incidentio.incidentio_client import IncidentIoClient
@@ -5,11 +9,10 @@ from robusta.core.sinks.incidentio.incidentio_sink_params import IncidentioSinkP
 from robusta.core.sinks.incidentio.incidentio_api import AlertEventsApi
 from robusta.core.sinks.sink_base import SinkBase
 
-from robusta.core.reporting.base import BaseBlock, Finding, FindingSeverity, Enrichment, Link, LinkType
+from robusta.core.reporting.base import BaseBlock, Finding
 from robusta.core.reporting.blocks import (
     HeaderBlock,
     JsonBlock,
-    LinksBlock,
     ListBlock,
     MarkdownBlock,
     TableBlock,
@@ -18,14 +21,17 @@ from robusta.core.reporting.blocks import (
 
 
 class IncidentioSink(SinkBase):
+    """
+    Incident.io sink for Robusta.
+    """
+
     params: IncidentioSinkParams
 
     def __init__(self, sink_config: IncidentioSinkConfigWrapper, registry):
         super().__init__(sink_config.incidentio_sink, registry)
         self.source_config_id = sink_config.incidentio_sink.source_config_id
         self.client = IncidentIoClient(
-            base_url=sink_config.incidentio_sink.base_url,
-            token=sink_config.incidentio_sink.token
+            base_url=sink_config.incidentio_sink.base_url, token=sink_config.incidentio_sink.token
         )
 
     @staticmethod
@@ -34,7 +40,6 @@ class IncidentioSink(SinkBase):
         if title.startswith("[RESOLVED]"):
             return "resolved"
         return "firing"
-    
 
     def __send_event_to_incidentio(self, finding: Finding, platform_enabled: bool) -> dict:
         metadata: Dict[str, Any] = {}
@@ -58,36 +63,49 @@ class IncidentioSink(SinkBase):
         metadata["source"] = finding.source.name
         metadata["fingerprint_id"] = finding.fingerprint
 
-        # Convert blocks to metadata
+        # Convert blocks to metadata as structured array
+        additional_info_list = []
         for enrichment in finding.enrichments:
             for block in enrichment.blocks:
                 text = self.__to_unformatted_text(block)
                 if text:
-                    metadata["additional_info"] = metadata.get("additional_info", "") + text + "\n"
+                    block_type = self.__get_block_type_name(block)
+                    additional_info_list.append({"type": block_type, "content": text})
 
-        return {
+        if additional_info_list:
+            metadata["additional_info"] = additional_info_list
+
+        payload = {
             "deduplication_key": finding.fingerprint,
             "title": finding.title,
             "description": finding.description or "No description provided.",
             "status": self.__to_incidentio_status_type(finding.title),
             "metadata": metadata,
-            "source_url": finding.get_investigate_uri(self.account_id, self.cluster_name),
             "links": links,
         }
+
+        if platform_enabled:
+            payload["source_url"] = finding.get_investigate_uri(self.account_id, self.cluster_name)
+
+        return payload
 
     def write_finding(self, finding: Finding, platform_enabled: bool) -> None:
         payload = self.__send_event_to_incidentio(finding, platform_enabled)
 
         response = self.client.request(
-            "POST",
-            AlertEventsApi(self.client.base_url, self.source_config_id).build_url(),
-            payload
+            "POST", AlertEventsApi(self.client.base_url, self.source_config_id).build_url(), payload
         )
 
         if not response.ok:
-            logging.error(
-                f"Error sending alert to Incident.io: {response.status_code}, {response.text}"
-            )
+            logging.error("Error sending alert to Incident.io: %s, %s", {response.status_code}, {response.text})
+
+    @staticmethod
+    def __get_block_type_name(block: BaseBlock) -> str:
+        """Extract the block type name, removing 'Block' suffix if present."""
+        class_name = block.__class__.__name__
+        if class_name.endswith("Block"):
+            return class_name[:-5].lower()  # Remove 'Block' suffix and convert to lowercase
+        return class_name.lower()
 
     @staticmethod
     def __to_unformatted_text(block: BaseBlock) -> Optional[str]:
@@ -103,4 +121,40 @@ class IncidentioSink(SinkBase):
             return block.json_str
         elif isinstance(block, KubernetesDiffBlock):
             return "\n".join(diff.formatted_path for diff in block.diffs)
+        else:
+            # Handle additional block types dynamically
+            block_class = block.__class__.__name__
+
+            # FileBlock: has file_content attribute
+            if hasattr(block, "file_content") and block.file_content:
+                return block.file_content
+
+            # EmptyFileBlock: just return a placeholder
+            elif block_class == "EmptyFileBlock":
+                return "[Empty File]"
+
+            # PrometheusBlock: has query results
+            elif hasattr(block, "query") and hasattr(block, "series_data"):
+                return f"Query: {block.query}\nResults: {len(block.series_data)} series"
+
+            # ScanReportBlock: has scan results
+            elif hasattr(block, "title") and hasattr(block, "score"):
+                return f"Scan: {block.title}, Score: {block.score}"
+
+            # CallbackBlock: has callback info
+            elif hasattr(block, "action_name"):
+                return f"Action: {block.action_name}"
+
+            # DividerBlock: just a visual separator
+            elif block_class == "DividerBlock":
+                return "[Divider]"
+
+            # Generic fallback: try to get text content from common attributes
+            elif hasattr(block, "text"):
+                return block.text
+            elif hasattr(block, "content"):
+                return str(block.content)
+            elif hasattr(block, "message"):
+                return block.message
+
         return None


### PR DESCRIPTION
### Changes
This PR improves on existing Incident.io implementation and allows to define per-alert incident severity in Incident.io (until now severity was determined by the alert severity, however not all alerts with the critical severity should have the same Incident.io severity).

The following configurational changes were made:
1. `severity_alert_label_name` - label on the alert that will contain information about Incident.io severity. Default set to `robusta_incidentio_severity`. 
2. `severity_default` - sane default in case when label is not defined
3. `dashboard_url_annotation_name` - Incident.io has something called the `source_url`. Usually, that can be a link toward Grafana dashboard or anything else. In this case, it is a name of the alert annotation. Default set to `dashboard_url`.
4. `runbook_url_annotation_name` - same as with the Dashboard URL, stored as metadata information that can be extracted and parsed in Incident.io interface.
5. Added `metadata["additional_info"]` for passing additional metadata information to Incident.io

Please note that severity names must be mapped in the Incident.io interface (whatever you pass  - minor, major, critical) to the actual severity ID. 

These changes are running on our production for months without any issues. 

### Risks
None

### Performance impact
None

### Security impact
None

### How to QA
1. Configure Incident.io Sink
2. Send a few simulated requests
```
./robusta playbooks trigger prometheus_alert --namespace=monitoring alert_name="IncidentIoSeverityTesting" severity=critical labels="robusta_incidentio_severity:major"
./robusta playbooks trigger prometheus_alert --namespace=monitoring alert_name="IncidentIoSeverityTesting" severity=critical labels="robusta_incidentio_severity:major" annotations="dashboard_url=https://grafana.com,runbook_url=https://google.com"
```
3. Go to Incident.io UI, find alerts and inspect payload

