### PR TITLE
ROB-3785 Mark AlertManager integration docs as legacy

### DIFF
--- a/docs/configuration/_legacy_banner.rst
+++ b/docs/configuration/_legacy_banner.rst
@@ -1,0 +1,3 @@
+.. warning::
+
+   This is a legacy feature. For new integrations, please use the :doc:`Send Events API </configuration/exporting/send-events-api>` instead.

--- a/docs/configuration/alertmanager-integration/alert-manager.rst
+++ b/docs/configuration/alertmanager-integration/alert-manager.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 AlertManager - in-cluster
 **************************
 

--- a/docs/configuration/alertmanager-integration/azure-managed-prometheus.rst
+++ b/docs/configuration/alertmanager-integration/azure-managed-prometheus.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Azure Managed Prometheus Alerts
 *********************************
 

--- a/docs/configuration/alertmanager-integration/coralogix_managed_prometheus.rst
+++ b/docs/configuration/alertmanager-integration/coralogix_managed_prometheus.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Coralogix Alerts
 *****************
 

--- a/docs/configuration/alertmanager-integration/customize-labels-priorities.rst
+++ b/docs/configuration/alertmanager-integration/customize-labels-priorities.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Customize Labels and Priorities
 =================================
 

--- a/docs/configuration/alertmanager-integration/dynatrace.rst
+++ b/docs/configuration/alertmanager-integration/dynatrace.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Dynatrace Integration with Robusta
 ==================================
 

--- a/docs/configuration/alertmanager-integration/eks-managed-prometheus.rst
+++ b/docs/configuration/alertmanager-integration/eks-managed-prometheus.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 AWS Managed Prometheus Alerts
 ******************************
 

--- a/docs/configuration/alertmanager-integration/embedded-prometheus.rst
+++ b/docs/configuration/alertmanager-integration/embedded-prometheus.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Embedded Prometheus Stack
 ============================
 

--- a/docs/configuration/alertmanager-integration/gcp-monitoring.rst
+++ b/docs/configuration/alertmanager-integration/gcp-monitoring.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 GCP Cloud Monitoring Integration with Robusta
 =============================================
 

--- a/docs/configuration/alertmanager-integration/google-managed-alertmanager.rst
+++ b/docs/configuration/alertmanager-integration/google-managed-alertmanager.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Google Managed Alertmanager
 ===========================
 

--- a/docs/configuration/alertmanager-integration/google-managed-prometheus.rst
+++ b/docs/configuration/alertmanager-integration/google-managed-prometheus.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Google Managed Prometheus Alerts
 =================================
 

--- a/docs/configuration/alertmanager-integration/grafana-cloud.rst
+++ b/docs/configuration/alertmanager-integration/grafana-cloud.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Grafana Cloud
 *************
 

--- a/docs/configuration/alertmanager-integration/grafana-self-hosted.rst
+++ b/docs/configuration/alertmanager-integration/grafana-self-hosted.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Grafana - Self-Hosted
 *********************
 

--- a/docs/configuration/alertmanager-integration/nagios.rst
+++ b/docs/configuration/alertmanager-integration/nagios.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Nagios Integration with Robusta
 ===============================
 

--- a/docs/configuration/alertmanager-integration/newrelic.rst
+++ b/docs/configuration/alertmanager-integration/newrelic.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 New Relic Integration with Robusta
 ==================================
 

--- a/docs/configuration/alertmanager-integration/outofcluster-prometheus.rst
+++ b/docs/configuration/alertmanager-integration/outofcluster-prometheus.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 AlertManager - external
 ************************
 

--- a/docs/configuration/alertmanager-integration/pagerduty-alerting.rst
+++ b/docs/configuration/alertmanager-integration/pagerduty-alerting.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 PagerDuty Integration
 ****************************************
 

--- a/docs/configuration/alertmanager-integration/solarwinds.rst
+++ b/docs/configuration/alertmanager-integration/solarwinds.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 SolarWinds Integration with Robusta
 ===================================
 

--- a/docs/configuration/alertmanager-integration/victoria-metrics.rst
+++ b/docs/configuration/alertmanager-integration/victoria-metrics.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 VictoriaMetrics Alerts
 =======================
 

--- a/docs/configuration/exporting/configuration-changes-api.rst
+++ b/docs/configuration/exporting/configuration-changes-api.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Configuration Changes API
 ==============================================
 

--- a/docs/configuration/exporting/custom-webhooks.rst
+++ b/docs/configuration/exporting/custom-webhooks.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Custom Webhooks
 ===============
 

--- a/docs/configuration/exporting/send-alerts-api.rst
+++ b/docs/configuration/exporting/send-alerts-api.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 Send Alerts API
 ===============
 

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -1,5 +1,7 @@
 :hide-toc:
 
+.. include:: ./_legacy_banner.rst
+
 Send Alerts to Robusta
 =======================
 


### PR DESCRIPTION

<img width="1479" height="316" alt="image" src="https://github.com/user-attachments/assets/1d7488c0-82b1-481c-86c9-da6384891844" />


## Summary
This PR adds legacy deprecation warnings to AlertManager integration documentation and related exporting APIs, directing users to the newer Send Events API for new integrations.

## Key Changes
- Created a new reusable `_legacy_banner.rst` file containing a deprecation warning that references the Send Events API
- Added the legacy banner include to all AlertManager integration documentation files:
  - Alert Manager (in-cluster and external)
  - Cloud provider integrations (Azure, AWS, GCP, Coralogix)
  - Monitoring platforms (Dynatrace, Grafana, Nagios, New Relic, SolarWinds, VictoriaMetrics)
  - Google Managed Alertmanager
- Added the legacy banner to related exporting APIs:
  - Configuration Changes API
  - Custom Webhooks
  - Send Alerts API

## Implementation Details
The deprecation banner is implemented as a reusable RST include file that can be easily maintained in one location. This approach ensures consistent messaging across all legacy features and makes it simple to update the deprecation notice in the future if needed.

https://claude.ai/code/session_01HPM81GrhcqWdvYgke5aGDt