### PR TITLE
ROB-3820: Forward chat-analytics fields through holmes_issue_chat

### DIFF
--- a/src/robusta/core/playbooks/internal/ai_integration.py
+++ b/src/robusta/core/playbooks/internal/ai_integration.py
@@ -270,12 +270,6 @@ def holmes_issue_chat(event: ExecutionBaseEvent, params: HolmesIssueChatParams):
             investigation_result=params.context.investigation_result,
             issue_type=params.context.issue_type,
         )
-        logging.info(
-            f"holmes_issue_chat forwarding "
-            f"source_ref={params.source_ref} request_source={params.request_source} "
-            f"request_type={params.request_type} conversation_id={params.conversation_id} "
-            f"conversation_source={params.conversation_source} is_internal={params.is_internal}"
-        )
         result = requests.post(f"{holmes_url}/api/issue_chat", data=holmes_req.json())
         result.raise_for_status()
 
@@ -328,12 +322,6 @@ def holmes_chat(event: ExecutionBaseEvent, params: HolmesChatParams):
         # This allows Holmes clients/servers to add new parameters without requiring updates here
         params_dict = params.dict(exclude={"holmes_url", "render_graph_images"})
         holmes_req = HolmesChatRequest(**params_dict)
-        logging.info(
-            f"holmes_chat forwarding "
-            f"source_ref={params.source_ref} request_source={params.request_source} "
-            f"request_type={params.request_type} conversation_id={params.conversation_id} "
-            f"conversation_source={params.conversation_source} is_internal={params.is_internal}"
-        )
         url = f"{holmes_url}/api/chat"
         if params.stream:
             if params.render_graph_images:

--- a/src/robusta/core/playbooks/internal/ai_integration.py
+++ b/src/robusta/core/playbooks/internal/ai_integration.py
@@ -264,12 +264,11 @@ def holmes_issue_chat(event: ExecutionBaseEvent, params: HolmesIssueChatParams):
     conversation_title = build_conversation_title(params)
     params_resource_kind = params.resource.kind or ""
     try:
+        params_dict = params.dict(exclude={"holmes_url", "render_graph_images", "resource", "context"})
         holmes_req = HolmesIssueChatRequest(
-            ask=params.ask,
-            conversation_history=params.conversation_history,
+            **params_dict,
             investigation_result=params.context.investigation_result,
             issue_type=params.context.issue_type,
-            model=params.model,
         )
         result = requests.post(f"{holmes_url}/api/issue_chat", data=holmes_req.json())
         result.raise_for_status()

--- a/src/robusta/core/playbooks/internal/ai_integration.py
+++ b/src/robusta/core/playbooks/internal/ai_integration.py
@@ -270,6 +270,12 @@ def holmes_issue_chat(event: ExecutionBaseEvent, params: HolmesIssueChatParams):
             investigation_result=params.context.investigation_result,
             issue_type=params.context.issue_type,
         )
+        logging.info(
+            f"holmes_issue_chat forwarding "
+            f"source_ref={params.source_ref} request_source={params.request_source} "
+            f"request_type={params.request_type} conversation_id={params.conversation_id} "
+            f"conversation_source={params.conversation_source} is_internal={params.is_internal}"
+        )
         result = requests.post(f"{holmes_url}/api/issue_chat", data=holmes_req.json())
         result.raise_for_status()
 
@@ -322,6 +328,12 @@ def holmes_chat(event: ExecutionBaseEvent, params: HolmesChatParams):
         # This allows Holmes clients/servers to add new parameters without requiring updates here
         params_dict = params.dict(exclude={"holmes_url", "render_graph_images"})
         holmes_req = HolmesChatRequest(**params_dict)
+        logging.info(
+            f"holmes_chat forwarding "
+            f"source_ref={params.source_ref} request_source={params.request_source} "
+            f"request_type={params.request_type} conversation_id={params.conversation_id} "
+            f"conversation_source={params.conversation_source} is_internal={params.is_internal}"
+        )
         url = f"{holmes_url}/api/chat"
         if params.stream:
             if params.render_graph_images:

