### PR TITLE
Upgrade Flask dependency to ^3.1.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -820,13 +820,13 @@ files = [
 
 [[package]]
 name = "flask"
-version = "3.1.2"
+version = "3.1.3"
 description = "A simple framework for building complex web applications."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c"},
-    {file = "flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87"},
+    {file = "flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"},
+    {file = "flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb"},
 ]
 
 [package.dependencies]
@@ -4026,4 +4026,4 @@ all = ["Flask", "better-exceptions", "datadog-api-client", "grafana-api", "kafka
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.12"
-content-hash = "6ab0c53929ec30212598ac83308ffd0ab649b6c1808b47740438bf332bab210d"
+content-hash = "c5d7cdbbba8b3be724a8ffe61ea0fc095df31655b409f77693144aeb79bb9842"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ idna= { version = ">=3.15", optional = true }
 supabase = "2.5.1"
 tabulate = { version = "^0.8.10" }
 slack-sdk = { version = "^3.23.0" }
-Flask = { version = "^3.0.0", optional = true }
+Flask = { version = "^3.1.3", optional = true }
 werkzeug = { version = ">=3.1.6", optional = true }
 jinja2 = { version = ">=3.1.5", optional = true }
 grafana-api = { version = "^1.0.3", optional = true }


### PR DESCRIPTION
## Summary
Updated the Flask dependency version constraint to ensure compatibility with newer Flask releases.

## Changes
- Bumped Flask version requirement from `^3.0.0` to `^3.1.3`

## Details
This change allows the project to use Flask 3.1.3 and compatible patch versions, ensuring access to bug fixes and improvements in the Flask 3.1.x release line while maintaining backward compatibility within the same minor version range.

https://claude.ai/code/session_01GhzK6FjeAfaFH3wKDB3g49