### PR TITLE
ROB-397 - global imagePullSecret for Helm chart

### DIFF
--- a/docs/setup-robusta/proxies.rst
+++ b/docs/setup-robusta/proxies.rst
@@ -113,6 +113,19 @@ When deploying Robusta in a tightly restricted environment, the runner needs out
 
 If you mirror images to a private registry, override ``image.registry`` (and the per-component ``image:`` fields) in your Helm values and you can drop the public registries from the allowlist.
 
+If your private registry requires authentication, set ``global.imagePullSecrets``. This applies the
+pull secret to every component at once — the runner, kubewatch, HolmesGPT, and the pods the runner
+launches at runtime (e.g. KRR, Popeye, via the runner ServiceAccount):
+
+.. code-block:: yaml
+
+    global:
+      imagePullSecrets:
+        - name: my-registry-secret
+
+A per-component value (e.g. ``runner.imagePullSecrets``, ``kubewatch.imagePullSecrets``) overrides the
+global one for that component. Leaving ``global.imagePullSecrets`` empty keeps the previous behavior.
+
 Verifying the Allowlist
 ----------------------------------------
 

--- a/docs/setup-robusta/proxies.rst
+++ b/docs/setup-robusta/proxies.rst
@@ -114,8 +114,9 @@ When deploying Robusta in a tightly restricted environment, the runner needs out
 If you mirror images to a private registry, override ``image.registry`` (and the per-component ``image:`` fields) in your Helm values and you can drop the public registries from the allowlist.
 
 If your private registry requires authentication, set ``global.imagePullSecrets``. This applies the
-pull secret to every component at once — the runner, kubewatch, HolmesGPT, and the pods the runner
-launches at runtime (e.g. KRR, Popeye, via the runner ServiceAccount):
+pull secret to the runner, kubewatch, and the pods the runner launches at runtime (e.g. KRR, Popeye,
+via the runner ServiceAccount). To also cover HolmesGPT, set ``holmes.imagePullSecrets`` — HolmesGPT
+is a subchart, so set it explicitly alongside the global value:
 
 .. code-block:: yaml
 
@@ -123,8 +124,14 @@ launches at runtime (e.g. KRR, Popeye, via the runner ServiceAccount):
       imagePullSecrets:
         - name: my-registry-secret
 
-A per-component value (e.g. ``runner.imagePullSecrets``, ``kubewatch.imagePullSecrets``) overrides the
-global one for that component. Leaving ``global.imagePullSecrets`` empty keeps the previous behavior.
+    # HolmesGPT is a subchart — set its pull secret as well
+    holmes:
+      imagePullSecrets:
+        - name: my-registry-secret
+
+A per-component value (e.g. ``runner.imagePullSecrets``, ``kubewatch.imagePullSecrets``,
+``holmes.imagePullSecrets``) overrides the global one for that component. Leaving
+``global.imagePullSecrets`` empty keeps the previous behavior.
 
 Verifying the Allowlist
 ----------------------------------------

--- a/helm/robusta/templates/forwarder-service-account.yaml
+++ b/helm/robusta/templates/forwarder-service-account.yaml
@@ -123,6 +123,11 @@ metadata:
     {{- toYaml . | nindent 4}}
   {{- end }}
   {{- end }}
