### PR TITLE
ROB-1256 Backport perl/glibc/git CVE fixes from Debian forky

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,10 +84,23 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends libexpat1 libc6 libc-bin libcap2 \
     && rm -rf /var/lib/apt/lists/*
 
+# Debian trixie ships no fix for libssh2/attr/acl or perl ("vulnerable, no DSA" in the
+# Debian security tracker), so the patched packages are pulled from forky with a
+# per-package pin. Nothing else is resolved against testing - the preferences file below
+# blocks every forky package except the ones named, and the sources are removed again in
+# the same layer.
+# - libssh2/libattr1/libacl1: CVE-2026-58050/58051/66032/66033/66034/66035, CVE-2026-54371,
+#   CVE-2026-54369/54370.
+# - perl-base/perl: CVE-2026-57433, CVE-2026-13221, CVE-2026-57432, CVE-2026-15534,
+#   CVE-2026-19487. forky's perl pre-depends on glibc >= 2.43, so libc6/libc-bin/
+#   libc-gconv-modules-extra/libcrypt1 come along too. git hard-depends on perl (Debian
+#   builds them from the same source with locked versions), so git/git-man/liberror-perl/
+#   perl-modules-5.42/libperl5.42 are pulled up to forky's git 2.53.0 as well - trying to
+#   pin perl-base alone makes apt remove git instead of upgrading it.
 RUN echo 'deb http://deb.debian.org/debian forky main' > /etc/apt/sources.list.d/forky.list \
-    && printf 'Package: libssh2-1t64 libattr1 libacl1\nPin: release n=forky\nPin-Priority: 990\n\nPackage: *\nPin: release n=forky\nPin-Priority: -1\n' > /etc/apt/preferences.d/99-forky \
+    && printf 'Package: libssh2-1t64 libattr1 libacl1 perl-base perl perl-modules-5.42 libperl5.42 liberror-perl git git-man libc6 libcrypt1 libc-bin libc-gconv-modules-extra\nPin: release n=forky\nPin-Priority: 990\n\nPackage: *\nPin: release n=forky\nPin-Priority: -1\n' > /etc/apt/preferences.d/99-forky \
     && apt-get update \
-    && apt-get install -y --no-install-recommends libssh2-1t64 libattr1 libacl1 \
+    && apt-get install -y --no-install-recommends libssh2-1t64 libattr1 libacl1 perl-base perl perl-modules-5.42 libperl5.42 liberror-perl git git-man libc6 libcrypt1 libc-bin libc-gconv-modules-extra \
     && rm -f /etc/apt/sources.list.d/forky.list /etc/apt/preferences.d/99-forky \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,9 @@ RUN apt-get update \
 # Debian security tracker), so the patched packages are pulled from forky with a
 # per-package pin. Nothing else is resolved against testing - the preferences file below
 # blocks every forky package except the ones named, and the sources are removed again in
-# the same layer.
+# the same layer. Package names are ":any"-qualified (and so is the "Package: *" block)
+# because arm64 is registered as a foreign architecture below - an unqualified name only
+# pins the native arch, which would leave arm64 resolution unpinned/unblocked.
 # - libssh2/libattr1/libacl1: CVE-2026-58050/58051/66032/66033/66034/66035, CVE-2026-54371,
 #   CVE-2026-54369/54370.
 # - perl-base/perl: CVE-2026-57433, CVE-2026-13221, CVE-2026-57432, CVE-2026-15534,
@@ -98,7 +100,7 @@ RUN apt-get update \
 #   perl-modules-5.42/libperl5.42 are pulled up to forky's git 2.53.0 as well - trying to
 #   pin perl-base alone makes apt remove git instead of upgrading it.
 RUN echo 'deb http://deb.debian.org/debian forky main' > /etc/apt/sources.list.d/forky.list \
-    && printf 'Package: libssh2-1t64 libattr1 libacl1 perl-base perl perl-modules-5.42 libperl5.42 liberror-perl git git-man libc6 libcrypt1 libc-bin libc-gconv-modules-extra\nPin: release n=forky\nPin-Priority: 990\n\nPackage: *\nPin: release n=forky\nPin-Priority: -1\n' > /etc/apt/preferences.d/99-forky \
+    && printf 'Package: libssh2-1t64:any libattr1:any libacl1:any perl-base:any perl:any perl-modules-5.42:any libperl5.42:any liberror-perl:any git:any git-man:any libc6:any libcrypt1:any libc-bin:any libc-gconv-modules-extra:any\nPin: release n=forky\nPin-Priority: 990\n\nPackage: *:any\nPin: release n=forky\nPin-Priority: -1\n' > /etc/apt/preferences.d/99-forky \
     && apt-get update \
     && apt-get install -y --no-install-recommends libssh2-1t64 libattr1 libacl1 perl-base perl perl-modules-5.42 libperl5.42 liberror-perl git git-man libc6 libcrypt1 libc-bin libc-gconv-modules-extra \
     && rm -f /etc/apt/sources.list.d/forky.list /etc/apt/preferences.d/99-forky \


### PR DESCRIPTION
## Summary

Fixes the `perl:5.40.1-6` critical finding (5 CVEs, CVSS 9.8) flagged against the runner image. Debian trixie has no patched perl - all 5 CVEs are marked **"vulnerable, no DSA"** on the Debian security tracker, meaning Debian itself has assessed them as not warranting a backported fix. The only actual fix is Debian **forky** (testing)'s `perl-base 5.42.3-1`.

This extends the existing per-package forky pin (already used to backport the `libssh2`/`libattr1`/`libacl1` fix in a prior PR) to also cover perl and its full dependency closure:

- `perl-base`, `perl`, `perl-modules-5.42`, `libperl5.42` → fixes `CVE-2026-57433`, `CVE-2026-13221`, `CVE-2026-57432`, `CVE-2026-15534`, `CVE-2026-19487`
- `libc6`, `libc-bin`, `libc-gconv-modules-extra`, `libcrypt1` → forky's perl pre-depends on `glibc >= 2.43`, unavailable in trixie
- `git`, `git-man`, `liberror-perl` → Debian's `git` package hard-depends on `perl` at a matched version, so pinning perl-base alone makes apt **remove git** instead of upgrading it (confirmed by testing). Picking up forky's git bumps it 2.47.3 → 2.53.0.

Nothing else moves - the per-package pin (`Pin-Priority: 990` for the named packages, `-1` for everything else in forky) keeps the resolution closed. Verified via a full `dpkg -l` diff between the old and new image that no unrelated package (`libssl3t64`, `curl`, coreutils, etc.) changed.

## Why not something narrower

- Bumping the `python:X.Y-slim` base image tag doesn't help - `3.12`/`3.13`/`3.14-slim` all currently resolve to the same Debian trixie base with the same vulnerable perl.
- Removing `perl-base` outright isn't possible while keeping `git` - Debian's `git` package has a hard `Depends: perl`, confirmed by testing (removing perl-base cascades into removing git, liberror-perl, and the perl packages together).

## Testing

- **Build**: full multi-stage image builds cleanly (`docker build`).
- **Package diff**: `dpkg -l` diff between baseline and patched image shows exactly the packages listed above changed, nothing else.
- **Compiled extensions**: `cryptography` (the dependency most sensitive to a glibc bump) imports and works in the patched image; `kubernetes` client and `robusta` package import fine.
- **Test suite**: full `pytest` run gives identical results on both images - 375 passed, 19 failed, 17 skipped, 1 error. The failures are pre-existing environment issues (no live k8s cluster in the sandbox), not regressions.
- **Git functional test**: stood up a real SSH git server in a container and drove the actual `GitRepo` class (`src/robusta/integrations/git/git_repo.py`) against it over SSH with a real key - the exact `GIT_SSH_COMMAND` path used for cloning custom playbook repos and for the git-audit playbook. Exercised the full command surface: `clone` (SSH), `add`, `commit`, `push`, `pull --rebase -Xtheirs`, `log --since`, `rm`. All passed identically on git 2.53.0 (patched) and git 2.47.3 (baseline) - no behavioral differences found.
- **kubectl / curl / ssh**: all functional post-bump.

## Test plan
- [ ] CI build passes (multi-arch, matches this local single-arch validation)
- [ ] Scanner re-run confirms the 5 perl CVEs are cleared
- [ ] Smoke-test a real custom playbook repo clone (`git@`) against a production-like cluster before/alongside rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)