### PR TITLE
Docs: clarify pod_ps shows global host PID, not container PID

### DIFF
--- a/playbooks/robusta_playbooks/pod_troubleshooting.py
+++ b/playbooks/robusta_playbooks/pod_troubleshooting.py
@@ -122,6 +122,8 @@ def python_profiler(event: PodEvent, action_params: StartProfilingParams):
 def pod_ps(event: PodEvent, params: PodRunningParams):
     """
     Fetch the list of running processes in a pod.
+
+    Note: the ``pid`` column shows the global (host) PID, not the container-namespaced PID.
     """
     pod = event.get_pod()
     if not pod:


### PR DESCRIPTION
Fixes #162

The `pod_ps` action lists processes using a debugger pod with `hostPID=True`, so the reported PIDs are global host PIDs, not container-namespaced PIDs. This was not documented and caused confusion (issue #162).

This updates the action's docstring, which the autorobusta Sphinx extension renders into the docs site.