### PR TITLE
Add support for Kubernetes 1.34 LifecycleHandler.sleep field

### DIFF
--- a/src/robusta/patch/patch.py
+++ b/src/robusta/patch/patch.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import InitVar, dataclass, field, is_dataclass, _FIELD
+from dataclasses import InitVar, dataclass, field, is_dataclass
 from inspect import getmodule, signature
 from typing import Dict, List, Optional, Union, get_type_hints
 
@@ -71,7 +71,10 @@ def patch_lifecycle_handler_sleep():
     sleep_field = field(default=None)
     sleep_field.name = "sleep"
     sleep_field.type = Optional[SleepAction]
-    sleep_field._field_type = _FIELD
+    # Borrow _field_type from an existing field so dataclasses.fields() picks
+    # this one up, without importing the private dataclasses._FIELD sentinel.
+    existing_field = next(iter(LifecycleHandler.__dataclass_fields__.values()))
+    sleep_field._field_type = existing_field._field_type
     LifecycleHandler.__dataclass_fields__["sleep"] = sleep_field
 
     v1_pkg.SleepAction = SleepAction

--- a/src/robusta/patch/patch.py
+++ b/src/robusta/patch/patch.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import InitVar, is_dataclass
+from dataclasses import InitVar, dataclass, field, is_dataclass, _FIELD
 from inspect import getmodule, signature
 from typing import Dict, List, Optional, Union, get_type_hints
 
@@ -44,7 +44,41 @@ def create_monkey_patches():
     logging.info("Creating kubernetes ContainerImage monkey patch")
     EventsV1Event.event_time = EventsV1Event.event_time.setter(event_time)
     patch_on_pod_conditions()
+    patch_lifecycle_handler_sleep()
     monkey_patches_applied = True
+
+
+@dataclass
+class SleepAction(HikaruBase):
+    """LifecycleHandler.sleep action, GA in Kubernetes 1.34.
+
+    Hikaru's bundled v1 model (rel_1_26) predates this field, so we add it here
+    to ensure preStop/postStart sleep handlers are parsed and diffed correctly.
+    """
+
+    seconds: int = 0
+
+
+def patch_lifecycle_handler_sleep():
+    from hikaru.model.rel_1_26 import v1 as v1_pkg
+    from hikaru.model.rel_1_26.v1 import LifecycleHandler
+
+    if "sleep" in LifecycleHandler.__dataclass_fields__:
+        return
+
+    LifecycleHandler.__annotations__["sleep"] = Optional[SleepAction]
+    LifecycleHandler.sleep = None
+    sleep_field = field(default=None)
+    sleep_field.name = "sleep"
+    sleep_field.type = Optional[SleepAction]
+    sleep_field._field_type = _FIELD
+    LifecycleHandler.__dataclass_fields__["sleep"] = sleep_field
+
+    v1_pkg.SleepAction = SleepAction
+    v1_pkg.v1.SleepAction = SleepAction
+
+    LifecycleHandler.cached_args = None
+    LifecycleHandler.cached_hints = None
 
 
 def patch_on_pod_conditions():


### PR DESCRIPTION
## Summary
This PR adds support for the `sleep` field in Kubernetes 1.34's `LifecycleHandler`, which is not present in Hikaru's bundled v1.26 model. The patch ensures that preStop/postStart sleep handlers are correctly parsed and diffed.

## Key Changes
- **New `SleepAction` dataclass**: Created a dataclass to represent the `sleep` action with a `seconds` field, matching the Kubernetes 1.34 API specification
- **New `patch_lifecycle_handler_sleep()` function**: Dynamically patches the `LifecycleHandler` class to add the missing `sleep` field by:
  - Adding the field to the class annotations
  - Creating and registering a proper dataclass field with correct metadata
  - Clearing cached arguments and type hints to ensure proper serialization
  - Registering `SleepAction` in the v1 package namespace
- **Integration**: The patch is automatically applied during monkey patch initialization

## Implementation Details
- The patch uses dataclass field manipulation to inject the `sleep` field into the existing `LifecycleHandler` class
- Field metadata (`_field_type`, `name`, `type`) is properly configured to integrate seamlessly with Hikaru's dataclass infrastructure
- The implementation includes a guard check to prevent re-patching if the field already exists
- Cached class attributes are cleared to ensure Hikaru's serialization logic picks up the new field

https://claude.ai/code/session_013fifvjn134B8JQUK1EE9tG