### PR TITLE
Improve Sentry integration documentation with detailed setup guide

### DIFF
--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -54,8 +54,8 @@ Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 Create the Custom Integration
 -----------------------------
 
-Open the list page
-~~~~~~~~~~~~~~~~~~
+Start a new Internal Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. In Sentry, navigate to **Settings → Integrations → Custom
    Integrations**.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -32,7 +32,8 @@ Prerequisites
 * Your Robusta ``account_id``, found in ``generated_values.yaml``.
 * A Robusta API key with ``Read/Write`` access to alerts, generated
   under **Settings → API Keys → New API Key**.
-* Sentry org-level access to install Internal Integrations.
+* Sentry **Owner** or **Manager** role on the org (lower roles can't
+  create Custom Integrations).
 
 Webhook URL
 -----------
@@ -44,18 +45,23 @@ Webhook URL
 Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 ``<ROBUSTA_API_KEY>`` with the API key you just generated.
 
-Create the Internal Integration
--------------------------------
+Create the Custom Integration
+-----------------------------
 
-1. In Sentry, go to **Settings → Developer Settings → New Internal
-   Integration**.
-2. **Name**: ``Robusta``.
-3. **Webhook URL**: paste the URL from above.
-4. **Permissions**: grant **Issue & Event: Read**.
-5. **Webhooks**: enable the ``issue`` checkbox. Sentry will POST to
+Sentry's "Internal Integration" has been renamed to **Custom
+Integration** in the current UI; it's the same feature.
+
+1. In Sentry, open **Settings → Integrations → Custom Integrations**
+   (direct link:
+   ``https://<your-org>.sentry.io/settings/custom-integrations/``).
+2. Click **Create New Integration → Internal Integration**.
+3. **Name**: ``Robusta``.
+4. **Webhook URL**: paste the URL from above.
+5. **Permissions**: grant **Issue & Event: Read**.
+6. **Webhooks**: enable the ``issue`` checkbox. Sentry will POST to
    the webhook URL whenever an issue is created, resolved, assigned,
    archived, or unresolved.
-6. **Schema** *(optional, only needed if you want Sentry Alert Rules to
+7. **Schema** *(optional, only needed if you want Sentry Alert Rules to
    target Robusta)*: paste the following JSON to register the
    integration as an Alert Rule Action.
 
@@ -75,7 +81,7 @@ Create the Internal Integration
         ]
       }
 
-7. Click **Save Changes**, then **Install** the integration to your
+8. Click **Save Changes**, then **Install** the integration to your
    organization.
 
 .. note::
@@ -89,7 +95,7 @@ Wire up an Issue Alert Rule (optional)
 --------------------------------------
 
 Skip this section if you only want the issue lifecycle webhook
-behavior — the integration is already live after step 7.
+behavior — the integration is already live after step 8.
 
 To route a specific Sentry alert rule through Robusta:
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -7,16 +7,16 @@ Integration.
 Sentry can send events to Robusta in two different ways. Use either
 one, or enable both on the same integration:
 
-* :ref:`Path A — Issue Lifecycle Webhook <sentry-path-issue-lifecycle>`
-  fires on every issue created / resolved / assigned / archived /
+* :ref:`Issue Lifecycle Webhook <sentry-path-issue-lifecycle>` fires
+  on every issue created / resolved / assigned / archived /
   unresolved across the org. Lighter payload (no per-event details,
   no event-level tags), zero alert-rule plumbing. Use this when you
   want every Sentry issue on the Robusta timeline.
-* :ref:`Path B — Alert Rule Action <sentry-path-alert-rule>` fires
-  only when a Sentry Issue Alert Rule (or Metric Alert Rule) triggers
-  and lists Robusta as one of its actions. Richer payload (event
-  detail, rule name, and all tags attached to the event). Use this
-  when you want rule-driven, throttled alerts.
+* :ref:`Alert Rule Action <sentry-path-alert-rule>` fires only when a
+  Sentry Issue Alert Rule (or Metric Alert Rule) triggers and lists
+  Robusta as one of its actions. Richer payload (event detail, rule
+  name, and all tags attached to the event). Use this when you want
+  rule-driven, throttled alerts.
 
 Prerequisites
 -------------
@@ -59,14 +59,15 @@ Create the Custom Integration
    only for display in Sentry).
 5. **Webhook URL**: paste the URL from the previous section.
 
-Then configure :ref:`Path A <sentry-path-issue-lifecycle>`,
-:ref:`Path B <sentry-path-alert-rule>`, or both, and save the
-integration at the end.
+Then configure
+:ref:`Issue Lifecycle Webhook <sentry-path-issue-lifecycle>`,
+:ref:`Alert Rule Action <sentry-path-alert-rule>`, or both, and save
+the integration at the end.
 
 .. _sentry-path-issue-lifecycle:
 
-Path A — Issue Lifecycle Webhook
----------------------------------
+Issue Lifecycle Webhook
+-----------------------
 
 Subscribe to lifecycle events so every Sentry issue lands on the
 Robusta timeline.
@@ -79,8 +80,6 @@ Then in the **WEBHOOKS** section:
 
 2. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
    ``resolved``, ``assigned``, ``archived``, ``unresolved``).
-3. Leave ``error``, ``comment``, ``seer``, and ``preprod_artifact``
-   unchecked.
 
 .. warning::
 
@@ -88,28 +87,20 @@ Then in the **WEBHOOKS** section:
    individual error event (not per issue) — a noisy service will
    generate far more webhook traffic than the issue checkbox does.
 
-Continue to :ref:`Path B <sentry-path-alert-rule>` if you also want
-rule-driven alerts, or jump to :ref:`Save the integration
-<sentry-save>`.
-
 .. _sentry-path-alert-rule:
 
-Path B — Alert Rule Action
---------------------------
+Alert Rule Action
+-----------------
 
 Register Robusta as a selectable action inside Sentry Issue Alert and
 Metric Alert rules so the integration receives the rich
 ``event_alert`` payload only when a rule fires.
 
-In the **PERMISSIONS** section of the same form:
+In the **INTERNAL INTEGRATION DETAILS** section of the same form:
 
-1. **Alerts**: set to **Read**.
+1. **Alert Rule Action**: tick this checkbox.
 
-Then back in **INTERNAL INTEGRATION DETAILS**:
-
-2. **Alert Rule Action**: tick this checkbox.
-
-3. **Schema**: paste the following JSON so Robusta appears in
+2. **Schema**: paste the following JSON so Robusta appears in
    Sentry's alert rule action picker.
 
    .. code-block:: json
@@ -140,9 +131,9 @@ Then back in **INTERNAL INTEGRATION DETAILS**:
    the integration in the picker — without it, Robusta won't appear
    in the "Send a notification via an integration" dropdown.
 
-After configuring Path B, continue to :ref:`Save the integration
-<sentry-save>` — Sentry needs the integration saved before any
-alert rule can reference it.
+Then in the **PERMISSIONS** section:
+
+3. **Alerts**: set to **Read**.
 
 .. _sentry-save:
 
@@ -159,8 +150,8 @@ Create a Sentry alert rule (Path B)
 -----------------------------------
 
 This section only applies if you configured
-:ref:`Path B <sentry-path-alert-rule>` above. Skip it for a Path A-only
-setup.
+:ref:`Alert Rule Action <sentry-path-alert-rule>` above. Skip it if
+you only set up the issue lifecycle webhook.
 
 The integration is now selectable in alert rules, but until a rule is
 actually configured against it Sentry won't POST anything. For each

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -48,31 +48,41 @@ Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 Create the Custom Integration
 -----------------------------
 
-Sentry's "Internal Integration" has been renamed to **Custom
-Integration** in the current UI; it's the same feature.
+Sentry's "Internal Integration" lives under **Custom Integrations** in
+the current UI; the two names refer to the same feature.
 
-1. In Sentry, open **Settings → Integrations → Custom Integrations**
-   (direct link:
+Open the list page
+~~~~~~~~~~~~~~~~~~
+
+1. In Sentry, navigate to **Settings → Integrations → Custom
+   Integrations** (direct link:
    ``https://<your-org>.sentry.io/settings/custom-integrations/``).
-2. Click **Create New Integration → Internal Integration**.
-3. **Name**: ``Robusta``.
-4. **Webhook URL**: paste the URL from above.
-5. **Permissions**: grant **Issue & Event: Read**.
-6. **Webhooks**: enable **only** the ``issue`` checkbox. Sentry will
-   POST to the webhook URL whenever an issue is created, resolved,
-   assigned, archived, or unresolved.
+2. Click **Create New Integration** in the top right.
+3. In the **Choose Integration Type** dialog, select **Internal
+   Integration** and click **Next**.
 
-   .. warning::
+Fill in "Internal Integration Details"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      Do **not** enable the ``error`` checkbox. It fires on every
-      individual error event (not per issue), which will exhaust
-      Robusta's 300-requests-per-5-minutes rate limit on any non-trivial
-      service. The relay parser also doesn't recognise the ``error``
-      webhook payload shape, so enabled-``error`` traffic lands as
-      ``parse_status=failed`` rows.
-7. **Schema** *(optional, only needed if you want Sentry Alert Rules to
-   target Robusta)*: paste the following JSON to register the
-   integration as an Alert Rule Action.
+In the **INTERNAL INTEGRATION DETAILS** section:
+
+4. **Name**: ``Robusta`` (or ``Robusta Prod Alerts``, etc. — this is
+   only for display in Sentry).
+5. **Webhook URL**: paste the URL from the previous section.
+6. **Alert Rule Action**: enable this checkbox if you want the
+   integration to be selectable inside Sentry Issue Alert and Metric
+   Alert rules. This is required for the alert-rule path described
+   below; leave it disabled if you only want the issue lifecycle
+   webhook.
+
+   .. note::
+
+      The checkbox stays locked until **Schema** (next field) contains
+      a valid ``alert-rule-action`` element. Fill the schema first,
+      then enable the checkbox.
+
+7. **Schema** *(required when Alert Rule Action is enabled, otherwise
+   leave blank)*: paste the following JSON.
 
    .. code-block:: json
 
@@ -90,21 +100,59 @@ Integration** in the current UI; it's the same feature.
         ]
       }
 
