### PR TITLE
Add conversation_link pass-through field to Holmes chat params

### DIFF
--- a/src/robusta/core/model/base_params.py
+++ b/src/robusta/core/model/base_params.py
@@ -213,6 +213,10 @@ class HolmesChatParams(HolmesParams):
     source_ref: Optional[str] = None
     conversation_id: Optional[str] = None
     conversation_source: Optional[str] = None
+    # URL of the surface the chat originated from (Slack thread permalink,
+    # Teams message link, platform chat/workflow-run URL). Holmes renders it
+    # into the system prompt so PRs/issues it creates link back to it.
+    conversation_link: Optional[str] = None
     is_internal: Optional[bool] = None
     meta: Optional[Dict[str, Any]] = None
 

--- a/src/robusta/core/reporting/holmes.py
+++ b/src/robusta/core/reporting/holmes.py
@@ -57,6 +57,10 @@ class HolmesChatRequest(BaseModel):
     source_ref: Optional[str] = None
     conversation_id: Optional[str] = None
     conversation_source: Optional[str] = None
+    # URL of the surface the chat originated from (Slack thread permalink,
+    # Teams message link, platform chat/workflow-run URL). Holmes renders it
+    # into the system prompt so PRs/issues it creates link back to it.
+    conversation_link: Optional[str] = None
     is_internal: Optional[bool] = None
     meta: Optional[Dict[str, Any]] = None
 


### PR DESCRIPTION
## What

Adds an optional `conversation_link` field to `HolmesChatParams` (`src/robusta/core/model/base_params.py`) and `HolmesChatRequest` (`src/robusta/core/reporting/holmes.py`). It carries the URL of the surface a chat originated from (Slack thread permalink, Teams message link, platform chat/workflow-run URL); Holmes renders it into its system prompt so any PR/MR/issue it creates links back to the originating conversation.

Pure pass-through — no behavior change in robusta itself. Old Holmes versions ignore the field; new Holmes validates it before rendering (shape + origin allowlist) — see the holmesgpt PR.

Companion PRs in holmesgpt (prompt rendering + validation), relay (link construction per chat surface), and robusta-frontend (platform chat URLs). Relay PR: robusta-dev/relay#748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5Lu9XsDRPWEANCEg9hYDS