### PR TITLE
ROB-3921 - Add user_email field to Holmes chat params

### DIFF
--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -209,6 +209,7 @@ class HolmesChatParams(HolmesParams):
     additional_system_prompt: Optional[str] = None
     request_type: Optional[str] = None
     request_source: Optional[str] = None
+    user_email: Optional[str] = None
     source_ref: Optional[str] = None
     conversation_id: Optional[str] = None
     conversation_source: Optional[str] = None

--- a/src/robusta/core/reporting/holmes.py
+++ b/src/robusta/core/reporting/holmes.py
@@ -53,6 +53,7 @@ class HolmesChatRequest(BaseModel):
     additional_system_prompt: Optional[str] = None
     request_type: Optional[str] = None
     request_source: Optional[str] = None
+    user_email: Optional[str] = None
     source_ref: Optional[str] = None
     conversation_id: Optional[str] = None
     conversation_source: Optional[str] = None


### PR DESCRIPTION
## Summary

- Declare `user_email: Optional[str] = None` on `HolmesChatParams` (frontend → runner) and `HolmesChatRequest` (runner → Holmes), placed next to `request_source` to match the sibling pattern.
- `HolmesIssueChatParams` / `HolmesIssueChatRequest` inherit from these, so they pick up the field automatically.

## Why

The frontend has started sending `user_email` on chat requests. Both models already have `class Config: extra = "allow"` and the runner forwards params via `params.dict()` → `HolmesChatRequest(**params_dict)`, so the field would already flow through transparently to Holmes without code changes. However, every sibling field (`request_type`, `request_source`, `conversation_id`, `source_ref`, …) is declared explicitly, and adding `user_email` to that list gives:

- type validation (`Optional[str]`)
- grep-ability / IDE autocomplete
- a documented contract for readers of the model

## Test plan

- [ ] Confirm runner accepts a chat request with `user_email` and forwards it to Holmes unchanged
- [ ] Confirm requests without `user_email` still work (field is optional, defaults to `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)