### PR TITLE
Add deprecation notices to legacy sink documentation pages

### DIFF
--- a/docs/_ext/region_box.py
+++ b/docs/_ext/region_box.py
@@ -27,6 +27,8 @@ import re
 from html import escape
 
 from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util import parselinenos
 from sphinx.util.docutils import SphinxDirective
 
 
@@ -68,6 +70,9 @@ class RobustaCodeDirective(SphinxDirective):
     required_arguments = 0
     optional_arguments = 1
     final_argument_whitespace = False
+    option_spec = {
+        "emphasize-lines": directives.unchanged_required,
+    }
 
     def run(self):
         language = self.arguments[0] if self.arguments else "text"
@@ -83,6 +88,17 @@ class RobustaCodeDirective(SphinxDirective):
         container = nodes.container(classes=["robusta-region-box", "robusta-region-box--code"])
         literal = nodes.literal_block(code, code)
         literal["language"] = language
+
+        emphasize_spec = self.options.get("emphasize-lines")
+        if emphasize_spec:
+            try:
+                nlines = len(code.split("\n"))
+                hl_lines = [x + 1 for x in parselinenos(emphasize_spec, nlines) if 0 <= x < nlines]
+            except ValueError:
+                hl_lines = []
+            if hl_lines:
+                literal["highlight_args"] = {"hl_lines": hl_lines}
+
         container += literal
         return [container]
 

--- a/docs/configuration/alertmanager-integration/launchdarkly.rst
+++ b/docs/configuration/alertmanager-integration/launchdarkly.rst
@@ -1,3 +1,5 @@
+.. include:: ../_legacy_banner.rst
+
 LaunchDarkly Integration with Robusta
 =====================================
 

--- a/docs/configuration/sinks/DataDog.rst
+++ b/docs/configuration/sinks/DataDog.rst
@@ -1,6 +1,14 @@
 DataDog
 ##########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your cluster to the Datadog events API.
 
 Example Output:

--- a/docs/configuration/sinks/DataDog.rst
+++ b/docs/configuration/sinks/DataDog.rst
@@ -4,7 +4,7 @@ DataDog
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/DataDog.rst
+++ b/docs/configuration/sinks/DataDog.rst
@@ -6,7 +6,7 @@ DataDog
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your cluster to the Datadog events API.

--- a/docs/configuration/sinks/DataDog.rst
+++ b/docs/configuration/sinks/DataDog.rst
@@ -6,7 +6,7 @@ DataDog
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your cluster to the Datadog events API.

--- a/docs/configuration/sinks/DataDog.rst
+++ b/docs/configuration/sinks/DataDog.rst
@@ -6,7 +6,9 @@ DataDog
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your cluster to the Datadog events API.

--- a/docs/configuration/sinks/DataDog.rst
+++ b/docs/configuration/sinks/DataDog.rst
@@ -6,7 +6,7 @@ DataDog
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your cluster to the Datadog events API.

--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -6,7 +6,7 @@ Opsgenie
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the OpsGenie alerts API.

--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -6,7 +6,9 @@ Opsgenie
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the OpsGenie alerts API.

--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -6,7 +6,7 @@ Opsgenie
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the OpsGenie alerts API.

--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -4,7 +4,7 @@ Opsgenie
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -6,7 +6,7 @@ Opsgenie
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the OpsGenie alerts API.

--- a/docs/configuration/sinks/Opsgenie.rst
+++ b/docs/configuration/sinks/Opsgenie.rst
@@ -1,6 +1,14 @@
 Opsgenie
 ##########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to the OpsGenie alerts API.
 
 To configure OpsGenie, We need an OpsGenie API key. It can be configured using the OpsGenie team integration.

--- a/docs/configuration/sinks/PagerDuty.rst
+++ b/docs/configuration/sinks/PagerDuty.rst
@@ -6,7 +6,7 @@ PagerDuty
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can send three types of data to `PagerDuty <https://www.pagerduty.com/>`_:

--- a/docs/configuration/sinks/PagerDuty.rst
+++ b/docs/configuration/sinks/PagerDuty.rst
@@ -6,7 +6,9 @@ PagerDuty
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can send three types of data to `PagerDuty <https://www.pagerduty.com/>`_:

--- a/docs/configuration/sinks/PagerDuty.rst
+++ b/docs/configuration/sinks/PagerDuty.rst
@@ -1,6 +1,14 @@
 PagerDuty
 ##########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can send three types of data to `PagerDuty <https://www.pagerduty.com/>`_:
 
 * `Change Events <https://support.pagerduty.com/docs/change-events>`_ - for example, when Deployments are updated

