### PR TITLE
Fix shell variable expansion in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,9 +46,9 @@ jobs:
 
       - name: Update package version
         run: |
-          sed -i 's/0.0.0/${{env.RELEASE_VER}}/g' src/robusta/_version.py helm/robusta/Chart.yaml helm/robusta/values.yaml
-          sed -i 's/version = "0.0.0"/version = "${{env.RELEASE_VER}}"/g' pyproject.toml
-          sed -i 's/0.0.1/${{env.RELEASE_VER}}/g' helm/robusta/Chart.yaml
+          sed -i "s/0.0.0/$RELEASE_VER/g" src/robusta/_version.py helm/robusta/Chart.yaml helm/robusta/values.yaml
+          sed -i "s/version = \"0.0.0\"/version = \"$RELEASE_VER\"/g" pyproject.toml
+          sed -i "s/0.0.1/$RELEASE_VER/g" helm/robusta/Chart.yaml
 
       # Set up the buildx to run build for multiple platforms
       - name: Set up QEMU
@@ -79,7 +79,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build with skaffold
-        run: ./skaffold build --profile release --file-output=container-ids.json --tag='${{env.RELEASE_VER}}'
+        run: ./skaffold build --profile release --file-output=container-ids.json --tag="$RELEASE_VER"
 
       - name: Save artifact with tags of built containers
         uses: actions/upload-artifact@v4
@@ -116,7 +116,7 @@ jobs:
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --platform linux/arm64,linux/amd64 \
           --cache-from us-central1-docker.pkg.dev/genuine-flight-317411/devel/robusta:cache \
-          --tag robustadev/robusta-runner:${{env.RELEASE_VER}} \
+          --tag "robustadev/robusta-runner:$RELEASE_VER" \
           --push \
           .
 
@@ -134,4 +134,4 @@ jobs:
       - name: Push Helm chart to OCI registry
         run: |
           helm package helm/robusta
-          helm push robusta-${{env.RELEASE_VER}}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push "robusta-$RELEASE_VER.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"


### PR DESCRIPTION
## Summary
Updated the release workflow to use double quotes instead of single quotes for environment variable expansion in shell commands. This ensures that `$RELEASE_VER` and other variables are properly interpolated at runtime rather than being treated as literal strings.

## Key Changes
- Changed `sed` commands from single quotes to double quotes to enable proper variable expansion of `$RELEASE_VER`
- Updated skaffold build command to use double quotes for the `--tag` parameter
- Added quotes around Docker image tag to properly handle variable expansion
- Added quotes around Helm chart filename and OCI registry path for consistency and proper variable expansion

## Implementation Details
The changes follow shell scripting best practices by using double quotes when variable expansion is needed. This ensures that environment variables set earlier in the workflow (like `RELEASE_VER`) are correctly substituted into commands rather than being passed as literal `$RELEASE_VER` strings, which would cause version updates and deployments to fail.

https://claude.ai/code/session_01QCBS4ZhVcGUzibiHGxTGVc