### PR TITLE
Prevent duplicate CI runs in test_robusta workflow

### DIFF
--- a/.github/workflows/test_robusta.yaml
+++ b/.github/workflows/test_robusta.yaml
@@ -1,6 +1,10 @@
 name: Test robusta with pytest
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
Configure workflow to only run on pushes to master branch and all pull requests. This prevents duplicate runs when pushing to a PR branch (both push and pull_request events).

Before - 2 test of each kind that were the same

<img width="843" height="448" alt="Screenshot 2026-01-14 at 16 45 03" src="https://github.com/user-attachments/assets/fe974e27-7233-4562-9768-2b84697a247d" />

After - only 1 test of each kind!

<img width="843" height="448" alt="Screenshot 2026-01-14 at 17 10 30" src="https://github.com/user-attachments/assets/fab4e674-88a2-4566-8fef-4e4b0eece7ac" />

