### PR TITLE
ROB-463 Document optional cluster parameter in Send Events API

### DIFF
--- a/docs/configuration/exporting/send-events-api.rst
+++ b/docs/configuration/exporting/send-events-api.rst
@@ -47,6 +47,8 @@ Query Parameters
      - Identifies the monitoring product. Must be one of the supported origins listed under `Integrations`_ below.
    * - ``account_id``
      - Your Robusta account ID, found in ``generated_values.yaml``.
+   * - ``cluster``
+     - Optional. The cluster to associate the alert with. When set, it overrides any cluster found in the alert payload and is used for the resulting alert investigation. When omitted, the cluster is taken from the payload if present, otherwise the alert is recorded under the ``external`` cluster. Use this when your monitoring system cannot add a cluster label to the alert itself.
 
 Authentication
 --------------


### PR DESCRIPTION
## Summary
Added documentation for the optional `cluster` query parameter in the Send Events API endpoint.

## Changes
- Added `cluster` parameter documentation to the Query Parameters table in the Send Events API configuration guide
- Documented the parameter's behavior:
  - When provided, it overrides any cluster found in the alert payload
  - Used for alert investigation routing
  - When omitted, the cluster is taken from the payload if present, otherwise defaults to the `external` cluster
  - Useful for monitoring systems that cannot add cluster labels to alerts themselves

## Details
This documentation clarifies an existing API capability, helping users understand how to properly route alerts from external monitoring systems that lack native cluster labeling support.

https://claude.ai/code/session_01Ru3h6bxtTvy7H9XViGKgqW