-8. Click **Save Changes**, then **Install** the integration to your
-   organization.
+   .. note::
 
-.. note::
+      Sentry appends the schema's ``uri`` path to the webhook URL host
+      when an alert rule fires, so the path component of the **Webhook
+      URL** field above (``/webhooks``) must match the schema ``uri``.
+      Query parameters in the Webhook URL are preserved.
 
-   Sentry appends the schema's ``uri`` path to the webhook URL host
-   when an alert rule fires, so the path component of the **Webhook
-   URL** field above (``/webhooks``) must match the schema ``uri``.
-   Query parameters in the Webhook URL are preserved.
+8. **Overview** and **Authorized JavaScript Origins**: leave both
+   blank.
+
+Grant permissions
+~~~~~~~~~~~~~~~~~
+
+In the **PERMISSIONS** section, change the dropdowns:
+
+9. **Issue & Event**: set to **Read**.
+10. **Alerts**: set to **Read** (only required if you enabled Alert
+    Rule Action in step 6).
+11. Leave every other permission row at **No Access**.
+
+Subscribe to webhook events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the **WEBHOOKS** section:
+
+12. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
+    ``resolved``, ``assigned``, ``archived``, ``unresolved``). Leave
+    ``error``, ``comment``, ``seer``, and ``preprod_artifact``
+    unchecked.
+
+    .. warning::
+
+       Do **not** enable the ``error`` checkbox. It fires on every
+       individual error event (not per issue), which will exhaust
+       Robusta's 300-requests-per-5-minutes rate limit on any
+       non-trivial service. The relay parser also doesn't recognise
+       the ``error`` webhook payload shape, so enabled-``error``
+       traffic lands as ``parse_status=failed`` rows.
+
+Save
+~~~~
+
+13. Click **Save Changes** at the bottom of the form. The integration
+    now appears under **INTERNAL INTEGRATIONS** on the Custom
+    Integrations list page with a **Dashboard** button next to it —
+    that dashboard is the primary debugging surface (see
+    :ref:`troubleshooting <sentry-troubleshooting>`).
 
 Wire up an Issue Alert Rule (optional)
 --------------------------------------
 
 Skip this section if you only want the issue lifecycle webhook
-behavior — the integration is already live after step 8.
+behavior — the integration is already live after step 13.
 
 To route a specific Sentry alert rule through Robusta:
 
@@ -127,6 +175,8 @@ Verify
 Open **Settings → Delivery Log** in the Robusta UI — the event should
 appear there with parse status ``parsed``, and the corresponding row
 should land on the Robusta timeline.
+
+.. _sentry-troubleshooting:
 
 Troubleshooting
 ---------------

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -7,16 +7,16 @@ Integration.
 Sentry can send events to Robusta in two different ways. Use either
 one, or enable both on the same integration:
 
-* :ref:`sentry-path-issue-lifecycle` — fires on every issue created /
-  resolved / assigned / archived / unresolved across the org. Lighter
-  payload (no per-event details, no event-level tags), zero
-  alert-rule plumbing. Use this when you want every Sentry issue on
-  the Robusta timeline.
-* :ref:`sentry-path-alert-rule` — fires only when a Sentry Issue
-  Alert Rule (or Metric Alert Rule) triggers and lists Robusta as one
-  of its actions. Richer payload (event detail, rule name, and all
-  tags attached to the event). Use this when you want rule-driven,
-  throttled alerts.
+* :ref:`Path A — Issue Lifecycle Webhook <sentry-path-issue-lifecycle>`
+  fires on every issue created / resolved / assigned / archived /
+  unresolved across the org. Lighter payload (no per-event details,
+  no event-level tags), zero alert-rule plumbing. Use this when you
+  want every Sentry issue on the Robusta timeline.
+* :ref:`Path B — Alert Rule Action <sentry-path-alert-rule>` fires
+  only when a Sentry Issue Alert Rule (or Metric Alert Rule) triggers
+  and lists Robusta as one of its actions. Richer payload (event
+  detail, rule name, and all tags attached to the event). Use this
+  when you want rule-driven, throttled alerts.
 
 The recommended setup uses both on a single integration: subscribe to
 the issue lifecycle webhook *and* register the integration as an alert
@@ -69,11 +69,13 @@ Start a new Internal Integration
 
 6. **Issue & Event**: set to **Read**.
 7. **Alerts**: set to **Read** (only needed if you'll set up
-   :ref:`sentry-path-alert-rule`; harmless to grant either way).
-8. Leave every other permission row at **No Access**.
+   :ref:`Path B <sentry-path-alert-rule>`; harmless to grant either
+   way).
 
-Continue to whichever path you want — :ref:`sentry-path-issue-lifecycle`,
-:ref:`sentry-path-alert-rule`, or both — then save the integration.
+Continue to whichever path you want —
+:ref:`Path A <sentry-path-issue-lifecycle>`,
+:ref:`Path B <sentry-path-alert-rule>`, or both — then save the
+integration.
 
 .. _sentry-path-issue-lifecycle:
 
@@ -99,8 +101,8 @@ In the **WEBHOOKS** section of the same form:
    generate far more webhook traffic than the issue checkbox does.
 
 That's the entire Path A configuration. Continue to
-:ref:`sentry-path-alert-rule` if you also want rule-driven alerts,
-or jump to :ref:`sentry-save` to save the integration.
+:ref:`Path B <sentry-path-alert-rule>` if you also want rule-driven
+alerts, or jump to :ref:`Save the integration <sentry-save>`.
 
 .. _sentry-path-alert-rule:
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -18,10 +18,6 @@ one, or enable both on the same integration:
   detail, rule name, and all tags attached to the event). Use this
   when you want rule-driven, throttled alerts.
 
-The recommended setup uses both on a single integration: subscribe to
-the issue lifecycle webhook *and* register the integration as an alert
-rule action.
-
 Prerequisites
 -------------
 
@@ -54,44 +50,36 @@ Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 Create the Custom Integration
 -----------------------------
 
-Start a new Internal Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 1. In Sentry, navigate to **Settings → Integrations → Custom
    Integrations**.
 2. Click **Create New Integration** in the top right.
 3. In the **Choose Integration Type** dialog, select **Internal
    Integration** and click **Next**.
-
 4. **Name**: ``Robusta`` (or ``Robusta Prod Alerts``, etc. — this is
    only for display in Sentry).
 5. **Webhook URL**: paste the URL from the previous section.
 
-6. **Issue & Event**: set to **Read**.
-7. **Alerts**: set to **Read** (only needed if you'll set up
-   :ref:`Path B <sentry-path-alert-rule>`; harmless to grant either
-   way).
-
-Continue to whichever path you want —
-:ref:`Path A <sentry-path-issue-lifecycle>`,
-:ref:`Path B <sentry-path-alert-rule>`, or both — then save the
-integration.
+Then configure :ref:`Path A <sentry-path-issue-lifecycle>`,
+:ref:`Path B <sentry-path-alert-rule>`, or both, and save the
+integration at the end.
 
 .. _sentry-path-issue-lifecycle:
 
 Path A — Issue Lifecycle Webhook
 ---------------------------------
 
-Sentry POSTs to the Webhook URL on every issue lifecycle transition
-(``created`` / ``resolved`` / ``assigned`` / ``archived`` /
-``unresolved``). This is the simpler path: no schema, no alert rules,
-every issue lands on the Robusta timeline automatically.
+Subscribe to lifecycle events so every Sentry issue lands on the
+Robusta timeline.
 
-In the **WEBHOOKS** section of the same form:
+In the **PERMISSIONS** section of the same form:
 
-1. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
+1. **Issue & Event**: set to **Read**.
+
+Then in the **WEBHOOKS** section:
+
+2. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
    ``resolved``, ``assigned``, ``archived``, ``unresolved``).
-2. Leave ``error``, ``comment``, ``seer``, and ``preprod_artifact``
+3. Leave ``error``, ``comment``, ``seer``, and ``preprod_artifact``
    unchecked.
 
 .. warning::
@@ -100,29 +88,28 @@ In the **WEBHOOKS** section of the same form:
    individual error event (not per issue) — a noisy service will
    generate far more webhook traffic than the issue checkbox does.
 
-That's the entire Path A configuration. Continue to
-:ref:`Path B <sentry-path-alert-rule>` if you also want rule-driven
-alerts, or jump to :ref:`Save the integration <sentry-save>`.
+Continue to :ref:`Path B <sentry-path-alert-rule>` if you also want
+rule-driven alerts, or jump to :ref:`Save the integration
+<sentry-save>`.
 
 .. _sentry-path-alert-rule:
 
 Path B — Alert Rule Action
 --------------------------
 
-This path makes Robusta selectable as an action inside Sentry Issue
-Alert and Metric Alert rules. Sentry POSTs only when one of those
-rules fires, and the webhook carries the event detail plus the rule
-name as the aggregation key.
+Register Robusta as a selectable action inside Sentry Issue Alert and
+Metric Alert rules so the integration receives the rich
+``event_alert`` payload only when a rule fires.
 
