### PR TITLE
ROB-3570: Add holmes_validate_toolset action for toolset validation

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -98,6 +98,7 @@ lightActions:
 - holmes_issue_chat
 - holmes_chat
 - holmes_validate_toolset
+- holmes_refresh_toolsets
 - list_pods
 - kubectl_describe
 - fetch_resource_yaml

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -97,6 +97,7 @@ lightActions:
 - holmes_conversation
 - holmes_issue_chat
 - holmes_chat
+- holmes_validate_toolset
 - list_pods
 - kubectl_describe
 - fetch_resource_yaml

--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -240,6 +240,12 @@ class HolmesValidateToolsetParams(HolmesParams):
     yaml_config: str
 
 
+class HolmesRefreshToolsetsParams(HolmesParams):
+    """Params for triggering a toolset status refresh via Holmes."""
+
+    pass
+
+
 class NamespacedResourcesParams(ActionParams):
     """
     :var name: Resource name

--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -232,6 +232,14 @@ class HolmesConversationParams(HolmesParams):
     include_tool_call_results: bool = True
 
 
+class HolmesValidateToolsetParams(HolmesParams):
+    """
+    :var yaml_config: Raw YAML string containing the toolset configuration, including the 'holmes:' wrapper.
+    """
+
+    yaml_config: str
+
+
 class NamespacedResourcesParams(ActionParams):
     """
     :var name: Resource name

