### PR TITLE
Disable Helm releases monitoring by default

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -124,7 +124,7 @@ lightActions:
 enablePrometheusStack: false
 enabledManagedConfiguration: false
 enableServiceMonitors: true
-monitorHelmReleases: true
+monitorHelmReleases: false
 argoRollouts: false
 
 


### PR DESCRIPTION
## Summary
Changed the default configuration for Helm releases monitoring from enabled to disabled in the Robusta Helm chart values.

## Changes
- Set `monitorHelmReleases` to `false` in `helm/robusta/values.yaml`

## Details
This change modifies the default behavior of the Robusta Helm chart to disable monitoring of Helm releases by default. Users who want to enable this feature can explicitly set `monitorHelmReleases: true` in their values configuration.

https://claude.ai/code/session_01GdDqFaL2bY3M9hvK3Y1fNn