-Two parts: register the integration as an alert action, then create
-the alert rule that uses it.
+In the **PERMISSIONS** section of the same form:
 
-Register Robusta as an alert action
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. **Alerts**: set to **Read**.
 
-1. **Alert Rule Action**: tick this checkbox.
+Then back in **INTERNAL INTEGRATION DETAILS**:
 
-2. **Schema**: paste the following JSON so Robusta appears in
+2. **Alert Rule Action**: tick this checkbox.
+
+3. **Schema**: paste the following JSON so Robusta appears in
    Sentry's alert rule action picker.
 
    .. code-block:: json
@@ -148,11 +135,14 @@ Register Robusta as an alert action
         ]
       }
 
-   The ``title`` is what shows up as the action label inside Sentry's
-   alert rule editor. The ``Alert Rule Action`` checkbox toggles the
-   feature on, but Sentry uses this schema to know *how* to render
+   The ``title`` is the action label that shows up inside Sentry's
+   alert rule editor. The schema is what tells Sentry how to render
    the integration in the picker — without it, Robusta won't appear
    in the "Send a notification via an integration" dropdown.
+
+After configuring Path B, continue to :ref:`Save the integration
+<sentry-save>` — Sentry needs the integration saved before any
+alert rule can reference it.
 
 .. _sentry-save:
 
@@ -165,12 +155,16 @@ Integrations list page with a **Dashboard** button next to it — that
 dashboard is the primary debugging surface (see
 :ref:`troubleshooting <sentry-troubleshooting>`).
 
-Wire up a Sentry alert rule (Path B)
-------------------------------------
+Create a Sentry alert rule (Path B)
+-----------------------------------
 
-If you set up Path B, the integration is now selectable in alert
-rules — but until a rule is actually configured against it Sentry
-won't POST anything. For each project that should forward to Robusta:
+This section only applies if you configured
+:ref:`Path B <sentry-path-alert-rule>` above. Skip it for a Path A-only
+setup.
+
+The integration is now selectable in alert rules, but until a rule is
+actually configured against it Sentry won't POST anything. For each
+project that should forward to Robusta:
 
 1. Open **Alerts → Create Alert** and choose **Issues**.
 2. Configure your conditions and filters as usual.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -58,9 +58,18 @@ Integration** in the current UI; it's the same feature.
 3. **Name**: ``Robusta``.
 4. **Webhook URL**: paste the URL from above.
 5. **Permissions**: grant **Issue & Event: Read**.
-6. **Webhooks**: enable the ``issue`` checkbox. Sentry will POST to
-   the webhook URL whenever an issue is created, resolved, assigned,
-   archived, or unresolved.
+6. **Webhooks**: enable **only** the ``issue`` checkbox. Sentry will
+   POST to the webhook URL whenever an issue is created, resolved,
+   assigned, archived, or unresolved.
+
+   .. warning::
+
+      Do **not** enable the ``error`` checkbox. It fires on every
+      individual error event (not per issue), which will exhaust
+      Robusta's 300-requests-per-5-minutes rate limit on any non-trivial
+      service. The relay parser also doesn't recognise the ``error``
+      webhook payload shape, so enabled-``error`` traffic lands as
+      ``parse_status=failed`` rows.
 7. **Schema** *(optional, only needed if you want Sentry Alert Rules to
    target Robusta)*: paste the following JSON to register the
    integration as an Alert Rule Action.
@@ -118,3 +127,62 @@ Verify
 Open **Settings → Delivery Log** in the Robusta UI — the event should
 appear there with parse status ``parsed``, and the corresponding row
 should land on the Robusta timeline.
+
+Troubleshooting
+---------------
+
+Sentry exposes its own delivery history on the Custom Integration's
+**Dashboard** tab — open the integration from **Settings → Integrations
+→ Custom Integrations → Robusta** and switch to **Dashboard**. The
+dashboard lists every outgoing webhook with the HTTP status code
+Robusta returned, the timestamp, the request body Sentry sent, and the
+response body Robusta replied with. Always start debugging here — it
+tells you whether the problem is on Sentry's side (no requests showing
+up) or Robusta's side (requests present but non-200).
+
+Common responses and what they mean:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 30 58
+
+   * - Status
+     - Meaning
+     - Fix
+   * - **200**
+     - Robusta accepted the event.
+     - If you don't see it on the timeline shortly after, check the
+       Robusta **Delivery Log** for parse failures.
+   * - **400**
+     - Missing or invalid query parameter.
+     - Re-check ``account_id``, ``origin=sentry``, and ``type=alert``
+       in the Webhook URL.
+   * - **401**
+     - API key rejected.
+     - The ``token`` in the URL is wrong, expired, or not scoped to the
+       same ``account_id``. Regenerate the API key with
+       ``Read/Write`` access to alerts and update the Webhook URL.
+   * - **429**
+     - Rate limit exceeded.
+     - More than 300 requests in 5 minutes from this account. Throttle
+       the Sentry alert rule or unsubscribe from the high-volume
+       ``error`` webhook event.
+   * - **5xx**
+     - Robusta-side failure.
+     - Open the Robusta **Delivery Log** for the event id Sentry
+       displays in the response body; if it isn't there, contact
+       Robusta support with the request id from the Sentry dashboard.
+
+If the dashboard shows **no recent requests** even though you triggered
+an event, the integration isn't subscribed to the right webhook:
+verify that the ``issue`` checkbox under **Webhooks** is enabled
+(``error`` is not needed — see the note in the previous section), and
+that the integration is **installed** to the organization, not just
+saved as a draft.
+
+If the dashboard shows **200 responses but nothing appears in the
+Robusta timeline**, open the Robusta **Delivery Log** and look for
+rows with ``origin=sentry`` and ``parse_status=failed`` — the
+``parser_error`` column tells you which field the parser couldn't
+read.
+

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -12,8 +12,8 @@ one, or enable both on the same integration:
   unresolved across the org. Lighter payload (no per-event details,
   no event-level tags), zero alert-rule plumbing. Use this when you
   want every Sentry issue on the Robusta timeline.
-* :ref:`Alert Rule Action <sentry-path-alert-rule>` fires only when a
-  Sentry Issue Alert Rule (or Metric Alert Rule) triggers and lists
+* :ref:`Send alert webhook <sentry-path-alert-rule>` fires only when
+  a Sentry Issue Alert Rule (or Metric Alert Rule) triggers and lists
   Robusta as one of its actions. Richer payload (event detail, rule
   name, and all tags attached to the event). Use this when you want
   rule-driven, throttled alerts.
@@ -61,7 +61,7 @@ Create the Custom Integration
 
 Then configure
 :ref:`Issue Lifecycle Webhook <sentry-path-issue-lifecycle>`,
-:ref:`Alert Rule Action <sentry-path-alert-rule>`, or both, and save
+:ref:`Send alert webhook <sentry-path-alert-rule>`, or both, and save
 the integration at the end.
 
 .. _sentry-path-issue-lifecycle:
@@ -93,12 +93,16 @@ Then in the **WEBHOOKS** section:
 
 .. _sentry-path-alert-rule:
 
-Alert Rule Action
------------------
+Send alert webhook
+------------------
 
 Register Robusta as a selectable action inside Sentry Issue Alert and
 Metric Alert rules so the integration receives the rich
-``event_alert`` payload only when a rule fires.
+``event_alert`` payload only when a rule fires. Two parts: configure
+the integration, then add Robusta to an existing alert rule.
+
+Configure the integration
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the **INTERNAL INTEGRATION DETAILS** section of the same form:
 
@@ -143,24 +147,20 @@ Then in the **PERMISSIONS** section:
    now appears under **INTERNAL INTEGRATIONS** on the Custom
    Integrations list page.
 
-Create a Sentry alert rule
---------------------------
+Add Robusta to an existing alert rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section only applies if you configured
-:ref:`Alert Rule Action <sentry-path-alert-rule>` above. Skip it if
-you only set up the issue lifecycle webhook.
+The integration is now selectable in alert rules, but until a rule
+references it Sentry won't POST anything. For each Sentry alert rule
+you want to forward to Robusta:
 
-The integration is now selectable in alert rules, but until a rule is
-actually configured against it Sentry won't POST anything. For each
-project that should forward to Robusta:
-
-1. Open **Alerts → Create Alert** and choose **Issues**.
-2. Configure your conditions and filters as usual.
-3. Under **Then perform these actions**, click **Add action** and
+1. In the project that owns the rule, open **Alerts → Alert Rules**
+   and click the rule you want to forward.
+2. Under **Then perform these actions**, click **Add action** and
    select **Send a notification via an integration → Robusta**.
-4. The "Destination" dropdown the schema declared appears here;
+3. The "Destination" dropdown the schema declared appears here;
    leave it at "Robusta".
-5. Save the rule.
+4. **Save** the rule.
 
 When the rule's conditions match, Sentry POSTs the ``event_alert``
 payload to Robusta, and the rule name shows up as the Robusta

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -96,7 +96,14 @@ In the **INTERNAL INTEGRATION DETAILS** section:
             "settings": {
               "type": "alert-rule-settings",
               "uri": "/webhooks",
-              "required_fields": []
+              "required_fields": [
+                {
+                  "type": "text",
+                  "name": "tags",
+                  "label": "Tags",
+                  "default": "sentry"
+                }
+              ]
             }
           }
         ]
