### PR TITLE
ROB-944 harden pull configs

### DIFF
--- a/src/robusta/runner/config_loader.py
+++ b/src/robusta/runner/config_loader.py
@@ -41,6 +41,7 @@ from robusta.integrations.scheduled.playbook_scheduler_manager_impl import Playb
 from robusta.integrations.scheduled.trigger import ScheduledTriggerEvent
 from robusta.model.config import PlaybooksRegistry, PlaybooksRegistryImpl, Registry, SinksRegistry
 from robusta.model.playbook_definition import PlaybookDefinition
+from robusta.utils.archive import safe_extract_tar
 from robusta.utils.cluster_provider_discovery import cluster_provider
 from robusta.utils.file_system_watcher import FileSystemWatcher
 from robusta.core.exceptions import SupabaseDnsException
@@ -354,7 +355,7 @@ class ConfigLoader:
             f.flush()
 
             with tarfile.open(f.name, "r:gz") as tar, tempfile.TemporaryDirectory() as temp_dir:
-                tar.extractall(path=temp_dir)
+                safe_extract_tar(tar, temp_dir)
                 extracted_items = os.listdir(temp_dir)
 
                 pkg_path = temp_dir

--- a/src/robusta/utils/archive.py
+++ b/src/robusta/utils/archive.py
@@ -1,0 +1,54 @@
+import os
+import tarfile
+from typing import List
+
+
+class UnsafeArchiveError(Exception):
+    """Raised when a tar archive contains a member that would be extracted outside the target directory."""
+
+
+def _is_within(directory: str, target: str) -> bool:
+    directory = os.path.realpath(directory)
+    target = os.path.realpath(target)
+    return target == directory or target.startswith(directory + os.sep)
+
+
+def _validate_members(tar: tarfile.TarFile, path: str) -> List[tarfile.TarInfo]:
+    members = tar.getmembers()
+    for member in members:
+        if member.isdev():
+            raise UnsafeArchiveError(f"Archive contains a device/fifo member: {member.name}")
+
+        if os.path.isabs(member.name) or member.name.startswith("/"):
+            raise UnsafeArchiveError(f"Archive contains a member with an absolute path: {member.name}")
+
+        if not _is_within(path, os.path.join(path, member.name)):
+            raise UnsafeArchiveError(f"Archive contains a member escaping the target directory: {member.name}")
+
+        if member.issym() or member.islnk():
+            # link targets are resolved relative to the directory holding the link
+            link_base = os.path.join(path, os.path.dirname(member.name))
+            if os.path.isabs(member.linkname) or not _is_within(path, os.path.join(link_base, member.linkname)):
+                raise UnsafeArchiveError(
+                    f"Archive contains a link escaping the target directory: {member.name} -> {member.linkname}"
+                )
+
+    return members
+
+
+def safe_extract_tar(tar: tarfile.TarFile, path: str) -> None:
+    """
+    Extract a tar archive into ``path``, refusing archives whose members would be written outside of it.
+
+    Guards against path traversal ("zip slip"), absolute member paths, escaping symlinks/hardlinks and
+    device nodes. Raises ``UnsafeArchiveError`` without extracting anything if the archive is unsafe.
+    """
+    if hasattr(tarfile, "data_filter"):  # python 3.12+, and 3.10.12+/3.11.4+ backports
+        # pre-validate so that nothing is written before an unsafe member is detected
+        _validate_members(tar, path)
+        try:
+            tar.extractall(path=path, filter="data")
+        except tarfile.FilterError as e:
+            raise UnsafeArchiveError(f"Refusing to extract unsafe archive: {e}") from e
+    else:
+        tar.extractall(path=path, members=_validate_members(tar, path))

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,104 @@
+import io
+import os
+import tarfile
+
+import pytest
+
+from robusta.runner.config_loader import ConfigLoader
+from robusta.utils.archive import UnsafeArchiveError, safe_extract_tar
+
+
+def _make_tgz(archive_path: str, members) -> str:
+    """members: list of (arcname, content) tuples, or TarInfo objects for links."""
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for member in members:
+            if isinstance(member, tarfile.TarInfo):
+                tar.addfile(member)
+                continue
+            arcname, content = member
+            data = content.encode()
+            info = tarfile.TarInfo(name=arcname)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return archive_path
+
+
+def _symlink_member(name: str, linkname: str) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name=name)
+    info.type = tarfile.SYMTYPE
+    info.linkname = linkname
+    return info
+
+
+def _install_remote(monkeypatch, tmp_path, archive_path: str):
+    """Run install_package_remote_tgz against a local archive, without pip-installing anything."""
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=65536):
+            with open(archive_path, "rb") as f:
+                while True:
+                    chunk = f.read(chunk_size)
+                    if not chunk:
+                        return
+                    yield chunk
+
+    monkeypatch.setattr("robusta.runner.config_loader.requests.get", lambda *a, **kw: _FakeResponse())
+    monkeypatch.setattr(ConfigLoader, "install_package", classmethod(lambda cls, **kwargs: None))
+    return ConfigLoader.install_package_remote_tgz(
+        url="https://example.com/pkg.tgz", headers=None, build_isolation=True
+    )
+
+
+def test_remote_tgz_rejects_path_traversal(monkeypatch, tmp_path):
+    archive = _make_tgz(str(tmp_path / "pkg.tgz"), [("../evil.txt", "pwned")])
+
+    with pytest.raises(UnsafeArchiveError):
+        _install_remote(monkeypatch, tmp_path, archive)
+
+    # nothing was written outside the (already deleted) extraction dir
+    assert not any(p.name == "evil.txt" for p in tmp_path.rglob("*"))
+
+
+def test_remote_tgz_rejects_absolute_path(monkeypatch, tmp_path):
+    archive = _make_tgz(str(tmp_path / "pkg.tgz"), [("/tmp/evil.txt", "pwned")])
+
+    with pytest.raises(UnsafeArchiveError):
+        _install_remote(monkeypatch, tmp_path, archive)
+
+
+def test_safe_extract_rejects_symlink_escape(tmp_path):
+    archive = _make_tgz(str(tmp_path / "pkg.tgz"), [_symlink_member("pkg/passwd", "/etc/passwd")])
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    with tarfile.open(archive, "r:gz") as tar:
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_tar(tar, str(dest))
+
+
+def test_safe_extract_rejects_relative_symlink_escape(tmp_path):
+    archive = _make_tgz(str(tmp_path / "pkg.tgz"), [_symlink_member("pkg/escape", "../../outside")])
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    with tarfile.open(archive, "r:gz") as tar:
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_tar(tar, str(dest))
+
+
+def test_safe_extract_allows_normal_package(tmp_path):
+    archive = _make_tgz(
+        str(tmp_path / "pkg.tgz"),
+        [("pkg/__init__.py", ""), ("pkg/pyproject.toml", "[tool.poetry]\n"), ("pkg/sub/mod.py", "x = 1\n")],
+    )
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    with tarfile.open(archive, "r:gz") as tar:
+        safe_extract_tar(tar, str(dest))
+
+    assert os.path.isfile(dest / "pkg" / "__init__.py")
+    assert (dest / "pkg" / "sub" / "mod.py").read_text() == "x = 1\n"


