### PR TITLE
Bump KRR image to v1.29.0 (JSON log format support)

### DIFF
--- a/playbooks/robusta_playbooks/krr.py
+++ b/playbooks/robusta_playbooks/krr.py
@@ -36,7 +36,7 @@ from robusta.integrations.openshift import IS_OPENSHIFT
 from robusta.integrations.prometheus.utils import generate_prometheus_config
 from robusta.utils.parsing import format_event_templated_string
 
-IMAGE: str = os.getenv("KRR_IMAGE_OVERRIDE", f"{IMAGE_REGISTRY}/krr:v1.28.0")
+IMAGE: str = os.getenv("KRR_IMAGE_OVERRIDE", f"{IMAGE_REGISTRY}/krr:v1.29.0")
 KRR_MEMORY_LIMIT: str = os.getenv("KRR_MEMORY_LIMIT", "2Gi")
 KRR_MEMORY_REQUEST: str = os.getenv("KRR_MEMORY_REQUEST", "2Gi")
 KRR_STRATEGY: str = os.getenv("KRR_STRATEGY", "simple")


### PR DESCRIPTION
## Summary

Bumps the default KRR scan-job image from `krr:v1.28.0` to **`krr:v1.29.0`** in `playbooks/robusta_playbooks/krr.py`.

`v1.29.0` is the first KRR release that includes JSON log format support (`ENABLE_JSON_LOGS_FORMAT`). The runner already propagates the toggle to KRR scan jobs (when `KRR_PUSH_SCAN` is enabled); this bump makes the scan-job image actually honor it. Without it, enabling `global.enableJsonLogsFormat` would have no effect on KRR scan pods.

Only reference to the image tag in the repo (`krr.py:39`); `KRR_IMAGE_OVERRIDE` still overrides as before.

Part of ROB-459 (sub-task ROB-693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AozEpN8uwPRQuF8FPRX4Jy)_