@@ -108,6 +115,17 @@ In the **INTERNAL INTEGRATION DETAILS** section:
    to render the integration in the picker — without it, Robusta
    won't appear in the "Send a notification via an integration"
    dropdown.
+
+   .. note::
+
+      Sentry's schema validator rejects ``alert-rule-action`` elements
+      whose ``required_fields`` array is empty
+      (*"[] is too short for element of type 'alert-rule-action'"*).
+      The ``tags`` field above is a placeholder so the schema saves
+      cleanly; users configuring an alert rule will see a "Tags" text
+      input pre-filled with ``sentry`` and can leave it as-is. Robusta
+      ignores ``data.issue_alert.settings`` server-side, so the value
+      doesn't affect ingestion.
 
    .. note::
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -63,11 +63,6 @@ Start a new Internal Integration
 3. In the **Choose Integration Type** dialog, select **Internal
    Integration** and click **Next**.
 
-Fill in "Internal Integration Details"
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In the **INTERNAL INTEGRATION DETAILS** section:
-
 4. **Name**: ``Robusta`` (or ``Robusta Prod Alerts``, etc. — this is
    only for display in Sentry).
 5. **Webhook URL**: paste the URL from the previous section.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -71,30 +71,24 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 4. **Name**: ``Robusta`` (or ``Robusta Prod Alerts``, etc. — this is
    only for display in Sentry).
 5. **Webhook URL**: paste the URL from the previous section.
-6. **Overview** and **Authorized JavaScript Origins**: leave both
-   blank.
-
-   You'll come back to **Alert Rule Action** and **Schema** in
-   :ref:`sentry-path-alert-rule` if you want that path; for now leave
-   them at their defaults.
 
 Grant permissions
 ~~~~~~~~~~~~~~~~~
 
 In the **PERMISSIONS** section, change the dropdowns:
 
-7. **Issue & Event**: set to **Read**.
-8. **Alerts**: set to **Read** (only needed if you'll set up
+6. **Issue & Event**: set to **Read**.
+7. **Alerts**: set to **Read** (only needed if you'll set up
    :ref:`sentry-path-alert-rule`; harmless to grant either way).
-9. Leave every other permission row at **No Access**.
+8. Leave every other permission row at **No Access**.
 
 Save the base integration before configuring either webhook path:
 
-10. Click **Save Changes** at the bottom of the form. The integration
-    now appears under **INTERNAL INTEGRATIONS** on the Custom
-    Integrations list page with a **Dashboard** button next to it —
-    that dashboard is the primary debugging surface (see
-    :ref:`troubleshooting <sentry-troubleshooting>`).
+9. Click **Save Changes** at the bottom of the form. The integration
+   now appears under **INTERNAL INTEGRATIONS** on the Custom
+   Integrations list page with a **Dashboard** button next to it —
+   that dashboard is the primary debugging surface (see
+   :ref:`troubleshooting <sentry-troubleshooting>`).
 
 .. _sentry-path-issue-lifecycle:
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -72,13 +72,8 @@ Start a new Internal Integration
    :ref:`sentry-path-alert-rule`; harmless to grant either way).
 8. Leave every other permission row at **No Access**.
 
-Save the base integration before configuring either webhook path:
-
-9. Click **Save Changes** at the bottom of the form. The integration
-   now appears under **INTERNAL INTEGRATIONS** on the Custom
-   Integrations list page with a **Dashboard** button next to it —
-   that dashboard is the primary debugging surface (see
-   :ref:`troubleshooting <sentry-troubleshooting>`).
+Continue to whichever path you want — :ref:`sentry-path-issue-lifecycle`,
+:ref:`sentry-path-alert-rule`, or both — then save the integration.
 
 .. _sentry-path-issue-lifecycle:
 
@@ -90,27 +85,22 @@ Sentry POSTs to the Webhook URL on every issue lifecycle transition
 ``unresolved``). This is the simpler path: no schema, no alert rules,
 every issue lands on the Robusta timeline automatically.
 
-Open the integration you just created and scroll to the **WEBHOOKS**
-section:
+In the **WEBHOOKS** section of the same form:
 
 1. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
    ``resolved``, ``assigned``, ``archived``, ``unresolved``).
 2. Leave ``error``, ``comment``, ``seer``, and ``preprod_artifact``
    unchecked.
-3. Click **Save Changes**.
 
 .. warning::
 
    Do **not** enable the ``error`` checkbox. It fires on every
-   individual error event (not per issue), which will exhaust
-   Robusta's 300-requests-per-5-minutes rate limit on any non-trivial
-   service. The relay parser also doesn't recognise the ``error``
-   webhook payload shape, so enabled-``error`` traffic lands as
-   ``parse_status=failed`` rows.
+   individual error event (not per issue) — a noisy service will
+   generate far more webhook traffic than the issue checkbox does.
 
-That's the entire Path A setup. Skip ahead to :ref:`Verify
-<sentry-verify>` to test it, or continue to Path B to layer
-alert-rule routing on top.
+That's the entire Path A configuration. Continue to
+:ref:`sentry-path-alert-rule` if you also want rule-driven alerts,
+or jump to :ref:`sentry-save` to save the integration.
 
 .. _sentry-path-alert-rule:
 
@@ -128,18 +118,7 @@ the alert rule that uses it.
 Register Robusta as an alert action
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open the integration and scroll back up to **INTERNAL INTEGRATION
-DETAILS**:
-
-1. **Alert Rule Action**: tick this checkbox. The notification
-   destination is the **Webhook URL** you saved earlier.
-
-   .. note::
-
-      The checkbox is locked until **Webhook URL** is filled in —
-      Sentry's tooltip reads
-      *"Cannot enable alert rule action without a webhook url"*. If
-      you completed the shared setup above the URL is already there.
+1. **Alert Rule Action**: tick this checkbox.
 
 2. **Schema**: paste the following JSON so Robusta appears in
    Sentry's alert rule action picker.
@@ -175,46 +154,36 @@ DETAILS**:
 
    .. note::
 
-      Sentry's schema validator requires ``required_fields`` to
-      contain **at least one element** — an empty array fails with
-      *"[] is too short for element of type 'alert-rule-action'"*.
-      The single ``select`` field above is a placeholder that mirrors
-      Sentry's `documented schema example
-      <https://docs.sentry.io/integrations/integration-platform/ui-components/alert-rule-action/>`_:
-      users configuring an alert rule see a "Destination" dropdown
-      whose only option is "Robusta", so there's nothing to type and
-      no risk of misconfiguration. Robusta ignores
-      ``data.issue_alert.settings`` server-side, so the value doesn't
-      affect ingestion.
-
-      A ``text`` field would also satisfy the constraint, but Sentry
-      additionally restricts ``text``/``textarea`` defaults to
-      ``issue.title`` or ``issue.description`` only, which is a more
-      brittle pattern.
-
-   .. note::
-
       Sentry appends the schema's ``uri`` path to the webhook URL
       host when an alert rule fires, so the path component of the
       **Webhook URL** field (``/webhooks``) must match the schema
       ``uri``. Query parameters in the Webhook URL are preserved.
 
-3. Click **Save Changes**.
+.. _sentry-save:
 
-Create the Sentry alert rule
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Save the integration
+--------------------
 
-The integration is now selectable in alert rules, but until a rule is
-actually configured against it Sentry won't POST anything. For each
-project that should forward to Robusta:
+Click **Save Changes** at the bottom of the form. The integration
+now appears under **INTERNAL INTEGRATIONS** on the Custom
+Integrations list page with a **Dashboard** button next to it — that
+dashboard is the primary debugging surface (see
+:ref:`troubleshooting <sentry-troubleshooting>`).
 
-4. Open **Alerts → Create Alert** and choose **Issues**.
-5. Configure your conditions and filters as usual.
-6. Under **Then perform these actions**, click **Add action** and
+Wire up a Sentry alert rule (Path B)
+------------------------------------
+
+If you set up Path B, the integration is now selectable in alert
+rules — but until a rule is actually configured against it Sentry
+won't POST anything. For each project that should forward to Robusta:
+
+1. Open **Alerts → Create Alert** and choose **Issues**.
+2. Configure your conditions and filters as usual.
+3. Under **Then perform these actions**, click **Add action** and
    select **Send a notification via an integration → Robusta**.
-7. The "Destination" dropdown the schema declared appears here; leave
-   it at "Robusta".
-8. Save the rule.
+4. The "Destination" dropdown the schema declared appears here;
+   leave it at "Robusta".
+5. Save the rule.
 
 When the rule's conditions match, Sentry POSTs the ``event_alert``
 payload to Robusta, and the rule name shows up as the Robusta

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -89,9 +89,7 @@ Then in the **WEBHOOKS** section:
 
 3. Click **Save Changes** at the bottom of the form. The integration
    now appears under **INTERNAL INTEGRATIONS** on the Custom
-   Integrations list page with a **Dashboard** button next to it —
-   that dashboard is the primary debugging surface (see
-   :ref:`troubleshooting <sentry-troubleshooting>`).
+   Integrations list page.
 
 .. _sentry-path-alert-rule:
 
@@ -143,9 +141,7 @@ Then in the **PERMISSIONS** section:
 
 4. Click **Save Changes** at the bottom of the form. The integration
    now appears under **INTERNAL INTEGRATIONS** on the Custom
-   Integrations list page with a **Dashboard** button next to it —
-   that dashboard is the primary debugging surface (see
-   :ref:`troubleshooting <sentry-troubleshooting>`).
+   Integrations list page.
 
 Create a Sentry alert rule (Path B)
 -----------------------------------

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -1,8 +1,7 @@
 Sentry
 =======
 