--- a/docs/configuration/sinks/PagerDuty.rst
+++ b/docs/configuration/sinks/PagerDuty.rst
@@ -6,7 +6,7 @@ PagerDuty
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can send three types of data to `PagerDuty <https://www.pagerduty.com/>`_:

--- a/docs/configuration/sinks/PagerDuty.rst
+++ b/docs/configuration/sinks/PagerDuty.rst
@@ -6,7 +6,7 @@ PagerDuty
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can send three types of data to `PagerDuty <https://www.pagerduty.com/>`_:

--- a/docs/configuration/sinks/PagerDuty.rst
+++ b/docs/configuration/sinks/PagerDuty.rst
@@ -4,7 +4,7 @@ PagerDuty
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/RobustaUI.rst
+++ b/docs/configuration/sinks/RobustaUI.rst
@@ -1,19 +1,9 @@
 Robusta UI
 #################
 
-Take your Kubernetes monitoring to the next level with a Robusta UI integration:
+The Robusta UI sink connects your Robusta installation to the Robusta SaaS platform, where you can investigate alerts with HolmesGPT, review timelines, and more.
 
-- **AI Assistant**: Solve alerts faster with an AI assistant that highlights relevant observability data
-- **Alert Timeline**: View Prometheus alerts across multiple clusters and spot correlations with a powerful timeline view
-- **Change Tracking**: Correlate alerts with changes to your infrastructure or applications, with Robusta’s automatic change tracking for Kubernetes
-
-.. raw:: html
-
-    <div style="text-align: center;">
-      <a href="https://www.loom.com/share/89c7e098d9494d79895738e0b06091f0" target="_blank" rel="noopener noreferrer">
-          <img src="https://cdn.loom.com/sessions/thumbnails/89c7e098d9494d79895738e0b06091f0-f508768968f50b46-full-play.gif">
-      </a>
-    </div>
+For the full list of platform features, see `home.robusta.dev <https://home.robusta.dev>`_.
 
 
 Configuring the Robusta UI Sink
@@ -45,6 +35,10 @@ Perform a :ref:`Helm Upgrade <Simple Upgrade>`.
 Handling Short-Lived Clusters in the UI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+
+   This is a Robusta classic feature for Kubernetes monitoring and does not apply to HolmesGPT.
+
 By default, inactive Robusta clusters will be kept in the UI for 6 months **data retention**. (4380 hours)
 
 If you have many short-lived clusters, you can remove them from the UI automatically once they stop running.
@@ -66,7 +60,11 @@ To do so, configure a shorter retention period by setting the ``ttl_hours`` in t
 Monitoring Specific Resources in Namespaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the Robusta UI sink discovers the standard resources in all namespaces using the standard discovery interval. 
+.. note::
+
+   This is a Robusta classic feature for Kubernetes monitoring and does not apply to HolmesGPT.
+
+By default, the Robusta UI sink discovers the standard resources in all namespaces using the standard discovery interval.
 However, we have a configuration to monitor custom namespaced resources, and an API is exposed via the Robusta Backend to see how many of each resource you have in a namespace.
 
 To configure this, use the ``namespace_discovery_seconds`` and ``namespaceMonitoredResources`` settings in the Robusta UI sink:

--- a/docs/configuration/sinks/ServiceNow.rst
+++ b/docs/configuration/sinks/ServiceNow.rst
@@ -6,7 +6,7 @@ ServiceNow
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster by creating

--- a/docs/configuration/sinks/ServiceNow.rst
+++ b/docs/configuration/sinks/ServiceNow.rst
@@ -6,7 +6,9 @@ ServiceNow
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster by creating

--- a/docs/configuration/sinks/ServiceNow.rst
+++ b/docs/configuration/sinks/ServiceNow.rst
@@ -6,7 +6,7 @@ ServiceNow
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster by creating

--- a/docs/configuration/sinks/ServiceNow.rst
+++ b/docs/configuration/sinks/ServiceNow.rst
@@ -4,7 +4,7 @@ ServiceNow
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/ServiceNow.rst
+++ b/docs/configuration/sinks/ServiceNow.rst
@@ -1,6 +1,14 @@
 ServiceNow
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster by creating
 issues in ServiceNow.
 

--- a/docs/configuration/sinks/ServiceNow.rst
+++ b/docs/configuration/sinks/ServiceNow.rst
@@ -6,7 +6,7 @@ ServiceNow
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster by creating

