### PR TITLE
Update Rootly webhook configuration to use URL token parameter

### DIFF
--- a/docs/configuration/exporting/send-events/rootly.rst
+++ b/docs/configuration/exporting/send-events/rootly.rst
@@ -20,10 +20,6 @@ Webhook URL
 
 Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<ROBUSTA_API_KEY>`` with the API key you generated.
 
-.. note::
-
-   Rootly outgoing webhooks **do not let you add custom outgoing HTTP headers**, so the Robusta API key goes in the ``&token=`` URL parameter rather than an ``Authorization`` header.
-
 Configure Rootly
 ----------------
 

--- a/docs/configuration/exporting/send-events/rootly.rst
+++ b/docs/configuration/exporting/send-events/rootly.rst
@@ -16,21 +16,21 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=rootly&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=rootly&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<ROBUSTA_API_KEY>`` with the API key you generated.
+
+.. note::
+
+   Rootly outgoing webhooks **do not let you add custom outgoing HTTP headers**, so the Robusta API key goes in the ``&token=`` URL parameter rather than an ``Authorization`` header.
 
 Configure Rootly
 ----------------
 
 1. In Rootly, go to **Integrations → Webhooks → New Webhook**.
 2. Set the **URL** to the webhook URL above.
-3. Add a custom header:
-
-   .. code-block::
-
-       Authorization: Bearer <ROBUSTA_API_KEY>
-
-4. Subscribe the webhook to the alert events you want forwarded — at minimum ``alert.created``. If the Rootly UI offers other ``alert.*`` events (for example to notify on resolution), subscribe to those as well; Robusta accepts the whole ``alert.*`` family and uses the alert object's ``ended_at`` field to tell firing from resolved, so the parser stays correct regardless of which specific event names Rootly emits.
-5. Save. Rootly will start delivering alerts immediately.
+3. Subscribe the webhook to the alert events you want forwarded — at minimum ``alert.created``. If the Rootly UI offers other ``alert.*`` events (for example to notify on resolution), subscribe to those as well; Robusta accepts the whole ``alert.*`` family and uses the alert object's ``ended_at`` field to tell firing from resolved, so the parser stays correct regardless of which specific event names Rootly emits.
+4. Save. Rootly will start delivering alerts immediately.
 
 Payload
 -------


### PR DESCRIPTION
## Summary
Updated the Rootly webhook integration documentation to pass the Robusta API key as a URL parameter instead of a custom HTTP header, since Rootly webhooks don't support custom outgoing headers.

## Key Changes
- Modified the webhook URL to include `&token=<ROBUSTA_API_KEY>` parameter
- Removed the custom `Authorization: Bearer` header configuration step
- Added a note explaining why the token must be passed as a URL parameter rather than a header
- Added clarification text for replacing placeholder values (`<ACCOUNT_ID>` and `<ROBUSTA_API_KEY>`)
- Renumbered the remaining configuration steps after removing the header step

## Implementation Details
- The API key is now passed directly in the webhook URL as a query parameter, which is the only viable approach given Rootly's webhook limitations
- The documentation now clearly explains this constraint to users
- All other webhook configuration steps remain functionally the same

https://claude.ai/code/session_013L7mUcwgJHs1xc32xyTB5F