-Forward Sentry alerts to Robusta via Sentry's Internal Integration
-(called **Custom Integration** in the current UI).
+Forward Sentry alerts to Robusta via Sentry's Internal Integration.
 
 Sentry exposes two webhook surfaces — pick whichever matches what you
 want forwarded, or set up both on the same integration:
@@ -59,8 +58,7 @@ Open the list page
 ~~~~~~~~~~~~~~~~~~
 
 1. In Sentry, navigate to **Settings → Integrations → Custom
-   Integrations** (direct link:
-   ``https://<your-org>.sentry.io/settings/custom-integrations/``).
+   Integrations**.
 2. Click **Create New Integration** in the top right.
 3. In the **Choose Integration Type** dialog, select **Internal
    Integration** and click **Next**.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -21,13 +21,6 @@ The recommended setup uses both on a single integration: subscribe to
 the issue lifecycle webhook *and* register the integration as an alert
 rule action.
 
-.. note::
-
-   Sentry Internal Integrations **do not let you add custom outgoing
-   HTTP headers** (the only auth header Sentry sends is its own
-   ``Sentry-Hook-Signature``). Pass the Robusta API key via the
-   ``&token=`` URL parameter instead.
-
 Prerequisites
 -------------
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -54,10 +54,6 @@ Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 Create the Custom Integration
 -----------------------------
 
-These steps are shared by both webhook paths — finish this section
-first, then jump to :ref:`sentry-path-issue-lifecycle`,
-:ref:`sentry-path-alert-rule`, or both.
-
 Open the list page
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -42,6 +42,14 @@ Webhook URL
 Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 ``<ROBUSTA_API_KEY>`` with the API key you just generated.
 
+.. note::
+
+   Sentry Internal Integrations **do not let you add custom outgoing
+   HTTP headers** (the only auth header Sentry sends is its own
+   ``Sentry-Hook-Signature``). The Robusta API key therefore goes in
+   the ``&token=`` URL parameter rather than an ``Authorization``
+   header.
+
 Create the Custom Integration
 -----------------------------
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -101,7 +101,7 @@ In the **INTERNAL INTEGRATION DETAILS** section:
                   "type": "text",
                   "name": "tags",
                   "label": "Tags",
-                  "default": "sentry"
+                  "default": "issue.title"
                 }
               ]
             }
@@ -118,14 +118,23 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 
    .. note::
 
-      Sentry's schema validator rejects ``alert-rule-action`` elements
-      whose ``required_fields`` array is empty
-      (*"[] is too short for element of type 'alert-rule-action'"*).
+      Sentry's schema validator imposes two constraints worth knowing
+      about:
+
+      * ``required_fields`` must contain **at least one element**
+        (*"[] is too short for element of type 'alert-rule-action'"*).
+      * ``text``/``textarea`` fields may only use ``issue.title`` or
+        ``issue.description`` as their ``default`` value — arbitrary
+        strings are rejected
+        (*"Elements of type ['text', 'textarea'] may only have a
+        default value of the following: ['issue.title',
+        'issue.description'], but X was found"*).
+
       The ``tags`` field above is a placeholder so the schema saves
-      cleanly; users configuring an alert rule will see a "Tags" text
-      input pre-filled with ``sentry`` and can leave it as-is. Robusta
-      ignores ``data.issue_alert.settings`` server-side, so the value
-      doesn't affect ingestion.
+      cleanly; pre-filled with ``issue.title`` so users configuring an
+      alert rule don't have to type anything. Robusta ignores
+      ``data.issue_alert.settings`` server-side, so the value doesn't
+      affect ingestion.
 
    .. note::
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -77,11 +77,10 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 
    .. note::
 
-      If the checkbox is locked, hover over the lock for Sentry's
-      explanation. Common causes: the org's Sentry plan doesn't
-      include alert-rule integration actions (a Business/Team-tier
-      feature on Sentry SaaS), or **Alerts** in the Permissions
-      section below hasn't been granted yet.
+      The checkbox stays locked until **Webhook URL** (step 5) is
+      filled in — Sentry's tooltip reads
+      *"Cannot enable alert rule action without a webhook url"*.
+      Fill the Webhook URL first, then tick this checkbox.
 
 7. **Schema**: leave blank for the typical Robusta setup. The schema
    is only needed when you want to add *custom form fields* (e.g.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -195,13 +195,14 @@ Troubleshooting
 ---------------
 
 Sentry exposes its own delivery history on the Custom Integration's
-**Dashboard** tab — open the integration from **Settings → Integrations
-→ Custom Integrations → Robusta** and switch to **Dashboard**. The
-dashboard lists every outgoing webhook with the HTTP status code
-Robusta returned, the timestamp, the request body Sentry sent, and the
-response body Robusta replied with. Always start debugging here — it
-tells you whether the problem is on Sentry's side (no requests showing
-up) or Robusta's side (requests present but non-200).
+**Dashboard** tab — open **Settings → Integrations → Custom
+Integrations** and, near the Robusta integration, click the
+**Dashboard** button. The dashboard lists every outgoing webhook
+with the HTTP status code Robusta returned, the timestamp, the
+request body Sentry sent, and the response body Robusta replied
+with. Always start debugging here — it tells you whether the problem
+is on Sentry's side (no requests showing up) or Robusta's side
+(requests present but non-200).
 
 Common responses and what they mean:
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -67,11 +67,6 @@ Start a new Internal Integration
    only for display in Sentry).
 5. **Webhook URL**: paste the URL from the previous section.
 
-Grant permissions
-~~~~~~~~~~~~~~~~~
-
-In the **PERMISSIONS** section, change the dropdowns:
-
 6. **Issue & Event**: set to **Read**.
 7. **Alerts**: set to **Read** (only needed if you'll set up
    :ref:`sentry-path-alert-rule`; harmless to grant either way).

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -26,7 +26,8 @@ Prerequisites
 -------------
 
 * A Robusta account with API access.