--- a/docs/configuration/sinks/VictorOps.rst
+++ b/docs/configuration/sinks/VictorOps.rst
@@ -4,7 +4,7 @@ VictorOps
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/VictorOps.rst
+++ b/docs/configuration/sinks/VictorOps.rst
@@ -6,7 +6,7 @@ VictorOps
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the VictorOps alerts API.

--- a/docs/configuration/sinks/VictorOps.rst
+++ b/docs/configuration/sinks/VictorOps.rst
@@ -1,6 +1,14 @@
 VictorOps
 ##########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to the VictorOps alerts API.
 
 | To configure VictorOps, a VictorOps REST endpoint (url) is needed.

--- a/docs/configuration/sinks/VictorOps.rst
+++ b/docs/configuration/sinks/VictorOps.rst
@@ -6,7 +6,7 @@ VictorOps
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the VictorOps alerts API.

--- a/docs/configuration/sinks/VictorOps.rst
+++ b/docs/configuration/sinks/VictorOps.rst
@@ -6,7 +6,9 @@ VictorOps
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the VictorOps alerts API.

--- a/docs/configuration/sinks/VictorOps.rst
+++ b/docs/configuration/sinks/VictorOps.rst
@@ -6,7 +6,7 @@ VictorOps
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to the VictorOps alerts API.

--- a/docs/configuration/sinks/YandexMessenger.rst
+++ b/docs/configuration/sinks/YandexMessenger.rst
@@ -6,7 +6,7 @@ Yandex Messenger
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Yandex Messenger chats, channels or private conversations.

--- a/docs/configuration/sinks/YandexMessenger.rst
+++ b/docs/configuration/sinks/YandexMessenger.rst
@@ -4,7 +4,7 @@ Yandex Messenger
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/YandexMessenger.rst
+++ b/docs/configuration/sinks/YandexMessenger.rst
@@ -6,7 +6,7 @@ Yandex Messenger
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Yandex Messenger chats, channels or private conversations.

--- a/docs/configuration/sinks/YandexMessenger.rst
+++ b/docs/configuration/sinks/YandexMessenger.rst
@@ -6,7 +6,9 @@ Yandex Messenger
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Yandex Messenger chats, channels or private conversations.

--- a/docs/configuration/sinks/YandexMessenger.rst
+++ b/docs/configuration/sinks/YandexMessenger.rst
@@ -1,6 +1,14 @@
 Yandex Messenger
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Yandex Messenger chats, channels or private conversations.
 
 .. note::

--- a/docs/configuration/sinks/YandexMessenger.rst
+++ b/docs/configuration/sinks/YandexMessenger.rst
@@ -6,7 +6,7 @@ Yandex Messenger
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Yandex Messenger chats, channels or private conversations.

--- a/docs/configuration/sinks/discord.rst
+++ b/docs/configuration/sinks/discord.rst
@@ -1,6 +1,14 @@
 Discord
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Discord.
 
 .. image:: /images/discord_example.png

--- a/docs/configuration/sinks/discord.rst
+++ b/docs/configuration/sinks/discord.rst
@@ -6,7 +6,9 @@ Discord
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Discord.

--- a/docs/configuration/sinks/discord.rst
+++ b/docs/configuration/sinks/discord.rst
@@ -6,7 +6,7 @@ Discord
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Discord.

--- a/docs/configuration/sinks/discord.rst
+++ b/docs/configuration/sinks/discord.rst
@@ -6,7 +6,7 @@ Discord
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Discord.

--- a/docs/configuration/sinks/discord.rst
+++ b/docs/configuration/sinks/discord.rst
@@ -4,7 +4,7 @@ Discord
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/discord.rst
+++ b/docs/configuration/sinks/discord.rst
@@ -6,7 +6,7 @@ Discord
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Discord.

--- a/docs/configuration/sinks/file.rst
+++ b/docs/configuration/sinks/file.rst
@@ -6,7 +6,9 @@ File
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can write issues and events in your Kubernetes cluster to a local file (in JSON format).

--- a/docs/configuration/sinks/file.rst
+++ b/docs/configuration/sinks/file.rst
@@ -4,7 +4,7 @@ File
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/file.rst
+++ b/docs/configuration/sinks/file.rst
@@ -6,7 +6,7 @@ File
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can write issues and events in your Kubernetes cluster to a local file (in JSON format).

