### PR TITLE
Upgrade kubewatch image to v2.16.1

### DIFF
--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -641,7 +641,7 @@ image:
 # parameters for the robusta forwarder deployment
 kubewatch:
   image: ~ # image can be used to override image.registry/imageName
-  imageName: kubewatch:v2.16.0
+  imageName: kubewatch:v2.16.1
   imagePullPolicy: IfNotPresent
   revisionHistoryLimit: 10
   pprof: True


### PR DESCRIPTION
## Summary
Updates the kubewatch forwarder deployment image version from v2.16.0 to v2.16.1.

## Changes
- Bumped kubewatch image version to v2.16.1 in the Helm values configuration

## Details
This is a patch version upgrade for the kubewatch component used in the robusta forwarder deployment. The change updates the `imageName` parameter in the Helm values to pull the latest patch release.

https://claude.ai/code/session_01Q9j4ub2dDMZPYhe3mvA1eD