### PR TITLE
Docs: dmesg enricher actions + fix pod_dmesg_enricher log message

### DIFF
--- a/docs/playbook-reference/actions/event-enrichment.rst
+++ b/docs/playbook-reference/actions/event-enrichment.rst
@@ -20,6 +20,8 @@ These actions can add context to any node-related event, be it from ``on_prometh
 
 .. robusta-action:: playbooks.robusta_playbooks.node_enrichments.node_graph_enricher
 
+.. robusta-action:: playbooks.robusta_playbooks.node_enrichments.node_dmesg_enricher
+
 .. robusta-action:: playbooks.robusta_playbooks.node_cpu_analysis.node_cpu_enricher
 
 .. .. robusta-action:: playbooks.robusta_playbooks.node_enrichments.node_health_watcher
@@ -41,6 +43,8 @@ These actions can add context to any pod-related event, be it from ``on_promethe
 .. robusta-action:: playbooks.robusta_playbooks.pod_enrichments.pod_node_graph_enricher
 
 .. robusta-action:: playbooks.robusta_playbooks.pod_troubleshooting.pod_ps
+
+.. robusta-action:: playbooks.robusta_playbooks.pod_enrichments.pod_dmesg_enricher
 
 .. robusta-action:: playbooks.robusta_playbooks.image_pull_backoff_enricher.image_pull_backoff_reporter
 

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -107,6 +107,7 @@ lightActions:
 - delete_job
 - list_resource_names
 - node_dmesg_enricher
+- pod_dmesg_enricher
 - status_enricher
 - krr_scan
 - popeye_scan

--- a/playbooks/robusta_playbooks/node_enrichments.py
+++ b/playbooks/robusta_playbooks/node_enrichments.py
@@ -121,7 +121,9 @@ def node_status_enricher(event: NodeEvent):
 @action
 def node_dmesg_enricher(event: NodeEvent, params: PodRunningParams):
     """
-    Gets the dmesg from a node
+    Get the kernel ring buffer messages (dmesg) from the event's node.
+
+    The output is attached to the finding as a file named ``dmesg.log``.
     """
     node = event.get_node()
     if not node:

--- a/playbooks/robusta_playbooks/pod_enrichments.py
+++ b/playbooks/robusta_playbooks/pod_enrichments.py
@@ -90,11 +90,13 @@ def pod_node_graph_enricher(pod_event: PodEvent, params: ResourceGraphEnricherPa
 @action
 def pod_dmesg_enricher(pod_event: PodEvent, params: PodRunningParams):
     """
-    Gets the dmesg from a node
+    Get the kernel ring buffer messages (dmesg) from the node that hosts the event's pod.
+
+    The output is attached to the finding as a file named ``dmesg.log``.
     """
     pod = pod_event.get_pod()
     if not pod:
-        logging.error(f"cannot run pod_node_graph_enricher on event with no pod: {pod_event}")
+        logging.error(f"cannot run pod_dmesg_enricher on event with no pod: {pod_event}")
         return
     node = pod.get_node()
     if not node:


### PR DESCRIPTION
Fixes #549

The dmesg enricher was already implemented (node_dmesg_enricher, pod_dmesg_enricher), but was never surfaced in the docs and pod_dmesg_enricher had a copy-paste bug in its error log. This PR:

- Adds `.. robusta-action::` directives for `node_dmesg_enricher` and `pod_dmesg_enricher` in event-enrichment.rst so they appear in the docs site
- Improves both docstrings to describe what the actions do (kernel ring buffer output attached as `dmesg.log`)
- Fixes pod_dmesg_enricher's error message (was referencing pod_node_graph_enricher)
- Adds `pod_dmesg_enricher` to `lightActions` in the Helm chart, matching `node_dmesg_enricher`