### PR TITLE
ROB-566 Upgrade pytest to ^9.0.3 to fix CVE-2025-71176

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -72,16 +72,6 @@ requests = "*"
 requests-oauthlib = "*"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
-
-[[package]]
 name = "attrs"
 version = "23.2.0"
 description = "Classes Without Boilerplate"
@@ -2307,17 +2297,6 @@ urllib3 = ">=2.6.0,<3.0.0"
 zipp = ">=3.20.1,<4.0.0"
 
 [[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
-]
-
-[[package]]
 name = "pyasn1"
 version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -2507,27 +2486,26 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "6.2.5"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
-    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=19.2.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-toml = "*"
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -4040,4 +4018,4 @@ all = ["CairoSVG", "Flask", "better-exceptions", "datadog-api-client", "grafana-
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.12"
-content-hash = "179d62083ad4e772614611e3847d673dde481f57da4d817dda8cbf6761e0472b"
+content-hash = "0baf9688a8ee5a35bb05d8f5d140798f024f43d3688e945bccb5350fc85274fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ virtualenv = "^20.36.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.13.0"
-pytest = "^6.2.4"
+# Pin to fix CVE-2025-71176 (pytest < 9.0.3)
+pytest = "^9.0.3"
 python-dotenv = "^0.18.0"
 Sphinx = "6.2.1"
 #furo = "^2021.11.12"


### PR DESCRIPTION
## Summary
Updated the pytest dependency to version 9.0.3 or higher to address a security vulnerability (CVE-2025-71176) that affects pytest versions below 9.0.3.

## Changes
- Upgraded pytest from `^6.2.4` to `^9.0.3` in dev dependencies
- Added explanatory comment referencing the CVE being fixed

## Details
This is a security-focused dependency update to mitigate CVE-2025-71176. The previous constraint allowed pytest versions below the patched version, so the minimum version requirement has been raised to ensure the vulnerability is not present in development environments.

https://claude.ai/code/session_01TjjSMyvjymxtXMYFQ1NKbu