### PR TITLE
ROB-906 Document the cluster query param across Send Events docs

### DIFF
--- a/docs/configuration/exporting/send-events-api.rst
+++ b/docs/configuration/exporting/send-events-api.rst
@@ -32,7 +32,7 @@ Endpoint
 
 .. robusta-code::
 
-    POST https://api.robusta.dev/webhooks?type=alert&origin=<ORIGIN>&account_id=<ACCOUNT_ID>
+    POST https://api.robusta.dev/webhooks?type=alert&origin=<ORIGIN>&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
 Query Parameters
 ----------------
@@ -50,7 +50,7 @@ Query Parameters
    * - ``account_id``
      - Your Robusta account ID, found in ``generated_values.yaml``.
    * - ``cluster``
-     - Optional. The cluster to associate the alert with. When set, it overrides any cluster found in the alert payload and is used for the resulting alert investigation. When omitted, the cluster is taken from the payload if present, otherwise the alert is recorded under the ``external`` cluster. Use this when your monitoring system cannot add a cluster label to the alert itself.
+     - Recommended. The cluster to associate the alert with. Set it to the exact name of the cluster as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with), so alerts are filed under that cluster and investigated in its context. When set, it overrides any cluster found in the alert payload. When omitted, the cluster is taken from the payload if present — otherwise the request still returns ``200`` but the alert is silently recorded under a generic ``external`` cluster.
 
 Authentication
 --------------
@@ -69,7 +69,7 @@ Example Request
 .. robusta-code:: bash
 
     curl --location --request POST \
-      'https://api.robusta.dev/webhooks?type=alert&origin=datadog&account_id=ACCOUNT_ID' \
+      'https://api.robusta.dev/webhooks?type=alert&origin=datadog&account_id=ACCOUNT_ID&cluster=CLUSTER_NAME' \
       --header 'Authorization: Bearer API_KEY' \
       --header 'Content-Type: application/json' \
       --data-raw '{ "title": "High error rate", "severity": "high" }'

--- a/docs/configuration/exporting/send-events-api.rst
+++ b/docs/configuration/exporting/send-events-api.rst
@@ -50,7 +50,7 @@ Query Parameters
    * - ``account_id``
      - Your Robusta account ID, found in ``generated_values.yaml``.
    * - ``cluster``
-     - Recommended. The cluster to associate the alert with. Set it to the exact name of the cluster as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with), so alerts are filed under that cluster and investigated in its context. When set, it overrides any cluster found in the alert payload. When omitted, the cluster is taken from the payload if present — otherwise the request still returns ``200`` but the alert is silently recorded under a generic ``external`` cluster.
+     - Recommended. The cluster to file the alert under — use the exact name shown in the Robusta UI. Overrides any cluster in the alert payload. If omitted, the cluster is taken from the payload, or silently defaults to ``external``.
 
 Authentication
 --------------

--- a/docs/configuration/exporting/send-events/alertmanager.rst
+++ b/docs/configuration/exporting/send-events/alertmanager.rst
@@ -17,11 +17,11 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=alertmanager&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 .. note::
 
-    If you can't set the URL parameter, this endpoint also reads the cluster from a ``cluster`` or ``cluster_name`` label on each alert (for example, set via Prometheus ``externalLabels``). The ``cluster`` URL parameter takes precedence over labels. Note this is a different mechanism from the :doc:`in-cluster AlertManager integration </configuration/alertmanager-integration/outofcluster-prometheus>`, which routes by label only — following that page's label advice does not remove the need for the URL parameter (or label) here.
+    Alerts can also carry the cluster as a ``cluster`` or ``cluster_name`` label (e.g. via Prometheus ``externalLabels``); the URL parameter takes precedence. The :doc:`in-cluster integration </configuration/alertmanager-integration/outofcluster-prometheus>` is a separate mechanism that routes by label only.
 
 Configure AlertManager
 ----------------------

