### PR TITLE
Update Send Alerts API documentation to focus on HolmesGPT

### DIFF
--- a/docs/configuration/exporting/send-alerts-api.rst
+++ b/docs/configuration/exporting/send-alerts-api.rst
@@ -1,12 +1,12 @@
 Send Alerts API
 ===============
 
-Send alerts to Robusta to have HolmesGPT automatically run an AI-powered root cause analysis on each one. Holmes investigates the alert against your live cluster state, logs, metrics, and connected data sources, then attaches its findings so you can skip the manual triage step.
+Send alerts to Robusta to have HolmesGPT automatically run an AI-powered root cause analysis on each one. HolmesGPT investigates the alert against your live cluster state, logs, metrics, and connected data sources, then attaches its findings to help accelerate triage.
 
 Integration Methods
 -------------------
 
-There are two main ways to send alerts to Robusta for Holmes to investigate:
+There are two main ways to send alerts to Robusta for HolmesGPT to investigate:
 
 1. **Pre-built Integrations**: Use our existing integrations for AlertManager, Nagios, SolarWinds, and other monitoring systems. See :doc:`Send Alerts <../index>`.
 

--- a/docs/configuration/exporting/send-alerts-api.rst
+++ b/docs/configuration/exporting/send-alerts-api.rst
@@ -15,9 +15,6 @@ There are two main ways to send alerts to Robusta for Holmes to investigate:
 Send Alerts API
 ---------------
 
-.. note::
-    This API is available with the Robusta SaaS platform and self-hosted commercial plans. It is not available in the open-source version.
-
 Use this endpoint to send alert data to Robusta. You can send up to 1000 alerts in a single request.
 
 .. _send-alerts-api:

--- a/docs/configuration/exporting/send-alerts-api.rst
+++ b/docs/configuration/exporting/send-alerts-api.rst
@@ -1,24 +1,12 @@
 Send Alerts API
 ===============
 
-Why Send Your Alerts to Robusta?
----------------------------------
-
-Benefits include:
-
-* Persistent alert history on a filterable timeline
-* Centralized view of alerts from all your monitoring systems (multiple Prometheus instances, cloud services, custom tools)
-* AI investigation of alerts
-* Correlations between alerts and Kubernetes deploys
-* and more!
-
-.. image:: /images/robusta-ui-timeline.png
-   :alt: Prometheus Alert History
+Send alerts to Robusta to have HolmesGPT automatically run an AI-powered root cause analysis on each one. Holmes investigates the alert against your live cluster state, logs, metrics, and connected data sources, then attaches its findings so you can skip the manual triage step.
 
 Integration Methods
 -------------------
 
-There are two main ways to send alerts to Robusta:
+There are two main ways to send alerts to Robusta for Holmes to investigate:
 
 1. **Pre-built Integrations**: Use our existing integrations for AlertManager, Nagios, SolarWinds, and other monitoring systems. See :doc:`Send Alerts <../index>`.
 


### PR DESCRIPTION
## Summary
Updated the Send Alerts API documentation to refocus the messaging around HolmesGPT's AI-powered root cause analysis capabilities rather than general alert management benefits.

## Key Changes
- Replaced the "Why Send Your Alerts to Robusta?" section with a concise description of HolmesGPT's automatic AI-powered root cause analysis functionality
- Removed the benefits list and timeline screenshot that emphasized alert history and centralized monitoring
- Updated the "Integration Methods" intro text to clarify that alerts are sent for Holmes to investigate
- Removed the note about API availability being limited to SaaS and commercial plans

## Notable Details
The documentation now emphasizes the core value proposition of automated AI investigation and triage, positioning HolmesGPT as the primary benefit of sending alerts to Robusta rather than focusing on alert aggregation and history features.

https://claude.ai/code/session_012jM54fvj27H8feByzcED2a