### PR TITLE
[ROB-3081] Update webhook configs with HTTP authorization

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@
    Dynatrace <configuration/alertmanager-integration/dynatrace>
    Embedded Prometheus Stack <configuration/alertmanager-integration/embedded-prometheus>
    Google Managed Prometheus <configuration/alertmanager-integration/google-managed-prometheus>
+   Google Managed Alertmanager <configuration/alertmanager-integration/google-managed-alertmanager>
    Grafana - Self-Hosted <configuration/alertmanager-integration/grafana-self-hosted>
    Grafana Cloud <configuration/alertmanager-integration/grafana-cloud>
    Nagios <configuration/alertmanager-integration/nagios>


### PR DESCRIPTION
Link the google-managed-alertmanager docs page in the main Send Alerts toctree so it appears in the documentation navigation.