--- a/docs/configuration/exporting/send-events/alertmanager.rst
+++ b/docs/configuration/exporting/send-events/alertmanager.rst
@@ -15,7 +15,13 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=alertmanager&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=alertmanager&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+
+.. note::
+
+    If you can't set the URL parameter, this endpoint also reads the cluster from a ``cluster`` or ``cluster_name`` label on each alert (for example, set via Prometheus ``externalLabels``). The ``cluster`` URL parameter takes precedence over labels. Note this is a different mechanism from the :doc:`in-cluster AlertManager integration </configuration/alertmanager-integration/outofcluster-prometheus>`, which routes by label only — following that page's label advice does not remove the need for the URL parameter (or label) here.
 
 Configure AlertManager
 ----------------------
@@ -27,7 +33,7 @@ Add a webhook receiver to ``alertmanager.yml``:
     receivers:
       - name: robusta
         webhook_configs:
-          - url: 'https://api.robusta.dev/webhooks?type=alert&origin=alertmanager&account_id=<ACCOUNT_ID>'
+          - url: 'https://api.robusta.dev/webhooks?type=alert&origin=alertmanager&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>'
             send_resolved: true
             http_config:
               authorization:

--- a/docs/configuration/exporting/send-events/aws-cloudwatch.rst
+++ b/docs/configuration/exporting/send-events/aws-cloudwatch.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=awscloudwatch&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=awscloudwatch&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Recipe
 ------
@@ -32,7 +34,7 @@ Recipe
        import urllib.error
        import urllib.request
 
-       URL = "https://api.robusta.dev/webhooks?type=alert&origin=awscloudwatch&account_id=<ACCOUNT_ID>"
+       URL = "https://api.robusta.dev/webhooks?type=alert&origin=awscloudwatch&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>"
        TIMEOUT_SECONDS = 5
 
        def lambda_handler(event, context):
@@ -54,7 +56,7 @@ Recipe
                    raise
            return {"ok": True}
 
-4. Replace ``<ACCOUNT_ID>`` with your Robusta account ID and deploy.
+4. Replace ``<ACCOUNT_ID>`` with your Robusta account ID and ``<CLUSTER_NAME>`` with your cluster's name as it appears in the Robusta UI, then deploy.
 
 Alternatively, if you already use **Amazon EventBridge → API destination**, point the destination at the same URL with a Bearer token connection — no Lambda required.
 

--- a/docs/configuration/exporting/send-events/aws-cloudwatch.rst
+++ b/docs/configuration/exporting/send-events/aws-cloudwatch.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=awscloudwatch&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Recipe
 ------

--- a/docs/configuration/exporting/send-events/azure-monitor.rst
+++ b/docs/configuration/exporting/send-events/azure-monitor.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=azure&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Azure
 ---------------

--- a/docs/configuration/exporting/send-events/azure-monitor.rst
+++ b/docs/configuration/exporting/send-events/azure-monitor.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=azure&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=azure&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Azure
 ---------------
@@ -25,7 +27,7 @@ Action Group webhook receivers do not allow custom headers, so authenticate via 
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=azure&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
+    https://api.robusta.dev/webhooks?type=alert&origin=azure&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>&token=<ROBUSTA_API_KEY>
 
 1. In the Azure Portal, open **Monitor → Action groups** and either create a new group or edit an existing one.
 2. Under **Actions**, add an action of type **Webhook**.

--- a/docs/configuration/exporting/send-events/datadog.rst
+++ b/docs/configuration/exporting/send-events/datadog.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=datadog&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Datadog
 -----------------

--- a/docs/configuration/exporting/send-events/datadog.rst
+++ b/docs/configuration/exporting/send-events/datadog.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=datadog&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=datadog&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Datadog
 -----------------

--- a/docs/configuration/exporting/send-events/dynatrace.rst
+++ b/docs/configuration/exporting/send-events/dynatrace.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=dynatrace&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=dynatrace&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Dynatrace
 -------------------

--- a/docs/configuration/exporting/send-events/dynatrace.rst
+++ b/docs/configuration/exporting/send-events/dynatrace.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=dynatrace&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Dynatrace
 -------------------