--- a/src/robusta/core/playbooks/internal/ai_integration.py
+++ b/src/robusta/core/playbooks/internal/ai_integration.py
@@ -403,7 +403,7 @@ def holmes_validate_toolset(event: ExecutionBaseEvent, params: HolmesValidateToo
         result = requests.post(url, data=holmes_req.json())
         result.raise_for_status()
         holmes_response = HolmesValidateToolsetResponse(**json.loads(result.text))
-        event.ws(data=json.dumps(holmes_response.dict()))
+        event.response = {"success": True, **holmes_response.dict()}
 
     except Exception as e:
         logging.exception("Failed to validate toolset via Holmes", exc_info=True)

--- a/src/robusta/core/playbooks/internal/ai_integration.py
+++ b/src/robusta/core/playbooks/internal/ai_integration.py
@@ -12,6 +12,7 @@ from robusta.core.model.base_params import (
     HolmesChatParams,
     HolmesConversationParams,
     HolmesIssueChatParams,
+    HolmesValidateToolsetParams,
     ResourceInfo,
 )
 from robusta.core.model.events import ExecutionBaseEvent
@@ -33,6 +34,8 @@ from robusta.core.reporting.holmes import (
     HolmesRequest,
     HolmesResult,
     HolmesResultsBlock,
+    HolmesValidateToolsetRequest,
+    HolmesValidateToolsetResponse,
 )
 from robusta.core.reporting.utils import convert_svg_to_png
 from robusta.core.stream.utils import (
@@ -382,6 +385,28 @@ def holmes_chat(event: ExecutionBaseEvent, params: HolmesChatParams):
         logging.exception(
             f"Failed to get holmes chat for {cluster_name} cluster", exc_info=True
         )
+        handle_holmes_error(e)
+
+
+@action
+def holmes_validate_toolset(event: ExecutionBaseEvent, params: HolmesValidateToolsetParams):
+    holmes_url = HolmesDiscovery.find_holmes_url(params.holmes_url)
+    if not holmes_url:
+        raise ActionException(
+            ErrorCodes.HOLMES_DISCOVERY_FAILED,
+            "Robusta couldn't connect to the Holmes client.",
+        )
+
+    try:
+        holmes_req = HolmesValidateToolsetRequest(yaml_config=params.yaml_config)
+        url = f"{holmes_url}/api/toolsets/validate"
+        result = requests.post(url, data=holmes_req.json())
+        result.raise_for_status()
+        holmes_response = HolmesValidateToolsetResponse(**json.loads(result.text))
+        event.ws(data=json.dumps(holmes_response.dict()))
+
+    except Exception as e:
+        logging.exception("Failed to validate toolset via Holmes", exc_info=True)
         handle_holmes_error(e)
 
 

--- a/src/robusta/core/playbooks/internal/ai_integration.py
+++ b/src/robusta/core/playbooks/internal/ai_integration.py
@@ -12,6 +12,7 @@ from robusta.core.model.base_params import (
     HolmesChatParams,
     HolmesConversationParams,
     HolmesIssueChatParams,
+    HolmesRefreshToolsetsParams,
     HolmesValidateToolsetParams,
     ResourceInfo,
 )
@@ -407,6 +408,26 @@ def holmes_validate_toolset(event: ExecutionBaseEvent, params: HolmesValidateToo
 
     except Exception as e:
         logging.exception("Failed to validate toolset via Holmes", exc_info=True)
+        handle_holmes_error(e)
+
+
+@action
+def holmes_refresh_toolsets(event: ExecutionBaseEvent, params: HolmesRefreshToolsetsParams):
+    holmes_url = HolmesDiscovery.find_holmes_url(params.holmes_url)
+    if not holmes_url:
+        raise ActionException(
+            ErrorCodes.HOLMES_DISCOVERY_FAILED,
+            "Robusta couldn't connect to the Holmes client.",
+        )
+
+    try:
+        url = f"{holmes_url}/api/toolsets/refresh"
+        result = requests.post(url)
+        result.raise_for_status()
+        event.response = {"success": True}
+
+    except Exception as e:
+        logging.exception("Failed to refresh toolsets via Holmes", exc_info=True)
         handle_holmes_error(e)
 
 

--- a/src/robusta/core/reporting/holmes.py
+++ b/src/robusta/core/reporting/holmes.py
@@ -93,3 +93,20 @@ class HolmesChatResult(BaseModel):
 
 class HolmesChatResultsBlock(BaseBlock):
     holmes_result: Optional[HolmesChatResult]
+
+
+class HolmesValidateToolsetRequest(BaseModel):
+    yaml_config: str = Field(
+        description="Raw YAML string containing the toolset configuration, including the 'holmes:' wrapper."
+    )
+
+
+class HolmesValidateToolsetResult(BaseModel):
+    toolset_name: str
+    status: str = Field(description="Toolset status: 'enabled' or 'failed'")
+    error: Optional[str] = None
+    description: Optional[str] = None
+
+
+class HolmesValidateToolsetResponse(BaseModel):
+    results: List[HolmesValidateToolsetResult]

--- a/src/robusta/core/reporting/holmes.py
+++ b/src/robusta/core/reporting/holmes.py
@@ -103,7 +103,7 @@ class HolmesValidateToolsetRequest(BaseModel):
 
 class HolmesValidateToolsetResult(BaseModel):
     toolset_name: str
-    status: str = Field(description="Toolset status: 'enabled' or 'failed'")
+    status: str = Field(description="Toolset status: 'valid' or 'invalid'")
     error: Optional[str] = None
     description: Optional[str] = None
 

--- a/src/robusta/runner/config_loader.py
+++ b/src/robusta/runner/config_loader.py
@@ -281,7 +281,12 @@ class ConfigLoader:
                 )
                 # Kill the whole process group (which means this process and all of its descendant
                 # processes). The rest of the runner shutdown happens in robusta.runner.process_setup.
-                os.killpg(os.getpgid(0), signal.SIGTERM)
+                # os.killpg(os.getpgid(0), signal.SIGTERM)
+                if hasattr(os, "killpg"):
+                    os.killpg(os.getpgid(0), signal.SIGTERM)
+                else:
+                    os.kill(os.getpid(), signal.SIGTERM)
+
 
     @classmethod
     def __prepare_runtime_config(


### PR DESCRIPTION
## Changes

- **base_params.py**: Add `HolmesValidateToolsetParams` class to define parameters for toolset validation with `yaml_config` field
- **ai_integration.py**: Implement `holmes_validate_toolset` action that validates toolset configuration via Holmes API endpoint `/api/toolsets/validate`
- **holmes.py**: Add request/response models for toolset validation:
  - `HolmesValidateToolsetRequest`: Request model with YAML configuration
  - `HolmesValidateToolsetResult`: Individual toolset validation result
  - `HolmesValidateToolsetResponse`: Response wrapper containing list of validation results

## Details

This enables validation of Holmes toolset configurations through the Holmes API, with proper error handling and response serialization.