-* Your Robusta ``account_id``, found in ``generated_values.yaml``.
+* Your Robusta ``account_id``, found in ``generated_values.yaml`` or
+  under **Settings → Workspace** in the Robusta UI.
 * A Robusta API key with ``Read/Write`` access to alerts, generated
   under **Settings → API Keys → New API Key**.
 * Sentry **Owner** or **Manager** role on the org (lower roles can't

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -152,13 +152,6 @@ Register Robusta as an alert action
    the integration in the picker — without it, Robusta won't appear
    in the "Send a notification via an integration" dropdown.
 
-   .. note::
-
-      Sentry appends the schema's ``uri`` path to the webhook URL
-      host when an alert rule fires, so the path component of the
-      **Webhook URL** field (``/webhooks``) must match the schema
-      ``uri``. Query parameters in the Webhook URL are preserved.
-
 .. _sentry-save:
 
 Save the integration

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -1,7 +1,8 @@
 Sentry
 =======
 
-Forward Sentry alerts to Robusta via Sentry's Internal Integration.
+Forward Sentry alerts and issues to Robusta via Sentry's Internal
+Integration.
 
 Sentry can send events to Robusta in two different ways. Use either
 one, or enable both on the same integration:

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -173,12 +173,12 @@ Verify
 
 Trigger an event end-to-end to confirm the pipeline:
 
-* **Path A**: in Sentry, pick any existing issue → click
-  **Resolve** → then **Unresolve**. Two ``issue`` webhooks fire
+* **Issue Lifecycle Webhook**: in Sentry, pick any existing issue →
+  click **Resolve** → then **Unresolve**. Two ``issue`` webhooks fire
   back-to-back.
-* **Path B**: trigger an Issue Alert Rule that targets the Robusta
-  integration (or set the rule to "An event is seen" with no filters
-  and trigger any error in the app).
+* **Send alert webhook**: trigger an Issue Alert Rule that targets
+  the Robusta integration (or set the rule to "An event is seen"
+  with no filters and trigger any error in the app).
 
 Then:
 
@@ -239,11 +239,11 @@ Common responses and what they mean:
 If the dashboard shows **no recent requests** even though you
 triggered an event:
 
-* For **Path A**, verify the ``issue`` checkbox under **Webhooks** is
-  enabled and the integration is saved.
-* For **Path B**, verify the **Alert Rule Action** checkbox is on,
-  the **Schema** is saved, and the alert rule in your project lists
-  Robusta as one of its actions.
+* For the **Issue Lifecycle Webhook**, verify the ``issue`` checkbox
+  under **Webhooks** is enabled and the integration is saved.
+* For the **Send alert webhook** path, verify the **Alert Rule
+  Action** checkbox is on, the **Schema** is saved, and the alert
+  rule in your project lists Robusta as one of its actions.
 
 If the dashboard shows **200 responses but nothing appears in the
 Robusta timeline**, open the Robusta **Delivery Log** and look for

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -1,22 +1,25 @@
 Sentry
 =======
 
-Forward Sentry alerts to Robusta via Sentry's Internal Integration.
+Forward Sentry alerts to Robusta via Sentry's Internal Integration
+(called **Custom Integration** in the current UI).
 
-Sentry's Internal Integrations expose two webhook surfaces. Pick the one
-that matches what you want forwarded:
+Sentry exposes two webhook surfaces — pick whichever matches what you
+want forwarded, or set up both on the same integration:
 
-* **Issue Alert webhook** — fires only when a Sentry Issue Alert Rule
-  triggers. Includes the rule name, the offending event, and any
-  Kubernetes tags you've attached. Use this when you only want
-  rule-driven alerts.
-* **Issue lifecycle webhook** — fires on every issue created / resolved
-  / archived in the org. Lighter payload (no per-event details, no k8s
-  subject), but zero alert-rule plumbing. Use this when you want every
-  Sentry issue on the Robusta timeline.
+* :ref:`sentry-path-issue-lifecycle` — fires on every issue created /
+  resolved / assigned / archived / unresolved across the org. Lighter
+  payload (no per-event details, no k8s subject), zero alert-rule
+  plumbing. Use this when you want every Sentry issue on the Robusta
+  timeline.
+* :ref:`sentry-path-alert-rule` — fires only when a Sentry Issue
+  Alert Rule (or Metric Alert Rule) triggers and lists Robusta as one
+  of its actions. Richer payload (event detail, rule name, Kubernetes
+  tags). Use this when you want rule-driven, throttled alerts.
 
-The recommended setup uses both: register the integration as an alert
-rule action *and* subscribe to issue lifecycle webhooks.
+The recommended setup uses both on a single integration: subscribe to
+the issue lifecycle webhook *and* register the integration as an alert
+rule action.
 
 .. note::
 
@@ -48,8 +51,9 @@ Replace ``<ACCOUNT_ID>`` with your Robusta account id and
 Create the Custom Integration
 -----------------------------
 
-Sentry's "Internal Integration" lives under **Custom Integrations** in
-the current UI; the two names refer to the same feature.
+These steps are shared by both webhook paths — finish this section
+first, then jump to :ref:`sentry-path-issue-lifecycle`,
+:ref:`sentry-path-alert-rule`, or both.
 
 Open the list page
 ~~~~~~~~~~~~~~~~~~
@@ -69,22 +73,94 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 4. **Name**: ``Robusta`` (or ``Robusta Prod Alerts``, etc. — this is
    only for display in Sentry).
 5. **Webhook URL**: paste the URL from the previous section.
-6. **Alert Rule Action**: enable this checkbox if you want the
-   integration to be selectable inside Sentry Issue Alert and Metric
-   Alert rules. The notification destination is the **Webhook URL**
-   you just filled in. Leave it disabled if you only want the issue
-   lifecycle webhook.
+6. **Overview** and **Authorized JavaScript Origins**: leave both
+   blank.
+
+   You'll come back to **Alert Rule Action** and **Schema** in
+   :ref:`sentry-path-alert-rule` if you want that path; for now leave
+   them at their defaults.
+
+Grant permissions
+~~~~~~~~~~~~~~~~~
+
+In the **PERMISSIONS** section, change the dropdowns:
+
+7. **Issue & Event**: set to **Read**.
+8. **Alerts**: set to **Read** (only needed if you'll set up
+   :ref:`sentry-path-alert-rule`; harmless to grant either way).
+9. Leave every other permission row at **No Access**.
+
+Save the base integration before configuring either webhook path:
+
+10. Click **Save Changes** at the bottom of the form. The integration
+    now appears under **INTERNAL INTEGRATIONS** on the Custom
+    Integrations list page with a **Dashboard** button next to it —
+    that dashboard is the primary debugging surface (see
+    :ref:`troubleshooting <sentry-troubleshooting>`).
+
+.. _sentry-path-issue-lifecycle:
+
+Path A — Issue Lifecycle Webhook
+---------------------------------
+
+Sentry POSTs to the Webhook URL on every issue lifecycle transition
+(``created`` / ``resolved`` / ``assigned`` / ``archived`` /
+``unresolved``). This is the simpler path: no schema, no alert rules,
+every issue lands on the Robusta timeline automatically.
+
+Open the integration you just created and scroll to the **WEBHOOKS**
+section:
+
+1. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
+   ``resolved``, ``assigned``, ``archived``, ``unresolved``).
+2. Leave ``error``, ``comment``, ``seer``, and ``preprod_artifact``
+   unchecked.
+3. Click **Save Changes**.
+
+.. warning::
+
+   Do **not** enable the ``error`` checkbox. It fires on every
+   individual error event (not per issue), which will exhaust
+   Robusta's 300-requests-per-5-minutes rate limit on any non-trivial
+   service. The relay parser also doesn't recognise the ``error``
+   webhook payload shape, so enabled-``error`` traffic lands as
+   ``parse_status=failed`` rows.
+
+That's the entire Path A setup. Skip ahead to :ref:`Verify
+<sentry-verify>` to test it, or continue to Path B to layer
+alert-rule routing on top.
+
+.. _sentry-path-alert-rule:
+
+Path B — Alert Rule Action
+--------------------------
+
+This path makes Robusta selectable as an action inside Sentry Issue
+Alert and Metric Alert rules. Sentry POSTs only when one of those
+rules fires, and the webhook carries the event detail plus the rule
+name as the aggregation key.
+
+Two parts: register the integration as an alert action, then create
+the alert rule that uses it.
+
+Register Robusta as an alert action
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Open the integration and scroll back up to **INTERNAL INTEGRATION
+DETAILS**:
+
+1. **Alert Rule Action**: tick this checkbox. The notification
+   destination is the **Webhook URL** you saved earlier.
 
    .. note::
 
-      The checkbox stays locked until **Webhook URL** (step 5) is
-      filled in — Sentry's tooltip reads
-      *"Cannot enable alert rule action without a webhook url"*.
-      Fill the Webhook URL first, then tick this checkbox.
+      The checkbox is locked until **Webhook URL** is filled in —
+      Sentry's tooltip reads
+      *"Cannot enable alert rule action without a webhook url"*. If
+      you completed the shared setup above the URL is already there.
 
-7. **Schema** *(required for the alert-rule path; leave blank if you
-   only want the issue lifecycle webhook)*: paste the following JSON
-   so Robusta appears in Sentry's alert rule action picker.
+2. **Schema**: paste the following JSON so Robusta appears in
+   Sentry's alert rule action picker.
 
    .. code-block:: json
 
@@ -110,11 +186,10 @@ In the **INTERNAL INTEGRATION DETAILS** section:
       }
 
    The ``title`` is what shows up as the action label inside Sentry's
-   alert rule editor. The ``Alert Rule Action`` checkbox in step 6
-   toggles the feature on, but Sentry uses this schema to know *how*
-   to render the integration in the picker — without it, Robusta
-   won't appear in the "Send a notification via an integration"
-   dropdown.
+   alert rule editor. The ``Alert Rule Action`` checkbox toggles the
+   feature on, but Sentry uses this schema to know *how* to render
+   the integration in the picker — without it, Robusta won't appear
+   in the "Send a notification via an integration" dropdown.
 
    .. note::
 
@@ -137,79 +212,54 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 
    .. note::
 
-      Sentry appends the schema's ``uri`` path to the webhook URL host
-      when an alert rule fires, so the path component of the **Webhook
-      URL** field above (``/webhooks``) must match the schema ``uri``.
-      Query parameters in the Webhook URL are preserved.
+      Sentry appends the schema's ``uri`` path to the webhook URL
+      host when an alert rule fires, so the path component of the
+      **Webhook URL** field (``/webhooks``) must match the schema
+      ``uri``. Query parameters in the Webhook URL are preserved.
 
-8. **Overview** and **Authorized JavaScript Origins**: leave both
-   blank.
+3. Click **Save Changes**.
 
-Grant permissions
-~~~~~~~~~~~~~~~~~
+Create the Sentry alert rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the **PERMISSIONS** section, change the dropdowns:
+The integration is now selectable in alert rules, but until a rule is
+actually configured against it Sentry won't POST anything. For each
+project that should forward to Robusta:
 
-9. **Issue & Event**: set to **Read**.
-10. **Alerts**: set to **Read** (only required if you enabled Alert
-    Rule Action in step 6).
-11. Leave every other permission row at **No Access**.
+4. Open **Alerts → Create Alert** and choose **Issues**.
+5. Configure your conditions and filters as usual.
+6. Under **Then perform these actions**, click **Add action** and
+   select **Send a notification via an integration → Robusta**.
+7. The "Destination" dropdown the schema declared appears here; leave
+   it at "Robusta".
+8. Save the rule.
 
-Subscribe to webhook events
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When the rule's conditions match, Sentry POSTs the ``event_alert``
+payload to Robusta, and the rule name shows up as the Robusta
+aggregation key.
 
-In the **WEBHOOKS** section:
-
-12. Tick **only** the ``issue`` checkbox (sub-events: ``created``,
-    ``resolved``, ``assigned``, ``archived``, ``unresolved``). Leave
-    ``error``, ``comment``, ``seer``, and ``preprod_artifact``
-    unchecked.
-
-    .. warning::
-
-       Do **not** enable the ``error`` checkbox. It fires on every
-       individual error event (not per issue), which will exhaust
-       Robusta's 300-requests-per-5-minutes rate limit on any
-       non-trivial service. The relay parser also doesn't recognise
-       the ``error`` webhook payload shape, so enabled-``error``
-       traffic lands as ``parse_status=failed`` rows.
-
-Save
-~~~~
-
-13. Click **Save Changes** at the bottom of the form. The integration
-    now appears under **INTERNAL INTEGRATIONS** on the Custom
-    Integrations list page with a **Dashboard** button next to it —
-    that dashboard is the primary debugging surface (see
-    :ref:`troubleshooting <sentry-troubleshooting>`).
-
-Wire up an Issue Alert Rule (optional)
---------------------------------------
-
-Skip this section if you only want the issue lifecycle webhook
-behavior — the integration is already live after step 13.
-
-To route a specific Sentry alert rule through Robusta:
-
-1. In each Sentry project, open **Alerts → Create Alert** and choose
-   **Issues**.
-2. Configure your conditions and filters as usual.
-3. Under **Then perform these actions**, select **Send a notification
-   via an integration** and pick ``Robusta``.
-4. Save the rule. When it fires, Sentry POSTs the event_alert payload
-   to Robusta, and the rule name shows up as the Robusta aggregation
-   key.
+.. _sentry-verify:
 
 Verify
 ------
 
-* Resolve and re-open a Sentry issue (lifecycle webhook), or
-* Trigger an Issue Alert Rule that targets the Robusta integration
-  (alert-rule-action webhook).
+Trigger an event end-to-end to confirm the pipeline:
 
-Open **Settings → Delivery Log** in the Robusta UI — the event should
-appear there with parse status ``parsed``, and the corresponding row
-should land on the Robusta timeline.
+* **Path A**: in Sentry, pick any existing issue → click
+  **Resolve** → then **Unresolve**. Two ``issue`` webhooks fire
+  back-to-back.
+* **Path B**: trigger an Issue Alert Rule that targets the Robusta
+  integration (or set the rule to "An event is seen" with no filters
+  and trigger any error in the app).
+
+Then:
+
+1. Open the integration's **Dashboard** tab in Sentry — each POST
+   should show HTTP **200** from Robusta.
+2. Open **Settings → Delivery Log** in the Robusta UI — the event
+   should appear with ``parse_status=parsed``.
+3. Open the Robusta timeline — the Sentry-sourced row should land
+   within a few seconds.
 
 .. _sentry-troubleshooting:
 
@@ -258,16 +308,17 @@ Common responses and what they mean:
        displays in the response body; if it isn't there, contact
        Robusta support with the request id from the Sentry dashboard.
 
-If the dashboard shows **no recent requests** even though you triggered
-an event, the integration isn't subscribed to the right webhook:
-verify that the ``issue`` checkbox under **Webhooks** is enabled
-(``error`` is not needed — see the note in the previous section), and
-that the integration is **installed** to the organization, not just
-saved as a draft.
+If the dashboard shows **no recent requests** even though you
+triggered an event:
+
+* For **Path A**, verify the ``issue`` checkbox under **Webhooks** is
+  enabled and the integration is saved.
+* For **Path B**, verify the **Alert Rule Action** checkbox is on,
+  the **Schema** is saved, and the alert rule in your project lists
+  Robusta as one of its actions.
 
 If the dashboard shows **200 responses but nothing appears in the
 Robusta timeline**, open the Robusta **Delivery Log** and look for
 rows with ``origin=sentry`` and ``parse_status=failed`` — the
 ``parser_error`` column tells you which field the parser couldn't
 read.
-

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -9,13 +9,14 @@ one, or enable both on the same integration:
 
 * :ref:`sentry-path-issue-lifecycle` — fires on every issue created /
   resolved / assigned / archived / unresolved across the org. Lighter
-  payload (no per-event details, no k8s subject), zero alert-rule
-  plumbing. Use this when you want every Sentry issue on the Robusta
-  timeline.
+  payload (no per-event details, no event-level tags), zero
+  alert-rule plumbing. Use this when you want every Sentry issue on
+  the Robusta timeline.
 * :ref:`sentry-path-alert-rule` — fires only when a Sentry Issue
   Alert Rule (or Metric Alert Rule) triggers and lists Robusta as one
-  of its actions. Richer payload (event detail, rule name, Kubernetes
-  tags). Use this when you want rule-driven, throttled alerts.
+  of its actions. Richer payload (event detail, rule name, and all
+  tags attached to the event). Use this when you want rule-driven,
+  throttled alerts.
 
 The recommended setup uses both on a single integration: subscribe to
 the issue lifecycle webhook *and* register the integration as an alert

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -71,41 +71,28 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 5. **Webhook URL**: paste the URL from the previous section.
 6. **Alert Rule Action**: enable this checkbox if you want the
    integration to be selectable inside Sentry Issue Alert and Metric
-   Alert rules. This is required for the alert-rule path described
-   below; leave it disabled if you only want the issue lifecycle
-   webhook.
+   Alert rules. The notification destination is the **Webhook URL**
+   you just filled in. Leave it disabled if you only want the issue
+   lifecycle webhook.
 
    .. note::
 
-      The checkbox stays locked until **Schema** (next field) contains
-      a valid ``alert-rule-action`` element. Fill the schema first,
-      then enable the checkbox.
+      If the checkbox is locked, hover over the lock for Sentry's
+      explanation. Common causes: the org's Sentry plan doesn't
+      include alert-rule integration actions (a Business/Team-tier
+      feature on Sentry SaaS), or **Alerts** in the Permissions
+      section below hasn't been granted yet.
 
-7. **Schema** *(required when Alert Rule Action is enabled, otherwise
-   leave blank)*: paste the following JSON.
+7. **Schema**: leave blank for the typical Robusta setup. The schema
+   is only needed when you want to add *custom form fields* (e.g.
+   a user-fillable title or filter) to the alert rule configuration
+   UI in Sentry. The basic "fire ``event_alert`` webhook to the
+   Webhook URL" behavior is driven entirely by the **Alert Rule
+   Action** checkbox above — no schema required.
 
-   .. code-block:: json
-
-      {
-        "elements": [
-          {
-            "type": "alert-rule-action",
-            "title": "Send to Robusta",
-            "settings": {
-              "type": "alert-rule-settings",
-              "uri": "/webhooks",
-              "required_fields": []
-            }
-          }
-        ]
-      }
-
-   .. note::
-
-      Sentry appends the schema's ``uri`` path to the webhook URL host
-      when an alert rule fires, so the path component of the **Webhook
-      URL** field above (``/webhooks``) must match the schema ``uri``.
-      Query parameters in the Webhook URL are preserved.
+   If you do want custom form fields, see Sentry's
+   `Alert Rule Action UI component docs
+   <https://docs.sentry.io/organization/integrations/integration-platform/ui-components/alert-rule-action/>`_.
 
 8. **Overview** and **Authorized JavaScript Origins**: leave both
    blank.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -98,10 +98,10 @@ In the **INTERNAL INTEGRATION DETAILS** section:
               "uri": "/webhooks",
               "required_fields": [
                 {
-                  "type": "text",
-                  "name": "tags",
-                  "label": "Tags",
-                  "default": "issue.title"
+                  "type": "select",
+                  "label": "Destination",
+                  "name": "destination",
+                  "options": [["robusta", "Robusta"]]
                 }
               ]
             }
