### PR TITLE
ROB-0000: Fix KRR recommendations API URL in docs

### DIFF
--- a/docs/configuration/resource-recommender.rst
+++ b/docs/configuration/resource-recommender.rst
@@ -229,7 +229,7 @@ Retrieves KRR resource recommendations for a specific cluster and namespace.
 
 .. code-block:: bash
 
-    curl -X GET "https://api.robusta.dev/api/query/krr/recommendations?account_id=YOUR_ACCOUNT_ID&cluster_id=my-cluster&namespace=default" \
+    curl -X GET "https://api.robusta.dev/api/krr/recommendations?account_id=YOUR_ACCOUNT_ID&cluster_id=my-cluster&namespace=default" \
       -H "Authorization: Bearer YOUR_API_KEY" \
       -H "Content-Type: application/json"
 


### PR DESCRIPTION
## Summary
- The KRR recommendations endpoint moved from `/api/query/krr/recommendations` to `/api/krr/recommendations` in relay (ROB-1895, "Move query endpoints to app for openshift").
- The section heading in `resource-recommender.rst` was already correct, but the curl example still used the old `/api/query/` prefix. This PR fixes the stale URL.
- Verified that the other `/api/query/*` doc references (`/api/query/report` in `alert-statistics-api.rst`, `/api/query/alerts` in `alert-export-api.rst`) are still served from `query_app.py` and remain correct.

## Test plan
- [ ] Render docs locally and confirm the curl example shows `https://api.robusta.dev/api/krr/recommendations`
- [ ] Sanity-check that calling the new URL returns recommendations as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)