--- a/src/robusta/integrations/receiver.py
+++ b/src/robusta/integrations/receiver.py
@@ -208,6 +208,18 @@ class ActionRequestReceiver:
             else:
                 ctx = nullcontext()
             with ctx:
+                if action.body.action_name.startswith("holmes_"):
+                    incoming_params = action.body.action_params or {}
+                    logging.info(
+                        f"receiver dispatching {action.body.action_name} stream={action.stream} "
+                        f"keys={sorted(incoming_params.keys())} "
+                        f"source_ref={incoming_params.get('source_ref')} "
+                        f"request_source={incoming_params.get('request_source')} "
+                        f"request_type={incoming_params.get('request_type')} "
+                        f"conversation_id={incoming_params.get('conversation_id')} "
+                        f"conversation_source={incoming_params.get('conversation_source')} "
+                        f"is_internal={incoming_params.get('is_internal')}"
+                    )
                 if action.stream:
                     self.__exec_external_stream_request(action, validate_timestamp)
                 else:

--- a/src/robusta/integrations/receiver.py
+++ b/src/robusta/integrations/receiver.py
@@ -208,18 +208,6 @@ class ActionRequestReceiver:
             else:
                 ctx = nullcontext()
             with ctx:
-                if action.body.action_name.startswith("holmes_"):
-                    incoming_params = action.body.action_params or {}
-                    logging.info(
-                        f"receiver dispatching {action.body.action_name} stream={action.stream} "
-                        f"keys={sorted(incoming_params.keys())} "
-                        f"source_ref={incoming_params.get('source_ref')} "
-                        f"request_source={incoming_params.get('request_source')} "
-                        f"request_type={incoming_params.get('request_type')} "
-                        f"conversation_id={incoming_params.get('conversation_id')} "
-                        f"conversation_source={incoming_params.get('conversation_source')} "
-                        f"is_internal={incoming_params.get('is_internal')}"
-                    )
                 if action.stream:
                     self.__exec_external_stream_request(action, validate_timestamp)
                 else:


### PR DESCRIPTION
## Summary

- `holmes_issue_chat` was building `HolmesIssueChatRequest` from five hand-picked params fields, silently dropping `source_ref` and the other chat-analytics fields added in [#2058](https://github.com/robusta-dev/robusta/pull/2058) (`request_type`, `request_source`, `conversation_id`, `conversation_source`, `is_internal`, `meta`) plus `enable_tool_approval`, `tool_decisions`, and `additional_system_prompt`.
- Slack/Teams threaded chats on an existing alert hit `/api/issue_chat`, which is why `source_ref` arrived from the relay populated yet ended up `NULL` in Holmes' `HolmesUsageEvents` rows.
- Mirror the `holmes_chat` pass-through pattern (`params.dict(exclude=…)` + splat) so any field on `HolmesChatParams` flows through to Holmes — same client/server-upgrade-without-middleware-changes property the `HolmesChatRequest` docstring describes.

## Why

Channel-agnostic by construction: same fix covers Slack, Teams, web UI, and any future channel that hits `/api/issue_chat`. Keeping `holmes_issue_chat` and `holmes_chat` symmetric also avoids drift the next time `HolmesChatParams` gains a field.

## Tradeoff

The runner stops being a typed gatekeeper for `/api/issue_chat` — fields go to Holmes whether or not the runner has typed them. This is already the accepted tradeoff for `holmes_chat` (`extra="allow"` on both schemas).

## Test plan

- [ ] Trigger a Slack threaded chat on an alert and verify the request body sent to Holmes includes `source_ref`.
- [ ] Repeat for Teams.
- [ ] Confirm `HolmesUsageEvents.source_ref` is populated for both channels.
- [ ] Smoke-test `holmes_chat` (top-level chat) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)