### PR TITLE
ROB-834 Add F5 Distributed Cloud page to Send Events API docs

### DIFF
--- a/docs/configuration/exporting/send-events-api.rst
+++ b/docs/configuration/exporting/send-events-api.rst
@@ -14,6 +14,7 @@ This is the recommended ingestion path for new integrations. The legacy :doc:`Se
    send-events/azure-monitor
    send-events/datadog
    send-events/dynatrace
+   send-events/f5
    send-events/gcp-monitoring
    send-events/grafana
    send-events/jsm
@@ -193,6 +194,11 @@ Other
 
 .. grid:: 1 1 2 3
     :gutter: 3
+
+    .. grid-item-card:: :octicon:`pulse;1em;` F5 Distributed Cloud
+        :class-card: sd-bg-light sd-bg-text-light
+        :link: send-events/f5
+        :link-type: doc
 
     .. grid-item-card:: :octicon:`pulse;1em;` Nagios
         :class-card: sd-bg-light sd-bg-text-light

--- a/docs/configuration/exporting/send-events/f5.rst
+++ b/docs/configuration/exporting/send-events/f5.rst
@@ -1,0 +1,43 @@
+F5 Distributed Cloud
+=====================
+
+Forward alerts from F5 Distributed Cloud (XC) to Robusta via a webhook alert receiver.
+
+Prerequisites
+-------------
+
+* A Robusta account with API access.
+* Your Robusta ``account_id``, found in ``generated_values.yaml``.
+* A Robusta API key with ``Read/Write`` access to alerts.
+* An F5 Distributed Cloud tenant with permission to manage alert receivers and alert policies.
+
+Webhook URL
+-----------
+
+.. robusta-code::
+
+    https://api.robusta.dev/webhooks?type=alert&origin=f5&account_id=<ACCOUNT_ID>
+
+Configure F5 Distributed Cloud
+------------------------------
+
+1. In the F5 Distributed Cloud Console, go to **Multi-Cloud App Connect → Alerts Management → Alert Receivers** (under Shared Configuration in some tenants) and select **Add Alert Receiver**.
+2. Set **Receiver** to ``Webhook`` and name it ``robusta``.
+3. Set the **URL** to the webhook URL above.
+4. Under **Authentication**, choose **Token** and set the token value to your Robusta API key. F5 sends it as ``Authorization: Bearer <API_KEY>``.
+5. Save the receiver.
+6. Go to **Alert Policies → Add Alert Policy**, name it ``robusta``, and add the receiver you just created under **Alert Receivers**.
+7. Under **Policy Rules**, select which alerts to route — choose **Select All Alerts** to forward everything, or filter by alert group/severity.
+8. Save the policy. Only alerts matched by an active alert policy are forwarded.
+
+Verify
+------
+
+Use **Send Test Alert** on the alert receiver (available from the receiver's action menu). The event should appear in **Settings → Delivery Log** and on the Robusta timeline.
+
+Notes
+-----
+
+* F5 severities map to Robusta priorities as follows: ``critical`` and ``major`` → ``HIGH``, ``minor`` → ``LOW``, ``info`` → ``INFO``.
+* The ``namespace`` on an F5 alert is a Distributed Cloud namespace, not a Kubernetes one; it is kept as an alert label along with ``tenant``, ``site``, and ``group``.
+* F5 alerts are not tied to a Kubernetes cluster. To associate them with one of your clusters anyway, append ``&cluster=<CLUSTER_NAME>`` to the webhook URL.


### PR DESCRIPTION
Adds the customer-facing setup page for the new F5 Distributed Cloud alerts integration — companion to robusta-dev/relay#691 (the `origin=f5` webhook alert parser) and robusta-dev/robusta-frontend#3483 (the `f5` source entry, whose card links to this page at `send-events/f5.html`).

## What

- **New page** `docs/configuration/exporting/send-events/f5.rst`, following the same structure as the sibling send-events pages (Grafana et al.): prerequisites, webhook URL, F5 XC console steps (webhook alert receiver with **Token** authentication + alert policy routing), and Send Test Alert verification. A Notes section covers the F5→Robusta severity mapping (`critical`/`major` → HIGH, `minor` → LOW, `info` → INFO), that F5's `namespace` label is an XC namespace kept as a label rather than a Kubernetes namespace, and the `&cluster=` URL override.
- **Index** `send-events-api.rst`: added `send-events/f5` to the toctree and an "F5 Distributed Cloud" card under the *Other* integrations section.

## Testing

Built the send-events pages with Sphinx (isolated project loading the repo's `region_box` extension plus `sphinx_design`/`sphinx_copybutton`, since the full-site build requires the robusta package): `f5.rst` and the updated index build clean with `-W`; the F5 card renders on the index and the webhook URL renders correctly on the page. (Full-site build runs in the deploy-docs workflow as usual.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhfExtHG9haNaK6Ls9dmLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhfExtHG9haNaK6Ls9dmLg)_