--- a/docs/configuration/sinks/file.rst
+++ b/docs/configuration/sinks/file.rst
@@ -6,7 +6,7 @@ File
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can write issues and events in your Kubernetes cluster to a local file (in JSON format).

--- a/docs/configuration/sinks/file.rst
+++ b/docs/configuration/sinks/file.rst
@@ -1,6 +1,14 @@
 File
 ###########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can write issues and events in your Kubernetes cluster to a local file (in JSON format).
 
 

--- a/docs/configuration/sinks/file.rst
+++ b/docs/configuration/sinks/file.rst
@@ -6,7 +6,7 @@ File
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can write issues and events in your Kubernetes cluster to a local file (in JSON format).

--- a/docs/configuration/sinks/google_chat.rst
+++ b/docs/configuration/sinks/google_chat.rst
@@ -1,6 +1,14 @@
 Google Chat
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster by sending
 messages via the `Google Chat <https://chat.google.com/>`_ app.
 

--- a/docs/configuration/sinks/google_chat.rst
+++ b/docs/configuration/sinks/google_chat.rst
@@ -6,7 +6,7 @@ Google Chat
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/google_chat.rst
+++ b/docs/configuration/sinks/google_chat.rst
@@ -6,7 +6,7 @@ Google Chat
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/google_chat.rst
+++ b/docs/configuration/sinks/google_chat.rst
@@ -6,7 +6,9 @@ Google Chat
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/google_chat.rst
+++ b/docs/configuration/sinks/google_chat.rst
@@ -4,7 +4,7 @@ Google Chat
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/google_chat.rst
+++ b/docs/configuration/sinks/google_chat.rst
@@ -6,7 +6,7 @@ Google Chat
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/index.rst
+++ b/docs/configuration/sinks/index.rst
@@ -11,7 +11,9 @@ All Sinks
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 Robusta can send notifications to various destinations, known as sinks.
 

--- a/docs/configuration/sinks/index.rst
+++ b/docs/configuration/sinks/index.rst
@@ -6,6 +6,13 @@ All Sinks
 ==================
 
 
+.. admonition:: Sinks are a legacy feature of Robusta classic
+   :class: warning
+
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+
 Robusta can send notifications to various destinations, known as sinks.
 
 **Related Topics:**

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -1,6 +1,14 @@
 Jira
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can automatically open and (optionally) resolve Jira tickets, based on issues in your Kubernetes cluster.
 
   .. image:: /images/jira_example.png

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -6,7 +6,7 @@ Jira
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can automatically open and (optionally) resolve Jira tickets, based on issues in your Kubernetes cluster.

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -6,7 +6,7 @@ Jira
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can automatically open and (optionally) resolve Jira tickets, based on issues in your Kubernetes cluster.

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -6,7 +6,7 @@ Jira
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can automatically open and (optionally) resolve Jira tickets, based on issues in your Kubernetes cluster.

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -6,7 +6,9 @@ Jira
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can automatically open and (optionally) resolve Jira tickets, based on issues in your Kubernetes cluster.

--- a/docs/configuration/sinks/jira.rst
+++ b/docs/configuration/sinks/jira.rst
@@ -4,7 +4,7 @@ Jira
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -6,7 +6,7 @@ Kafka
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a Kafka topic.

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -4,7 +4,7 @@ Kafka
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -6,7 +6,9 @@ Kafka
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a Kafka topic.

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -6,7 +6,7 @@ Kafka
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a Kafka topic.

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -6,7 +6,7 @@ Kafka
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a Kafka topic.

--- a/docs/configuration/sinks/kafka.rst
+++ b/docs/configuration/sinks/kafka.rst
@@ -1,6 +1,14 @@
 Kafka
 #########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to a Kafka topic.
 
 Configuring the Kafka sink

--- a/docs/configuration/sinks/mail.rst
+++ b/docs/configuration/sinks/mail.rst
@@ -4,7 +4,7 @@ Mail
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/mail.rst
+++ b/docs/configuration/sinks/mail.rst
@@ -6,7 +6,7 @@ Mail
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/mail.rst
+++ b/docs/configuration/sinks/mail.rst
@@ -6,7 +6,7 @@ Mail
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/mail.rst
+++ b/docs/configuration/sinks/mail.rst
@@ -6,7 +6,9 @@ Mail
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/mail.rst
+++ b/docs/configuration/sinks/mail.rst
@@ -1,6 +1,14 @@
 Mail
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster by sending
 emails using either SMTP servers or Amazon Simple Email Service (SES).
 

