### PR TITLE
ROB-923: Scope helm release monitoring to configurable secret types

### DIFF
--- a/docs/playbook-reference/triggers/helm-releases-monitoring.rst
+++ b/docs/playbook-reference/triggers/helm-releases-monitoring.rst
@@ -16,6 +16,52 @@ There are two prerequisites for using Helm triggers:
 * The :ref:`Robusta UI` sink must be enabled
 * ``monitorHelmReleases: true`` must be set in Robusta's Helm values
 
+Supported release storage types
+--------------------------------
+
+Robusta discovers Helm releases by reading the release state that Helm itself stores in the cluster.
+Only the following storage backend is supported:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 30 45
+
+   * - Helm storage driver
+     - Kubernetes object read
+     - Supported
+   * - ``secret`` (Helm v3 default)
+     - ``Secret`` of type ``helm.sh/release.v1``, labeled ``owner=helm``
+     - ✅ Yes
+   * - ``configmap``
+     - ``ConfigMap`` with release payload
+     - ❌ No
+   * - ``sql``
+     - External SQL database
+     - ❌ No
+   * - Helm v2 (Tiller)
+     - ``ConfigMap`` in ``kube-system``
+     - ❌ No
+
+When listing secrets, Robusta always applies the label selector ``owner=helm`` and only decodes the
+``release`` payload of matching secrets — the contents of other secrets are never read or sent anywhere.
+
+Required permissions
+---------------------
+
+Setting ``monitorHelmReleases: true`` adds ``get``, ``list`` and ``watch`` on ``secrets`` to the
+runner's ``ClusterRole``. This grant is cluster-wide, so releases in **all namespaces** are monitored.
+
+This is a Kubernetes RBAC limitation: RBAC rules cannot filter by secret ``type`` or by label, so it is
+not possible to grant access only to ``helm.sh/release.v1`` secrets. Although Robusta itself only reads
+Helm release secrets (see above), the permission technically allows reading any secret in the cluster.
+
+If this grant does not fit your security requirements, you can:
+
+* Keep ``monitorHelmReleases: false`` (the default). No secret read permission is granted, and the
+  runner sets ``DISABLE_HELM_MONITORING`` so it never attempts to list secrets.
+* Replace the runner's RBAC rules entirely with ``runner.overrideClusterRoles`` in Robusta's Helm
+  values, and manage the secret permissions yourself.
+
 Triggers
 -----------
 

--- a/docs/playbook-reference/triggers/helm-releases-monitoring.rst
+++ b/docs/playbook-reference/triggers/helm-releases-monitoring.rst
@@ -16,51 +16,29 @@ There are two prerequisites for using Helm triggers:
 * The :ref:`Robusta UI` sink must be enabled
 * ``monitorHelmReleases: true`` must be set in Robusta's Helm values
 
-Supported release storage types
---------------------------------
+Secret types and permissions
+-----------------------------
 
