### PR TITLE
Add grace period support to pod deletion action

### DIFF
--- a/playbooks/robusta_playbooks/pod_actions.py
+++ b/playbooks/robusta_playbooks/pod_actions.py
@@ -27,10 +27,12 @@ class DeleteAlertPodParams(ActionParams):
     """
     :var rate_limit: Optional rate limit (seconds). If set, the action will only run once per period for the same alert label value.
     :var rate_limit_field: Alert label name whose value is used to build the rate limit key.
+    :var grace_period_seconds: Optional grace period (seconds) for the pod deletion. Zero means delete immediately. If not set, the pod's default grace period is used.
     """
 
     rate_limit: Optional[int] = None
     rate_limit_field: Optional[str] = None
+    grace_period_seconds: Optional[int] = None
 
 
 @action
@@ -62,4 +64,4 @@ def delete_alert_pod(event: PrometheusKubernetesAlert, params: DeleteAlertPodPar
                 logging.info(f"delete_alert_pod rate limited for {key}; skipping deletion")
                 return
 
-    pod.delete()
+    pod.delete(grace_period_seconds=params.grace_period_seconds)


### PR DESCRIPTION
## Summary
Added support for configurable grace period when deleting pods in the `delete_alert_pod` action, allowing users to specify how long Kubernetes should wait before forcefully terminating a pod.

## Changes
- Added `grace_period_seconds` optional parameter to `DeleteAlertPodParams` class
- Updated the `pod.delete()` call to pass the grace period parameter
- Added documentation for the new parameter explaining that zero means immediate deletion and omitting it uses the pod's default grace period

## Implementation Details
- The `grace_period_seconds` parameter is optional (defaults to `None`), maintaining backward compatibility
- When `None`, the pod's default grace period is used by Kubernetes
- When set to `0`, the pod is deleted immediately without waiting
- The parameter is passed directly to the underlying `pod.delete()` method

https://claude.ai/code/session_01GT8gcjrboPS1NkX52BBeLD