### PR DESCRIPTION
## Problem

`ConfigLoader.install_package_remote_tgz` downloads a `.tgz` from a configured `playbook_repos` URL and extracted it with `tar.extractall(path=temp_dir)` — no `members=` and no `filter=`.

Archive contents are remote and unverified. On the Python versions this project targets (`pyproject.toml` pins `>=3.10,<3.12`; the runner image is `python:3.11-slim`), `extractall()` defaults to `fully_trusted`, so a crafted archive can use `../` or absolute member paths — or escaping symlinks — to write files anywhere as root, before the extracted tree is handed to `pip install` (which executes package build code).

## Changes

- **`src/robusta/utils/archive.py`** (new): `safe_extract_tar()` and `UnsafeArchiveError`. Every member is validated up front — absolute paths, traversal outside the destination, symlink/hardlink targets resolving outside the destination, and device/fifo nodes are rejected. Nothing is extracted if any member is unsafe. On interpreters that provide `tarfile.data_filter`, extraction additionally uses `filter="data"`; otherwise the validated `members=` list is passed. Both paths raise the same error type.
- **`src/robusta/runner/config_loader.py`**: the extraction call now goes through `safe_extract_tar`. The existing `except Exception` in `__load_playbooks_repos` logs and skips the offending repo, so a hostile archive fails that repo rather than crashing the runner.
- **`tests/test_config_loader.py`** (new): traversal and absolute-path members rejected through `install_package_remote_tgz` (with the HTTP fetch and `install_package` stubbed), absolute and relative symlink escapes rejected, and a normal nested package still extracting correctly.

HTTP policy is unchanged — `http://` playbook repo URLs still work with the existing warning.

## Testing

- `pytest tests/test_config_loader.py` — 5 passed.
- `pytest tests/test_config_validation.py tests/test_url_validation.py` — 19 passed, no regressions.
- Forced the non-`data_filter` fallback branch by removing `tarfile.data_filter` at runtime: same rejections, same successful extraction of a benign archive.

## Not addressed here

`requests.get` still follows redirects, and there is no download size cap or package signature verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDcapMbrGMnqTjEfAG8chH)_