### PR TITLE
fix: replace bare except with except Exception (PEP 8 E722)

### DIFF
--- a/src/robusta/core/sinks/robusta/prometheus_discovery_utils.py
+++ b/src/robusta/core/sinks/robusta/prometheus_discovery_utils.py
@@ -73,7 +73,7 @@ class PrometheusDiscoveryUtils:
             value = query_result.vector_result[0]["value"]["value"]
             return_value = float("%.2f" % float(value))
             return return_value if return_value >= 0 else None
-        except:
+        except Exception:
             logging.exception("PrometheusDiscoveryUtils failed to get prometheus results.")
             return
 

--- a/src/robusta/core/sinks/transformer.py
+++ b/src/robusta/core/sinks/transformer.py
@@ -87,7 +87,7 @@ class Transformer:
     def apply_length_limit_to_markdown(msg: str, max_length: int, truncator: str = "...") -> str:
         try:
             return Transformer.trim_markdown(msg, max_length, truncator)
-        except:
+        except Exception:
             return Transformer.apply_length_limit(msg, max_length, truncator)
 
     @staticmethod

--- a/src/robusta/integrations/prometheus/models.py
+++ b/src/robusta/integrations/prometheus/models.py
@@ -39,7 +39,7 @@ def update_severity_map(global_config):
         custom_severity_map = global_config.get("custom_severity_map", {})
         for key in custom_severity_map.keys():
             SEVERITY_MAP[key] = FindingSeverity.from_severity(custom_severity_map[key].upper())
-    except:
+    except Exception:
         logging.exception("Failed to map custom severities")
 
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in three files:
- `src/robusta/core/sinks/transformer.py`
- `src/robusta/integrations/prometheus/models.py`
- `src/robusta/core/sinks/robusta/prometheus_discovery_utils.py`

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which can mask critical errors and make debugging harder. Using `except Exception:` is the PEP 8 recommended practice (E722) and preserves the ability to interrupt the program.

**Change:**
```python
# Before
except:
    ...

# After
except Exception:
    ...
```

## Testing
No behavior change for normal exception handling — this is a correctness/style fix that only affects the handling of `BaseException` subclasses like `KeyboardInterrupt`.