-Robusta discovers Helm releases by reading the release state that Helm itself stores in the cluster.
-Only the following storage backend is supported:
+Helm v3 stores release state in Secrets of type ``helm.sh/release.v1`` (the ``secret`` storage
+driver — Helm's default). Robusta reads only these secrets: it lists them across all namespaces with
+the label selector ``owner=helm`` and a ``type`` field selector, and decodes only the ``release``
+payload. The ``configmap`` and ``sql`` storage drivers and Helm v2 are not supported.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 30 45
+The secret types read are configurable in Robusta's Helm values (defaults shown):
 
-   * - Helm storage driver
-     - Kubernetes object read
-     - Supported
-   * - ``secret`` (Helm v3 default)
-     - ``Secret`` of type ``helm.sh/release.v1``, labeled ``owner=helm``
-     - ✅ Yes
-   * - ``configmap``
-     - ``ConfigMap`` with release payload
-     - ❌ No
-   * - ``sql``
-     - External SQL database
-     - ❌ No
-   * - Helm v2 (Tiller)
-     - ``ConfigMap`` in ``kube-system``
-     - ❌ No
+.. code-block:: yaml
 
-When listing secrets, Robusta always applies the label selector ``owner=helm`` and only decodes the
-``release`` payload of matching secrets — the contents of other secrets are never read or sent anywhere.
+    monitorHelmReleases: true
+    helmReleaseSecretTypes:
+      - helm.sh/release.v1
 
-Required permissions
----------------------
+.. note::
 
-Setting ``monitorHelmReleases: true`` adds ``get``, ``list`` and ``watch`` on ``secrets`` to the
-runner's ``ClusterRole``. This grant is cluster-wide, so releases in **all namespaces** are monitored.
-
-This is a Kubernetes RBAC limitation: RBAC rules cannot filter by secret ``type`` or by label, so it is
-not possible to grant access only to ``helm.sh/release.v1`` secrets. Although Robusta itself only reads
-Helm release secrets (see above), the permission technically allows reading any secret in the cluster.
-
-If this grant does not fit your security requirements, you can:
-
-* Keep ``monitorHelmReleases: false`` (the default). No secret read permission is granted, and the
-  runner sets ``DISABLE_HELM_MONITORING`` so it never attempts to list secrets.
-* Replace the runner's RBAC rules entirely with ``runner.overrideClusterRoles`` in Robusta's Helm
-  values, and manage the secret permissions yourself.
+    Enabling ``monitorHelmReleases`` grants the runner's ClusterRole ``get``/``list``/``watch`` on
+    secrets cluster-wide, since Kubernetes RBAC cannot filter by secret type or label. Only secrets
+    matching ``helmReleaseSecretTypes`` are actually read. To avoid the grant entirely, keep
+    ``monitorHelmReleases: false`` (the default), or manage RBAC yourself via
+    ``runner.overrideClusterRoles``.
 
 Triggers
 -----------

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -130,6 +130,9 @@ spec:
           {{- if not .Values.monitorHelmReleases }}
           - name: DISABLE_HELM_MONITORING
             value: "True"
+          {{- else if .Values.helmReleaseSecretTypes }}
+          - name: HELM_RELEASE_SECRET_TYPES
+            value: {{ join "," .Values.helmReleaseSecretTypes | quote }}
           {{- end }}
           {{- if .Values.enableHolmesGPT }}
           - name: HOLMES_ENABLED

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -134,6 +134,12 @@ lightActions:
 enablePrometheusStack: false
 enabledManagedConfiguration: false
 enableServiceMonitors: true
+# monitor Helm releases (all namespaces) and enable on_helm_release_* triggers.
+# Robusta only reads Helm v3 release Secrets (type helm.sh/release.v1, listed with label selector owner=helm);
+# the configmap/sql storage drivers and Helm v2 are not supported.
+# NOTE: enabling this grants the runner ClusterRole get/list/watch on secrets cluster-wide,
+# because Kubernetes RBAC cannot filter by secret type or label.
+# See https://docs.robusta.dev/master/playbook-reference/triggers/helm-releases-monitoring.html
 monitorHelmReleases: false
 argoRollouts: false
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -135,12 +135,16 @@ enablePrometheusStack: false
 enabledManagedConfiguration: false
 enableServiceMonitors: true
 # monitor Helm releases (all namespaces) and enable on_helm_release_* triggers.
-# Robusta only reads Helm v3 release Secrets (type helm.sh/release.v1, listed with label selector owner=helm);
-# the configmap/sql storage drivers and Helm v2 are not supported.
 # NOTE: enabling this grants the runner ClusterRole get/list/watch on secrets cluster-wide,
-# because Kubernetes RBAC cannot filter by secret type or label.
+# because Kubernetes RBAC cannot filter by secret type or label. At runtime the runner only
+# reads secrets matching helmReleaseSecretTypes (with label selector owner=helm).
 # See https://docs.robusta.dev/master/playbook-reference/triggers/helm-releases-monitoring.html
 monitorHelmReleases: false
+# Secret types the runner reads when monitorHelmReleases is enabled. Each type is applied
+# as a field selector (type=<value>) when listing secrets across all namespaces, so only
+# Helm release secrets are ever read. Defaults to Helm v3's secret storage driver.
+helmReleaseSecretTypes:
+  - helm.sh/release.v1
 argoRollouts: false
 
 

--- a/src/robusta/core/discovery/discovery.py
+++ b/src/robusta/core/discovery/discovery.py
@@ -45,6 +45,7 @@ from robusta.core.model.cluster_status import ClusterStats
 from robusta.core.model.env_vars import (
     ARGO_ROLLOUTS,
     DISABLE_HELM_MONITORING,
+    HELM_RELEASE_SECRET_TYPES,
     DISCOVERY_BATCH_SIZE,
     DISCOVERY_MAX_BATCHES,
     DISCOVERY_POD_OWNED_PODS,
@@ -702,29 +703,32 @@ class Discovery:
         if not DISABLE_HELM_MONITORING:
             # discover helm state
             try:
-                continue_ref: Optional[str] = None
-                for _ in range(DISCOVERY_MAX_BATCHES):
-                    secrets = client.CoreV1Api().list_secret_for_all_namespaces(
-                        label_selector="owner=helm", _continue=continue_ref
-                    )
-                    if not secrets.items:
-                        break
+                for secret_type in HELM_RELEASE_SECRET_TYPES:
+                    continue_ref: Optional[str] = None
+                    for _ in range(DISCOVERY_MAX_BATCHES):
+                        secrets = client.CoreV1Api().list_secret_for_all_namespaces(
+                            label_selector="owner=helm",
+                            field_selector=f"type={secret_type}",
+                            _continue=continue_ref,
+                        )
+                        if not secrets.items:
+                            break
 
-                    for secret_item in secrets.items:
-                        release_data = secret_item.data.get("release", None)
-                        if not release_data:
-                            continue
+                        for secret_item in secrets.items:
+                            release_data = secret_item.data.get("release", None)
+                            if not release_data:
+                                continue
 
-                        try:
-                            decoded_release_row = HelmRelease.from_api_server(secret_item.data["release"])
-                            # we use map here to deduplicate and pick only the latest release data
-                            helm_releases_map[decoded_release_row.get_service_key()] = decoded_release_row
-                        except Exception as e:
-                            logging.error(f"an error occurred while decoding helm releases: {e}")
+                            try:
+                                decoded_release_row = HelmRelease.from_api_server(secret_item.data["release"])
+                                # we use map here to deduplicate and pick only the latest release data
+                                helm_releases_map[decoded_release_row.get_service_key()] = decoded_release_row
+                            except Exception as e:
+                                logging.error(f"an error occurred while decoding helm releases: {e}")
 
-                    continue_ref = secrets.metadata._continue
-                    if not continue_ref:
-                        break
+                        continue_ref = secrets.metadata._continue
+                        if not continue_ref:
+                            break
 
             except Exception as e:
                 logging.error(

--- a/src/robusta/core/model/env_vars.py
+++ b/src/robusta/core/model/env_vars.py
@@ -100,6 +100,10 @@ DISCOVERY_BATCH_SIZE = int(os.environ.get("DISCOVERY_BATCH_SIZE", 30000))
 DISCOVERY_POD_OWNED_PODS = load_bool("DISCOVERY_POD_OWNED_PODS", False)
 
 DISABLE_HELM_MONITORING = load_bool("DISABLE_HELM_MONITORING", False)
+# comma-separated secret types read during helm releases discovery, applied as field selectors
+HELM_RELEASE_SECRET_TYPES = [
+    t.strip() for t in os.environ.get("HELM_RELEASE_SECRET_TYPES", "helm.sh/release.v1").split(",") if t.strip()
+]
 DISABLE_FINDINGS_PERSISTENCE = load_bool("DISABLE_FINDINGS_PERSISTENCE", False)
 DISABLE_DISCOVERY = load_bool("DISABLE_DISCOVERY", False)
 DISABLE_RESOURCE_WATCH_PERSISTENCE = load_bool("DISABLE_RESOURCE_WATCH_PERSISTENCE", False)


### PR DESCRIPTION
## Summary

Addresses the deep-scan finding on `runner-service-account.yaml:41`: when `monitorHelmReleases` is enabled, the runner previously listed **all** secrets labeled `owner=helm`. It now restricts reads to specific secret types, configurable via a new Helm value (cluster-wide across all namespaces — intentionally not namespace-restricted).

- **helm/robusta/values.yaml**: new `helmReleaseSecretTypes` value (default `["helm.sh/release.v1"]`) listing the secret types read during helm release discovery.
- **helm/robusta/templates/runner.yaml**: passes the value to the runner as `HELM_RELEASE_SECRET_TYPES` (comma-joined) when `monitorHelmReleases: true`.
- **src/robusta/core/model/env_vars.py**: parses `HELM_RELEASE_SECRET_TYPES` (comma-separated, default `helm.sh/release.v1`).
- **src/robusta/core/discovery/discovery.py**: helm discovery now lists secrets per configured type with `field_selector=type=<type>` in addition to `label_selector=owner=helm`, so only Helm release secrets are ever read.
- **docs/playbook-reference/triggers/helm-releases-monitoring.rst**: documents the supported storage type (Helm v3 `secret` driver only), the new value, and the RBAC note (RBAC can't filter by secret type/label, so the ClusterRole grant remains cluster-wide when enabled; runtime reads are type-scoped).

The RBAC grant itself is unchanged — Kubernetes RBAC cannot express "only `helm.sh/release.v1` secrets" — but the runner's actual reads are now server-side filtered by type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D64P1Je5SdGNuwWZZnxLPh