--- a/docs/configuration/exporting/send-events/f5.rst
+++ b/docs/configuration/exporting/send-events/f5.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=f5&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=f5&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure F5 Distributed Cloud
 ------------------------------

--- a/docs/configuration/exporting/send-events/f5.rst
+++ b/docs/configuration/exporting/send-events/f5.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=f5&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure F5 Distributed Cloud
 ------------------------------

--- a/docs/configuration/exporting/send-events/gcp-monitoring.rst
+++ b/docs/configuration/exporting/send-events/gcp-monitoring.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=gcp&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure GCP
 -------------

--- a/docs/configuration/exporting/send-events/gcp-monitoring.rst
+++ b/docs/configuration/exporting/send-events/gcp-monitoring.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=gcp&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=gcp&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure GCP
 -------------
@@ -25,7 +27,7 @@ GCP webhook notification channels do not support custom headers in the console, 
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=gcp&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
+    https://api.robusta.dev/webhooks?type=alert&origin=gcp&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>&token=<ROBUSTA_API_KEY>
 
 The ``token`` query parameter is accepted as an alternative to the ``Authorization`` header.
 

--- a/docs/configuration/exporting/send-events/grafana.rst
+++ b/docs/configuration/exporting/send-events/grafana.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=grafana&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Grafana
 -----------------

--- a/docs/configuration/exporting/send-events/grafana.rst
+++ b/docs/configuration/exporting/send-events/grafana.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=grafana&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=grafana&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Grafana
 -----------------

--- a/docs/configuration/exporting/send-events/jsm.rst
+++ b/docs/configuration/exporting/send-events/jsm.rst
@@ -19,7 +19,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=jsm&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Jira Service Management
 ---------------------------------

--- a/docs/configuration/exporting/send-events/jsm.rst
+++ b/docs/configuration/exporting/send-events/jsm.rst
@@ -17,7 +17,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=jsm&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=jsm&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Jira Service Management
 ---------------------------------

--- a/docs/configuration/exporting/send-events/nagios.rst
+++ b/docs/configuration/exporting/send-events/nagios.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=nagios&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=nagios&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Nagios
 ----------------
@@ -51,7 +53,7 @@ Define a notification command that references ``$USER20$``:
                 "type": "$NOTIFICATIONTYPE$",
                 "output": "$SERVICEOUTPUT$"
             }' \
-            'https://api.robusta.dev/webhooks?type=alert&origin=nagios&account_id=<ACCOUNT_ID>'
+            'https://api.robusta.dev/webhooks?type=alert&origin=nagios&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>'
     }
 
 Define an analogous ``notify-robusta-host`` command, then attach both to a Nagios contact:

--- a/docs/configuration/exporting/send-events/nagios.rst
+++ b/docs/configuration/exporting/send-events/nagios.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=nagios&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Nagios
 ----------------

--- a/docs/configuration/exporting/send-events/newrelic.rst
+++ b/docs/configuration/exporting/send-events/newrelic.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=newrelic&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure New Relic
 -------------------

--- a/docs/configuration/exporting/send-events/newrelic.rst
+++ b/docs/configuration/exporting/send-events/newrelic.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=newrelic&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=newrelic&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure New Relic
 -------------------

--- a/docs/configuration/exporting/send-events/opsgenie.rst
+++ b/docs/configuration/exporting/send-events/opsgenie.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=opsgenie&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Opsgenie
 ------------------

--- a/docs/configuration/exporting/send-events/opsgenie.rst
+++ b/docs/configuration/exporting/send-events/opsgenie.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=opsgenie&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=opsgenie&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Opsgenie
 ------------------

--- a/docs/configuration/exporting/send-events/pagerduty.rst
+++ b/docs/configuration/exporting/send-events/pagerduty.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=pagerduty&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure PagerDuty
 -------------------