--- a/docs/configuration/sinks/mail.rst
+++ b/docs/configuration/sinks/mail.rst
@@ -6,7 +6,7 @@ Mail
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster by sending

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -6,7 +6,7 @@ Mattermost
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Mattermost.

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -6,7 +6,7 @@ Mattermost
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Mattermost.

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -4,7 +4,7 @@ Mattermost
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -6,7 +6,7 @@ Mattermost
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Mattermost.

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -6,7 +6,9 @@ Mattermost
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Mattermost.

--- a/docs/configuration/sinks/mattermost.rst
+++ b/docs/configuration/sinks/mattermost.rst
@@ -1,6 +1,14 @@
 Mattermost
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Mattermost.
 
 .. image:: /images/mattermost_sink_example.png

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -8,7 +8,7 @@ MS Teams
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
-   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions instead of blindly forwarding every notification.
+   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 Robusta can report issues and events in your Kubernetes cluster to a MS Teams webhook.
 

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -1,6 +1,15 @@
 MS Teams
 ##########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want to connect HolmesGPT to Slack and Teams directly, instead of using this legacy sink.
+
+   Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
+
+   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions instead of blindly forwarding every notification.
+
 Robusta can report issues and events in your Kubernetes cluster to a MS Teams webhook.
 
 .. image:: /images/msteams_sink/deployment-babysitter-teams.png

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -4,11 +4,15 @@ MS Teams
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   For new setups, we recommend connecting HolmesGPT to MS Teams directly instead of using this legacy sink.
+   For new setups, we recommend connecting HolmesGPT to MS Teams instead of using this legacy sink.
 
-   Open the `MS Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to MS Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
+   Open the `MS Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform to connect HolmesGPT to MS Teams. This adds a single HolmesGPT bot that powers all of the flows below:
 
-   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   - **Chat** — ``@mention`` the bot in any channel to investigate issues on demand; it replies in the thread.
+   - **Alerts** — let `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ automatically investigate incoming alerts and post the findings to MS Teams.
+   - **Custom events** — use :ref:`Triggered Workflows <defining-playbooks>` to react to arbitrary events and notify MS Teams.
+
+   These are separate flows that share the same bot: chat is interactive, while Alerts Triage and Triggered Workflows run automatically.
 
 Robusta can report issues and events in your Kubernetes cluster to a MS Teams webhook.
 

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -8,7 +8,7 @@ MS Teams
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
-   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert, using :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_. You can also configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ directly in the platform.
+   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 Robusta can report issues and events in your Kubernetes cluster to a MS Teams webhook.
 

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -4,7 +4,7 @@ MS Teams
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want to connect HolmesGPT to Slack and Teams directly, instead of using this legacy sink.
+   For new setups, we recommend connecting HolmesGPT to Slack and Teams directly instead of using this legacy sink.
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -4,9 +4,9 @@ MS Teams
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   For new setups, we recommend connecting HolmesGPT to Slack and Teams directly instead of using this legacy sink.
+   For new setups, we recommend connecting HolmesGPT to MS Teams directly instead of using this legacy sink.
 
-   Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
+   Open the `MS Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to MS Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
    Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 

--- a/docs/configuration/sinks/ms-teams.rst
+++ b/docs/configuration/sinks/ms-teams.rst
@@ -8,7 +8,7 @@ MS Teams
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
-   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert, using :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_. You can also configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ directly in the platform.
 
 Robusta can report issues and events in your Kubernetes cluster to a MS Teams webhook.
 

--- a/docs/configuration/sinks/pushover.rst
+++ b/docs/configuration/sinks/pushover.rst
@@ -6,7 +6,7 @@ Pushover
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Pushover notification enabled devices.

--- a/docs/configuration/sinks/pushover.rst
+++ b/docs/configuration/sinks/pushover.rst
@@ -1,6 +1,14 @@
 Pushover
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Pushover notification enabled devices.
 
 .. note::

--- a/docs/configuration/sinks/pushover.rst
+++ b/docs/configuration/sinks/pushover.rst
@@ -6,7 +6,7 @@ Pushover
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Pushover notification enabled devices.

--- a/docs/configuration/sinks/pushover.rst
+++ b/docs/configuration/sinks/pushover.rst
@@ -4,7 +4,7 @@ Pushover
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/pushover.rst
+++ b/docs/configuration/sinks/pushover.rst
@@ -6,7 +6,7 @@ Pushover
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Pushover notification enabled devices.

