### PR TITLE
ROB-584 Add Jira Service Management (JSM) alert ingestion docs

### DIFF
--- a/docs/configuration/exporting/send-events-api.rst
+++ b/docs/configuration/exporting/send-events-api.rst
@@ -16,6 +16,7 @@ This is the recommended ingestion path for new integrations. The legacy :doc:`Se
    send-events/dynatrace
    send-events/gcp-monitoring
    send-events/grafana
+   send-events/jsm
    send-events/nagios
    send-events/newrelic
    send-events/opsgenie
@@ -175,6 +176,11 @@ Incident Management
     .. grid-item-card:: :octicon:`pulse;1em;` Opsgenie
         :class-card: sd-bg-light sd-bg-text-light
         :link: send-events/opsgenie
+        :link-type: doc
+
+    .. grid-item-card:: :octicon:`pulse;1em;` Jira Service Management
+        :class-card: sd-bg-light sd-bg-text-light
+        :link: send-events/jsm
         :link-type: doc
 
     .. grid-item-card:: :octicon:`pulse;1em;` Rootly

--- a/docs/configuration/exporting/send-events/jsm.rst
+++ b/docs/configuration/exporting/send-events/jsm.rst
@@ -1,0 +1,38 @@
+Jira Service Management
+========================
+
+Forward Jira Service Management (JSM) alerts to Robusta via the JSM outgoing webhook integration.
+
+Prerequisites
+-------------
+
+* A Robusta account with API access.
+* Your Robusta ``account_id``, found in ``generated_values.yaml``.
+* A Robusta API key with ``Read/Write`` access to alerts, generated under **Settings → API Keys → New API Key**.
+* Admin access to Operations in Jira Service Management.
+
+Webhook URL
+-----------
+
+.. robusta-code::
+
+    https://api.robusta.dev/webhooks?type=alert&origin=jsm&account_id=<ACCOUNT_ID>
+
+Configure Jira Service Management
+---------------------------------
+
+1. In Jira Service Management, go to **Operations → Integrations → Add integration**.
+2. Search for **Webhook** and select the outgoing webhook integration.
+3. Set the **Webhook URL** to the URL above.
+4. Add a custom **Header**:
+
+   .. code-block::
+
+       Authorization: Bearer <ROBUSTA_API_KEY>
+
+5. Choose which alert actions (``Create``, ``Acknowledge``, ``Close``, …) trigger the webhook and turn the integration on.
+
+Verify
+------
+
+Create a test alert in Jira Service Management. The event should appear in **Settings → Delivery Log** and on the Robusta timeline.


### PR DESCRIPTION
Documents the new `origin=jsm` webhook ingestion point in the Send Events API:

- New page `docs/configuration/exporting/send-events/jsm.rst` — webhook URL, Bearer-token auth, and setup steps for the JSM Operations outgoing webhook integration (modeled on the Opsgenie/PagerDuty pages)
- Registered in `send-events-api.rst` (toctree + Incident Management grid card)

Companion PRs: `origin=jsm` parser in `relay`, frontend catalog entries in `robusta-frontend` (same branch name). The frontend's new "Jira Service Management" source card links to this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q56oorVdMa1QEmywkRgXGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q56oorVdMa1QEmywkRgXGs)_