@@ -118,23 +118,22 @@ In the **INTERNAL INTEGRATION DETAILS** section:
 
    .. note::
 
-      Sentry's schema validator imposes two constraints worth knowing
-      about:
-
-      * ``required_fields`` must contain **at least one element**
-        (*"[] is too short for element of type 'alert-rule-action'"*).
-      * ``text``/``textarea`` fields may only use ``issue.title`` or
-        ``issue.description`` as their ``default`` value — arbitrary
-        strings are rejected
-        (*"Elements of type ['text', 'textarea'] may only have a
-        default value of the following: ['issue.title',
-        'issue.description'], but X was found"*).
-
-      The ``tags`` field above is a placeholder so the schema saves
-      cleanly; pre-filled with ``issue.title`` so users configuring an
-      alert rule don't have to type anything. Robusta ignores
+      Sentry's schema validator requires ``required_fields`` to
+      contain **at least one element** — an empty array fails with
+      *"[] is too short for element of type 'alert-rule-action'"*.
+      The single ``select`` field above is a placeholder that mirrors
+      Sentry's `documented schema example
+      <https://docs.sentry.io/integrations/integration-platform/ui-components/alert-rule-action/>`_:
+      users configuring an alert rule see a "Destination" dropdown
+      whose only option is "Robusta", so there's nothing to type and
+      no risk of misconfiguration. Robusta ignores
       ``data.issue_alert.settings`` server-side, so the value doesn't
       affect ingestion.
+
+      A ``text`` field would also satisfy the constraint, but Sentry
+      additionally restricts ``text``/``textarea`` defaults to
+      ``issue.title`` or ``issue.description`` only, which is a more
+      brittle pattern.
 
    .. note::
 

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -82,16 +82,39 @@ In the **INTERNAL INTEGRATION DETAILS** section:
       *"Cannot enable alert rule action without a webhook url"*.
       Fill the Webhook URL first, then tick this checkbox.
 
-7. **Schema**: leave blank for the typical Robusta setup. The schema
-   is only needed when you want to add *custom form fields* (e.g.
-   a user-fillable title or filter) to the alert rule configuration
-   UI in Sentry. The basic "fire ``event_alert`` webhook to the
-   Webhook URL" behavior is driven entirely by the **Alert Rule
-   Action** checkbox above — no schema required.
+7. **Schema** *(required for the alert-rule path; leave blank if you
+   only want the issue lifecycle webhook)*: paste the following JSON
+   so Robusta appears in Sentry's alert rule action picker.
 
-   If you do want custom form fields, see Sentry's
-   `Alert Rule Action UI component docs
-   <https://docs.sentry.io/organization/integrations/integration-platform/ui-components/alert-rule-action/>`_.
+   .. code-block:: json
+
+      {
+        "elements": [
+          {
+            "type": "alert-rule-action",
+            "title": "Send to Robusta",
+            "settings": {
+              "type": "alert-rule-settings",
+              "uri": "/webhooks",
+              "required_fields": []
+            }
+          }
+        ]
+      }
+
+   The ``title`` is what shows up as the action label inside Sentry's
+   alert rule editor. The ``Alert Rule Action`` checkbox in step 6
+   toggles the feature on, but Sentry uses this schema to know *how*
+   to render the integration in the picker — without it, Robusta
+   won't appear in the "Send a notification via an integration"
+   dropdown.
+
+   .. note::
+
+      Sentry appends the schema's ``uri`` path to the webhook URL host
+      when an alert rule fires, so the path component of the **Webhook
+      URL** field above (``/webhooks``) must match the schema ``uri``.
+      Query parameters in the Webhook URL are preserved.
 
 8. **Overview** and **Authorized JavaScript Origins**: leave both
    blank.

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -3,8 +3,8 @@ Sentry
 
 Forward Sentry alerts to Robusta via Sentry's Internal Integration.
 
-Sentry exposes two webhook surfaces — pick whichever matches what you
-want forwarded, or set up both on the same integration:
+Sentry can send events to Robusta in two different ways. Use either
+one, or enable both on the same integration:
 
 * :ref:`sentry-path-issue-lifecycle` — fires on every issue created /
   resolved / assigned / archived / unresolved across the org. Lighter

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -143,8 +143,8 @@ Then in the **PERMISSIONS** section:
    now appears under **INTERNAL INTEGRATIONS** on the Custom
    Integrations list page.
 
-Create a Sentry alert rule (Path B)
------------------------------------
+Create a Sentry alert rule
+--------------------------
 
 This section only applies if you configured
 :ref:`Alert Rule Action <sentry-path-alert-rule>` above. Skip it if

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -87,6 +87,12 @@ Then in the **WEBHOOKS** section:
    individual error event (not per issue) — a noisy service will
    generate far more webhook traffic than the issue checkbox does.
 
+3. Click **Save Changes** at the bottom of the form. The integration
+   now appears under **INTERNAL INTEGRATIONS** on the Custom
+   Integrations list page with a **Dashboard** button next to it —
+   that dashboard is the primary debugging surface (see
+   :ref:`troubleshooting <sentry-troubleshooting>`).
+
 .. _sentry-path-alert-rule:
 
 Alert Rule Action
@@ -135,16 +141,11 @@ Then in the **PERMISSIONS** section:
 
 3. **Alerts**: set to **Read**.
 
-.. _sentry-save:
-
-Save the integration
---------------------
-
-Click **Save Changes** at the bottom of the form. The integration
-now appears under **INTERNAL INTEGRATIONS** on the Custom
-Integrations list page with a **Dashboard** button next to it — that
-dashboard is the primary debugging surface (see
-:ref:`troubleshooting <sentry-troubleshooting>`).
+4. Click **Save Changes** at the bottom of the form. The integration
+   now appears under **INTERNAL INTEGRATIONS** on the Custom
+   Integrations list page with a **Dashboard** button next to it —
+   that dashboard is the primary debugging surface (see
+   :ref:`troubleshooting <sentry-troubleshooting>`).
 
 Create a Sentry alert rule (Path B)
 -----------------------------------

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -1,35 +1,114 @@
 Sentry
 =======
 
-Forward Sentry issues to Robusta via Sentry's webhook integration.
+Forward Sentry alerts to Robusta via Sentry's Internal Integration.
+
+Sentry's Internal Integrations expose two webhook surfaces. Pick the one
+that matches what you want forwarded:
+
+* **Issue Alert webhook** — fires only when a Sentry Issue Alert Rule
+  triggers. Includes the rule name, the offending event, and any
+  Kubernetes tags you've attached. Use this when you only want
+  rule-driven alerts.
+* **Issue lifecycle webhook** — fires on every issue created / resolved
+  / archived in the org. Lighter payload (no per-event details, no k8s
+  subject), but zero alert-rule plumbing. Use this when you want every
+  Sentry issue on the Robusta timeline.
+
+The recommended setup uses both: register the integration as an alert
+rule action *and* subscribe to issue lifecycle webhooks.
+
+.. note::
+
+   Sentry Internal Integrations **do not let you add custom outgoing
+   HTTP headers** (the only auth header Sentry sends is its own
+   ``Sentry-Hook-Signature``). Pass the Robusta API key via the
+   ``&token=`` URL parameter instead.
 
 Prerequisites
 -------------
 
 * A Robusta account with API access.
 * Your Robusta ``account_id``, found in ``generated_values.yaml``.
-* A Robusta API key with ``Read/Write`` access to alerts.
-* Sentry org-level access to install internal integrations.
+* A Robusta API key with ``Read/Write`` access to alerts, generated
+  under **Settings → API Keys → New API Key**.
+* Sentry org-level access to install Internal Integrations.
 
 Webhook URL
 -----------
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=sentry&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=sentry&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
 
-Configure Sentry
-----------------
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and
+``<ROBUSTA_API_KEY>`` with the API key you just generated.
 
-Sentry's webhook destinations support custom headers via Internal Integrations:
+Create the Internal Integration
+-------------------------------
 
-1. In Sentry, go to **Settings → Developer Settings → New Internal Integration**.
-2. Name it ``Robusta`` and grant **Issue & Event: Read** permissions.
-3. Subscribe to the **issue** webhook events.
-4. Set the **Webhook URL** to the URL above.
-5. Add the bearer token to a **Custom Outgoing Header** named ``Authorization`` with value ``Bearer <ROBUSTA_API_KEY>`` if your Sentry plan supports it; otherwise append ``&token=<ROBUSTA_API_KEY>`` to the URL.
+1. In Sentry, go to **Settings → Developer Settings → New Internal
+   Integration**.
+2. **Name**: ``Robusta``.
+3. **Webhook URL**: paste the URL from above.
+4. **Permissions**: grant **Issue & Event: Read**.
+5. **Webhooks**: enable the ``issue`` checkbox. Sentry will POST to
+   the webhook URL whenever an issue is created, resolved, assigned,
+   archived, or unresolved.
+6. **Schema** *(optional, only needed if you want Sentry Alert Rules to
+   target Robusta)*: paste the following JSON to register the
+   integration as an Alert Rule Action.
+
+   .. code-block:: json
+
+      {
+        "elements": [
+          {
+            "type": "alert-rule-action",
+            "title": "Send to Robusta",
+            "settings": {
+              "type": "alert-rule-settings",
+              "uri": "/webhooks",
+              "required_fields": []
+            }
+          }
+        ]
+      }
+
+7. Click **Save Changes**, then **Install** the integration to your
+   organization.
+
+.. note::
+
+   Sentry appends the schema's ``uri`` path to the webhook URL host
+   when an alert rule fires, so the path component of the **Webhook
+   URL** field above (``/webhooks``) must match the schema ``uri``.
+   Query parameters in the Webhook URL are preserved.
+
+Wire up an Issue Alert Rule (optional)
+--------------------------------------
+
+Skip this section if you only want the issue lifecycle webhook
+behavior — the integration is already live after step 7.
+
+To route a specific Sentry alert rule through Robusta:
+
+1. In each Sentry project, open **Alerts → Create Alert** and choose
+   **Issues**.
+2. Configure your conditions and filters as usual.
+3. Under **Then perform these actions**, select **Send a notification
+   via an integration** and pick ``Robusta``.
+4. Save the rule. When it fires, Sentry POSTs the event_alert payload
+   to Robusta, and the rule name shows up as the Robusta aggregation
+   key.
 
 Verify
 ------
 
-Resolve and re-open a Sentry issue, or trigger an issue alert rule that points at this integration. The event should appear in **Settings → Delivery Log** and on the Robusta timeline.
+* Resolve and re-open a Sentry issue (lifecycle webhook), or
+* Trigger an Issue Alert Rule that targets the Robusta integration
+  (alert-rule-action webhook).
+
+Open **Settings → Delivery Log** in the Robusta UI — the event should
+appear there with parse status ``parsed``, and the corresponding row
+should land on the Robusta timeline.


### PR DESCRIPTION
## Summary
Significantly expanded and restructured the Sentry integration documentation to provide clearer guidance on setting up Sentry's Internal Integration with Robusta, including detailed step-by-step instructions and clarification on webhook options.

## Key Changes
- **Clarified webhook options**: Added explanation of two webhook surfaces (Issue Alert webhook vs. Issue lifecycle webhook) with use cases for each
- **Updated authentication approach**: Documented that Sentry Internal Integrations don't support custom headers, requiring API key to be passed via `&token=` URL parameter instead
- **Enhanced webhook URL**: Updated the URL format to include the `&token=` parameter for API authentication
- **Added detailed setup steps**: Provided comprehensive step-by-step instructions for creating the Internal Integration, including:
  - Navigation paths in Sentry UI
  - Required permissions (Issue & Event: Read)
  - Webhook configuration
  - Optional schema JSON for registering as an Alert Rule Action
- **Added optional Alert Rule setup**: Included separate section for wiring up Issue Alert Rules with detailed instructions
- **Improved verification steps**: Enhanced the verification section with clearer instructions on what to check and where to find results
- **Added helpful notes**: Included clarifications about schema URI path matching and the recommended approach of using both webhook types

## Notable Details
- The schema JSON block enables Sentry Alert Rules to target Robusta as an action, making the integration more discoverable in Sentry's UI
- Documentation now explicitly addresses the limitation that Sentry Internal Integrations cannot use custom HTTP headers
- Restructured content to separate mandatory setup from optional alert rule configuration for better clarity

https://claude.ai/code/session_01TGHe7iJY3tciJjyhaLU1E5