--- a/docs/configuration/sinks/pushover.rst
+++ b/docs/configuration/sinks/pushover.rst
@@ -6,7 +6,9 @@ Pushover
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Pushover notification enabled devices.

--- a/docs/configuration/sinks/rocketchat.rst
+++ b/docs/configuration/sinks/rocketchat.rst
@@ -6,7 +6,7 @@ Rocket.Chat
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Rocket.Chat.

--- a/docs/configuration/sinks/rocketchat.rst
+++ b/docs/configuration/sinks/rocketchat.rst
@@ -4,7 +4,7 @@ Rocket.Chat
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/rocketchat.rst
+++ b/docs/configuration/sinks/rocketchat.rst
@@ -6,7 +6,9 @@ Rocket.Chat
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Rocket.Chat.

--- a/docs/configuration/sinks/rocketchat.rst
+++ b/docs/configuration/sinks/rocketchat.rst
@@ -6,7 +6,7 @@ Rocket.Chat
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Rocket.Chat.

--- a/docs/configuration/sinks/rocketchat.rst
+++ b/docs/configuration/sinks/rocketchat.rst
@@ -1,6 +1,14 @@
 Rocket.Chat
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Rocket.Chat.
 
 .. image:: /images/rocketchat1.png

--- a/docs/configuration/sinks/rocketchat.rst
+++ b/docs/configuration/sinks/rocketchat.rst
@@ -6,7 +6,7 @@ Rocket.Chat
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Rocket.Chat.

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -8,7 +8,7 @@ Slack
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
-   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions instead of blindly forwarding every notification.
+   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 Robusta can proxy Prometheus alerts to Slack, adding powerful features like :ref:`AI investigation <AI Analysis>`, :ref:`smart grouping <notification-grouping>` and more.
 

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -8,7 +8,7 @@ Slack
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
-   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert, using :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_. You can also configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ directly in the platform.
 
 Robusta can proxy Prometheus alerts to Slack, adding powerful features like :ref:`AI investigation <AI Analysis>`, :ref:`smart grouping <notification-grouping>` and more.
 

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -4,7 +4,7 @@ Slack
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want to connect HolmesGPT to Slack and Teams directly, instead of using this legacy sink.
+   For new setups, we recommend connecting HolmesGPT to Slack and Teams directly instead of using this legacy sink.
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -8,7 +8,7 @@ Slack
 
    Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
-   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert, using :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_. You can also configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ directly in the platform.
+   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 Robusta can proxy Prometheus alerts to Slack, adding powerful features like :ref:`AI investigation <AI Analysis>`, :ref:`smart grouping <notification-grouping>` and more.
 

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -1,6 +1,15 @@
 Slack
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want to connect HolmesGPT to Slack and Teams directly, instead of using this legacy sink.
+
+   Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
+
+   Under the hood this investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions instead of blindly forwarding every notification.
+
 Robusta can proxy Prometheus alerts to Slack, adding powerful features like :ref:`AI investigation <AI Analysis>`, :ref:`smart grouping <notification-grouping>` and more.
 
 .. image:: /images/robusta-slack.png

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -4,11 +4,15 @@ Slack
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   For new setups, we recommend connecting HolmesGPT to Slack directly instead of using this legacy sink.
+   For new setups, we recommend connecting HolmesGPT to Slack instead of using this legacy sink.
 
-   Open the `Slack settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
+   Open the `Slack settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform to connect HolmesGPT to Slack. This adds a single HolmesGPT Slack bot that powers all of the flows below:
 
-   Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   - **Chat** — ``@mention`` the bot in any channel to investigate issues on demand; it replies in the thread.
+   - **Alerts** — let `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ automatically investigate incoming alerts and post the findings to Slack.
+   - **Custom events** — use :ref:`Triggered Workflows <defining-playbooks>` to react to arbitrary events and notify Slack.
+
+   These are separate flows that share the same bot: chat is interactive, while Alerts Triage and Triggered Workflows run automatically.
 
 Robusta can proxy Prometheus alerts to Slack, adding powerful features like :ref:`AI investigation <AI Analysis>`, :ref:`smart grouping <notification-grouping>` and more.
 

--- a/docs/configuration/sinks/slack.rst
+++ b/docs/configuration/sinks/slack.rst
@@ -4,9 +4,9 @@ Slack
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   For new setups, we recommend connecting HolmesGPT to Slack and Teams directly instead of using this legacy sink.
+   For new setups, we recommend connecting HolmesGPT to Slack directly instead of using this legacy sink.
 
-   Open the `Slack & Teams settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack and Teams there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
+   Open the `Slack settings page <https://platform.robusta.dev/settings/slack-and-teams>`_ in the Robusta platform and connect HolmesGPT to Slack there. HolmesGPT can then triage alerts and reply in your channels, and you can chat with it directly to investigate issues on demand.
 
    Under the hood this investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 