--- a/docs/configuration/exporting/send-events/pagerduty.rst
+++ b/docs/configuration/exporting/send-events/pagerduty.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=pagerduty&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=pagerduty&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure PagerDuty
 -------------------

--- a/docs/configuration/exporting/send-events/rootly.rst
+++ b/docs/configuration/exporting/send-events/rootly.rst
@@ -16,9 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=rootly&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
+    https://api.robusta.dev/webhooks?type=alert&origin=rootly&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>&token=<ROBUSTA_API_KEY>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<ROBUSTA_API_KEY>`` with the API key you generated.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, ``<ROBUSTA_API_KEY>`` with the API key you generated, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Rootly
 ----------------

--- a/docs/configuration/exporting/send-events/rootly.rst
+++ b/docs/configuration/exporting/send-events/rootly.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=rootly&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>&token=<ROBUSTA_API_KEY>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, ``<ROBUSTA_API_KEY>`` with the API key you generated, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, ``<ROBUSTA_API_KEY>`` with the API key you generated, and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Rootly
 ----------------

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -38,10 +38,8 @@ Webhook URL
 
 Replace ``<ACCOUNT_ID>`` with your Robusta account id,
 ``<ROBUSTA_API_KEY>`` with the API key you just generated, and
-``<CLUSTER_NAME>`` with the name of the cluster to file alerts under.
-The name must exactly match the cluster's name as it appears in the
-Robusta UI (the ``clusterName`` your Robusta agent was installed
-with). If ``cluster`` is omitted, alerts are silently filed under a
+``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in
+the Robusta UI. If ``cluster`` is omitted, alerts are filed under a
 generic ``external`` cluster.
 
 .. note::

--- a/docs/configuration/exporting/send-events/sentry.rst
+++ b/docs/configuration/exporting/send-events/sentry.rst
@@ -34,10 +34,15 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=sentry&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
+    https://api.robusta.dev/webhooks?type=alert&origin=sentry&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>&token=<ROBUSTA_API_KEY>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id and
-``<ROBUSTA_API_KEY>`` with the API key you just generated.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id,
+``<ROBUSTA_API_KEY>`` with the API key you just generated, and
+``<CLUSTER_NAME>`` with the name of the cluster to file alerts under.
+The name must exactly match the cluster's name as it appears in the
+Robusta UI (the ``clusterName`` your Robusta agent was installed
+with). If ``cluster`` is omitted, alerts are silently filed under a
+generic ``external`` cluster.
 
 .. note::
 

--- a/docs/configuration/exporting/send-events/solarwinds.rst
+++ b/docs/configuration/exporting/send-events/solarwinds.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=solarwinds&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure SolarWinds
 --------------------

--- a/docs/configuration/exporting/send-events/solarwinds.rst
+++ b/docs/configuration/exporting/send-events/solarwinds.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=solarwinds&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=solarwinds&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure SolarWinds
 --------------------
@@ -25,7 +27,7 @@ SolarWinds does not ship a native bearer-token webhook action. Use the **Execute
 
 .. robusta-code::
 
-    curl -sS -X POST -H "Authorization: Bearer <ROBUSTA_API_KEY>" -H "Content-Type: application/json" --data "{ \"alertName\": \"${N=Alerting;M=AlertName}\", \"node\": \"${N=SwisEntity;M=Caption}\", \"severity\": \"${N=Alerting;M=Severity}\", \"message\": \"${N=Alerting;M=AlertMessage}\" }" "https://api.robusta.dev/webhooks?type=alert&origin=solarwinds&account_id=<ACCOUNT_ID>"
+    curl -sS -X POST -H "Authorization: Bearer <ROBUSTA_API_KEY>" -H "Content-Type: application/json" --data "{ \"alertName\": \"${N=Alerting;M=AlertName}\", \"node\": \"${N=SwisEntity;M=Caption}\", \"severity\": \"${N=Alerting;M=Severity}\", \"message\": \"${N=Alerting;M=AlertMessage}\" }" "https://api.robusta.dev/webhooks?type=alert&origin=solarwinds&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>"
 
 Save the action and attach it to the alerts you want forwarded.
 

