### PR TITLE
Fix hardcoded alertmanager webhook URL to use Release.Name

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -788,7 +788,7 @@ kube-prometheus-stack:
         - name: 'null'
         - name:  'robusta'
           webhook_configs:
-            - url: 'http://robusta-runner.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/api/alerts'
+            - url: 'http://{{ .Release.Name }}-runner.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/api/alerts'
               send_resolved: true
     alertmanagerSpec:
       resources:


### PR DESCRIPTION
## Summary
- The alertmanager webhook URL was hardcoded to `robusta-runner`, which breaks when the Helm release name is not `robusta`
- Changed to use `{{ .Release.Name }}-runner` to match the actual runner service name generated by `{{ include "robusta.fullname" . }}-runner`

## Test plan
- [x] `helm template` verified the URL renders correctly (`test-release-runner.default.svc.cluster.local`)
- [ ] Deploy with a non-default release name and verify alertmanager routes to the correct runner service

🤖 Generated with [Claude Code](https://claude.com/claude-code)