--- a/docs/configuration/sinks/telegram.rst
+++ b/docs/configuration/sinks/telegram.rst
@@ -1,6 +1,14 @@
 Telegram
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Telegram conversations.
 
 .. note::

--- a/docs/configuration/sinks/telegram.rst
+++ b/docs/configuration/sinks/telegram.rst
@@ -6,7 +6,7 @@ Telegram
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Telegram conversations.

--- a/docs/configuration/sinks/telegram.rst
+++ b/docs/configuration/sinks/telegram.rst
@@ -6,7 +6,9 @@ Telegram
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Telegram conversations.

--- a/docs/configuration/sinks/telegram.rst
+++ b/docs/configuration/sinks/telegram.rst
@@ -6,7 +6,7 @@ Telegram
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Telegram conversations.

--- a/docs/configuration/sinks/telegram.rst
+++ b/docs/configuration/sinks/telegram.rst
@@ -4,7 +4,7 @@ Telegram
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/telegram.rst
+++ b/docs/configuration/sinks/telegram.rst
@@ -6,7 +6,7 @@ Telegram
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Telegram conversations.

--- a/docs/configuration/sinks/webex.rst
+++ b/docs/configuration/sinks/webex.rst
@@ -1,6 +1,14 @@
 Webex
 #################
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Webex.
 
 .. image:: /images/webex_sink/webex_sink_example.png

--- a/docs/configuration/sinks/webex.rst
+++ b/docs/configuration/sinks/webex.rst
@@ -6,7 +6,9 @@ Webex
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Webex.

--- a/docs/configuration/sinks/webex.rst
+++ b/docs/configuration/sinks/webex.rst
@@ -6,7 +6,7 @@ Webex
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Webex.

--- a/docs/configuration/sinks/webex.rst
+++ b/docs/configuration/sinks/webex.rst
@@ -6,7 +6,7 @@ Webex
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Webex.

--- a/docs/configuration/sinks/webex.rst
+++ b/docs/configuration/sinks/webex.rst
@@ -6,7 +6,7 @@ Webex
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Webex.

--- a/docs/configuration/sinks/webex.rst
+++ b/docs/configuration/sinks/webex.rst
@@ -4,7 +4,7 @@ Webex
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/webhook.rst
+++ b/docs/configuration/sinks/webhook.rst
@@ -6,7 +6,7 @@ Webhook
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a webhook.

--- a/docs/configuration/sinks/webhook.rst
+++ b/docs/configuration/sinks/webhook.rst
@@ -6,7 +6,7 @@ Webhook
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a webhook.

--- a/docs/configuration/sinks/webhook.rst
+++ b/docs/configuration/sinks/webhook.rst
@@ -6,7 +6,7 @@ Webhook
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a webhook.

--- a/docs/configuration/sinks/webhook.rst
+++ b/docs/configuration/sinks/webhook.rst
@@ -6,7 +6,9 @@ Webhook
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to a webhook.

--- a/docs/configuration/sinks/webhook.rst
+++ b/docs/configuration/sinks/webhook.rst
@@ -1,6 +1,14 @@
 Webhook
 ###########
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to a webhook.
 
 .. admonition:: Add this to your generated_values.yaml

--- a/docs/configuration/sinks/webhook.rst
+++ b/docs/configuration/sinks/webhook.rst
@@ -4,7 +4,7 @@ Webhook
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/zulip.rst
+++ b/docs/configuration/sinks/zulip.rst
@@ -1,6 +1,14 @@
 Zulip
 ######
 
+.. admonition:: This page documents a legacy sink in Robusta classic
+   :class: warning
+
+   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+
+
 Robusta can report issues and events in your Kubernetes cluster to Zulip.
 
 .. image:: /images/zulip_example.png

--- a/docs/configuration/sinks/zulip.rst
+++ b/docs/configuration/sinks/zulip.rst
@@ -4,7 +4,7 @@ Zulip
 .. admonition:: This page documents a legacy sink in Robusta classic
    :class: warning
 
-   You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
    Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 

--- a/docs/configuration/sinks/zulip.rst
+++ b/docs/configuration/sinks/zulip.rst
@@ -6,7 +6,9 @@ Zulip
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Zulip.