--- a/docs/configuration/exporting/send-events/splunk.rst
+++ b/docs/configuration/exporting/send-events/splunk.rst
@@ -16,7 +16,9 @@ Webhook URL
 
 .. robusta-code::
 
-    https://api.robusta.dev/webhooks?type=alert&origin=splunk&account_id=<ACCOUNT_ID>
+    https://api.robusta.dev/webhooks?type=alert&origin=splunk&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
+
+Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
 
 Configure Splunk
 ----------------
@@ -28,7 +30,7 @@ Splunk's built-in **Webhook** alert action does not let you set custom headers, 
 
    .. robusta-code::
 
-       https://api.robusta.dev/webhooks?type=alert&origin=splunk&account_id=<ACCOUNT_ID>&token=<ROBUSTA_API_KEY>
+       https://api.robusta.dev/webhooks?type=alert&origin=splunk&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>&token=<ROBUSTA_API_KEY>
 
 3. Save the search. If your Splunk environment has the **Webhook Alert Action** app installed, you can instead set an ``Authorization: Bearer <ROBUSTA_API_KEY>`` header and use the plain webhook URL without ``&token=…``.
 

--- a/docs/configuration/exporting/send-events/splunk.rst
+++ b/docs/configuration/exporting/send-events/splunk.rst
@@ -18,7 +18,7 @@ Webhook URL
 
     https://api.robusta.dev/webhooks?type=alert&origin=splunk&account_id=<ACCOUNT_ID>&cluster=<CLUSTER_NAME>
 
-Replace ``<ACCOUNT_ID>`` with your Robusta account id, and ``<CLUSTER_NAME>`` with the name of the cluster to file alerts under. The name must exactly match the cluster's name as it appears in the Robusta UI (the ``clusterName`` your Robusta agent was installed with). If ``cluster`` is omitted, alerts are silently filed under a generic ``external`` cluster.
+Replace ``<ACCOUNT_ID>`` with your Robusta account id and ``<CLUSTER_NAME>`` with your cluster's name exactly as it appears in the Robusta UI. If ``cluster`` is omitted, alerts are filed under a generic ``external`` cluster.
 
 Configure Splunk
 ----------------


### PR DESCRIPTION
Fixes [ROB-906](https://linear.app/robusta/issue/ROB-906/docs-send-events-pages-dont-document-the-required-cluster-query-param).

## Problem

Every Send Events integration page documented only `type`, `origin`, and `account_id`. Copying the example URLs verbatim silently files every alert under the generic `external` cluster: the request returns HTTP 200, the alert appears in the UI, and nothing surfaces the omission — the only symptom is a wrong value in one UI column.

## Changes

- Added `cluster=<CLUSTER_NAME>` to every webhook URL and example across all 17 Send Events integration pages (AlertManager, Grafana, Datadog, New Relic, Dynatrace, Splunk, Sentry, GCP, Azure, AWS CloudWatch, PagerDuty, Opsgenie, JSM, Rootly, F5, Nagios, SolarWinds) and the Send Events API index page.
- Added a consistent note under each Webhook URL: the name must exactly match the cluster's name as it appears in the Robusta UI (the `clusterName` the agent was installed with), and omitting `cluster` silently files alerts under `external`.
- Upgraded the `cluster` param on the API index page from "Optional" to "Recommended", spelling out the payload-fallback and `external`-fallback behavior.
- On the AlertManager page, clarified how the URL param relates to the `cluster`/`cluster_name` **label** mechanism: the param takes precedence, labels are a payload fallback, and the in-cluster integration described on the out-of-cluster Prometheus page is a separate, label-only mechanism.

Behavior verified against the relay implementation (`_cluster_override_from_row` in `relay/pkg/apps/webhooks/executor.py` and `cluster_from_labels` in `parsers/base.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfTuEudsMxDEEY9moaiQjr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfTuEudsMxDEEY9moaiQjr)_