+{{- $pullSecrets := .Values.kubewatch.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+{{- if $pullSecrets }}
+imagePullSecrets:
+{{- toYaml $pullSecrets | nindent 2}}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/robusta/templates/forwarder-service-account.yaml
+++ b/helm/robusta/templates/forwarder-service-account.yaml
@@ -123,11 +123,6 @@ metadata:
     {{- toYaml . | nindent 4}}
   {{- end }}
   {{- end }}
-{{- $pullSecrets := .Values.kubewatch.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
-{{- if $pullSecrets }}
-imagePullSecrets:
-{{- toYaml $pullSecrets | nindent 2}}
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -31,9 +31,10 @@ spec:
       serviceAccountName: {{ include "robusta.fullname" . }}-forwarder-service-account
       {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- if .Values.kubewatch.imagePullSecrets }}
+      {{- $pullSecrets := .Values.kubewatch.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-      {{- toYaml .Values.kubewatch.imagePullSecrets | nindent 6 }}
+      {{- toYaml $pullSecrets | nindent 6 }}
       {{- end }}
       {{- with .Values.kubewatch.securityContext.pod }}
       securityContext:

--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: {{ include "robusta.fullname" . }}-forwarder-service-account
       {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- $pullSecrets := .Values.kubewatch.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+      {{- $pullSecrets := .Values.kubewatch.imagePullSecrets | default .Values.global.imagePullSecrets }}
       {{- if $pullSecrets }}
       imagePullSecrets:
       {{- toYaml $pullSecrets | nindent 6 }}

--- a/helm/robusta/templates/runner-service-account.yaml
+++ b/helm/robusta/templates/runner-service-account.yaml
@@ -556,7 +556,7 @@ metadata:
     {{- toYaml . | nindent 4}}
   {{- end }}
   {{- end }}
-{{- $pullSecrets := .Values.runnerServiceAccount.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+{{- $pullSecrets := .Values.runnerServiceAccount.imagePullSecrets | default .Values.global.imagePullSecrets }}
 {{- if $pullSecrets }}
 imagePullSecrets:
 {{- toYaml $pullSecrets | nindent 2}}

--- a/helm/robusta/templates/runner-service-account.yaml
+++ b/helm/robusta/templates/runner-service-account.yaml
@@ -556,9 +556,10 @@ metadata:
     {{- toYaml . | nindent 4}}
   {{- end }}
   {{- end }}
-{{- if .Values.runnerServiceAccount.imagePullSecrets }}
+{{- $pullSecrets := .Values.runnerServiceAccount.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+{{- if $pullSecrets }}
 imagePullSecrets:
-{{- toYaml .Values.runnerServiceAccount.imagePullSecrets | nindent 2}}
+{{- toYaml $pullSecrets | nindent 2}}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: {{ include "robusta.fullname" . }}-runner-service-account
       {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- $pullSecrets := .Values.runner.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+      {{- $pullSecrets := .Values.runner.imagePullSecrets | default .Values.global.imagePullSecrets }}
       {{- if $pullSecrets }}
       imagePullSecrets:
       {{- toYaml $pullSecrets | nindent 6 }}

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -34,9 +34,10 @@ spec:
       serviceAccountName: {{ include "robusta.fullname" . }}-runner-service-account
       {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- if .Values.runner.imagePullSecrets }}
+      {{- $pullSecrets := .Values.runner.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) }}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-      {{- toYaml .Values.runner.imagePullSecrets | nindent 6 }}
+      {{- toYaml $pullSecrets | nindent 6 }}
       {{- end }}
       {{- with .Values.runner.securityContext.pod }}
       securityContext:

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -33,6 +33,11 @@ clusterZone: ""
 
 global:
   clusterDomain: "cluster.local"
+  # Optional image pull secrets applied globally to the runner, kubewatch, holmes,
+  # and runtime pods created by the runner (e.g. KRR, Popeye, via the runner ServiceAccount).
+  # A per-component imagePullSecrets (e.g. runner.imagePullSecrets) overrides this global
+  # value for that component. Leave empty to keep existing behavior.
+  imagePullSecrets: []
 
 automountServiceAccountToken: true
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -33,10 +33,11 @@ clusterZone: ""
 
 global:
   clusterDomain: "cluster.local"
-  # Optional image pull secrets applied globally to the runner, kubewatch, holmes,
-  # and runtime pods created by the runner (e.g. KRR, Popeye, via the runner ServiceAccount).
-  # A per-component imagePullSecrets (e.g. runner.imagePullSecrets) overrides this global
-  # value for that component. Leave empty to keep existing behavior.
+  # Optional image pull secrets applied to the runner, kubewatch, and the runtime pods
+  # created by the runner (e.g. KRR, Popeye, via the runner ServiceAccount).
+  # A component's own imagePullSecrets (e.g. runner.imagePullSecrets), when set, is used
+  # instead of this global; otherwise the component inherits this global. Leave empty to
+  # keep existing behavior. HolmesGPT is a separate subchart - set holmes.imagePullSecrets.
   imagePullSecrets: []
 
 automountServiceAccountToken: true
@@ -653,6 +654,7 @@ kubewatch:
   tolerations: []
   annotations: {}
   nodeSelector: ~
+  # set to override global.imagePullSecrets for kubewatch; leave empty to inherit the global
   imagePullSecrets: []
   config:
     namespace: ""
@@ -712,6 +714,7 @@ grafanaRenderer:
 # parameters for the robusta runner service account
 runnerServiceAccount:
   # image pull secrets added to the runner service account. Any pod using the service account will get those
+  # set to override global.imagePullSecrets; leave empty to inherit the global
   imagePullSecrets: []
   # Additional annotations for the ServiceAccount.
   annotations: {}
@@ -742,6 +745,7 @@ runner:
   annotations: {}
   nodeSelector: ~
   customClusterRoleRules: []
+  # set to override global.imagePullSecrets for the runner; leave empty to inherit the global
   imagePullSecrets: []
   extraVolumes: []
   extraVolumeMounts: []


### PR DESCRIPTION
## What

Adds an optional `global.imagePullSecrets` to the Robusta Helm chart so a single value applies the image pull secret to every component, instead of configuring several separate per-component keys.

Covers:
- **runner** (deployment + ServiceAccount)
- **kubewatch / forwarder** (deployment pod-level)
- **runtime pods** the runner launches (KRR, Popeye) — automatically, via the runner ServiceAccount they default to (`RUNNER_SERVICE_ACCOUNT`), so no code changes needed

## Semantics (backwards compatible)

- New `global.imagePullSecrets`, default `[]`.
- **Override**: a per-component value (e.g. `runner.imagePullSecrets`) wins over the global for that component; components without one fall back to global.
- Empty global → render is byte-for-byte unchanged.

## Verification

`helm template` dry-renders confirm:
| Scenario | Result |
|---|---|
| default (nothing set) | no `imagePullSecrets` rendered anywhere |
| global only | same secret on runner deployment + runner SA + forwarder deployment |
| each component individually | each resource gets its own |
| global + local | local wins; components without a local fall back to global |

## Follow-up (not in this PR)

The Holmes subchart change lives in the holmesgpt repo (deployment + SA templates + `values.yaml`) and requires repackaging the bundled `holmes-*.tgz` — separate PR.

Linear: ROB-397

🤖 Generated with [Claude Code](https://claude.com/claude-code)