--- a/docs/configuration/sinks/zulip.rst
+++ b/docs/configuration/sinks/zulip.rst
@@ -6,7 +6,7 @@ Zulip
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Zulip.

--- a/docs/configuration/sinks/zulip.rst
+++ b/docs/configuration/sinks/zulip.rst
@@ -6,7 +6,7 @@ Zulip
 
    You probably want `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert instead of blindly forwarding everything.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically**, using :ref:`triggered workflows <defining-playbooks>` together with `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, so the LLM makes intelligent triage decisions about each alert.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Zulip.

--- a/docs/configuration/sinks/zulip.rst
+++ b/docs/configuration/sinks/zulip.rst
@@ -6,7 +6,7 @@ Zulip
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with :ref:`triggered workflows <defining-playbooks>` and `MCP servers <https://holmesgpt.dev/data-sources/remote-mcp-servers/?tab=robusta-helm-chart>`_, or configure `alert triage <https://platform.robusta.dev/holmes/alerts-triage>`_ in the Robusta platform.
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 
 Robusta can report issues and events in your Kubernetes cluster to Zulip.

--- a/docs/notification-routing/configuring-sinks.rst
+++ b/docs/notification-routing/configuring-sinks.rst
@@ -39,7 +39,9 @@ Defining Sinks
 
    For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
 
-   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+   HolmesGPT triages your alerts instead of just forwarding them. Sinks are deterministic: they send every notification, unchanged, to a fixed destination, leaving you to read and prioritize each one yourself.
+
+   HolmesGPT instead uses AI to investigate each alert, surface the likely root cause, and escalate only what needs attention — so you get fewer, more actionable notifications. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
 
 Robusta can send notifications to various destinations, called sinks.
 

--- a/docs/notification-routing/configuring-sinks.rst
+++ b/docs/notification-routing/configuring-sinks.rst
@@ -34,6 +34,13 @@ Defining Sinks
    ../configuration/sinks/zulip
    ../configuration/sinks/sinks-development
 
+.. admonition:: Sinks are a legacy feature of Robusta classic
+   :class: warning
+
+   For new setups, we recommend `HolmesGPT <https://holmesgpt.dev/>`_ instead.
+
+   Sinks statically forward every notification to a fixed destination. Modern Robusta instead investigates and routes alerts **agentically** so the LLM makes intelligent triage decisions about each alert. Set this up with `Alerts Triage <https://platform.robusta.dev/holmes/alerts-triage>`_ for alerts, or :ref:`Triggered Workflows <defining-playbooks>` for custom events.
+
 Robusta can send notifications to various destinations, called sinks.
 
 A Simple Sink Configuration

--- a/docs/setup-robusta/proxies.rst
+++ b/docs/setup-robusta/proxies.rst
@@ -128,7 +128,7 @@ After applying firewall rules, you can sanity-check connectivity from inside the
 A non-zero HTTP code (including ``401``/``404``) confirms TCP + TLS reach the host. Connection timeouts indicate the firewall is still blocking.
 
 Copying Images to a Private Image Registry
-----------------------------------------
+------------------------------------------
 
 If you are running the Robusta **self-hosted platform** (the ``robusta-platform`` Helm chart) in an environment that cannot pull from public registries (Docker Hub, ``us-central1-docker.pkg.dev``, ``quay.io``), mirror the images below to your internal registry and override the registry fields in your Helm values.
 


### PR DESCRIPTION
## Summary
Added deprecation warnings to all sink documentation pages to guide users toward HolmesGPT as the modern alternative to the legacy Robusta classic sinks.

## Changes
- Added warning admonitions to the top of 24 sink documentation files
- Two variants of deprecation notices:
  - **Slack & MS Teams**: Directs users to connect HolmesGPT directly via the Robusta platform settings page, highlighting agentic alert investigation and routing capabilities
  - **All other sinks**: Generic deprecation notice recommending HolmesGPT as a replacement, explaining the shift from static notification forwarding to intelligent agentic alert handling

## Implementation Details
- Warnings are implemented as reStructuredText `admonition` directives with the `warning` class for consistent styling
- Slack and MS Teams notices include specific platform links and mention MCP servers for enhanced context
- All notices emphasize the benefits of agentic decision-making over blind notification forwarding
- Notices are placed immediately after the page title, before existing content, ensuring high visibility

https://claude.ai/code/session_017Rj9Tk6fmiMaeCQvZzuvtp