### PR TITLE
ROB-1364 Fix missing text in Holmes PromQL chart renderings sent to Slack

### DIFF
--- a/src/robusta/core/reporting/custom_rendering.py
+++ b/src/robusta/core/reporting/custom_rendering.py
@@ -37,6 +37,15 @@ def charts_style(
         opacity_hover=".9",
         transition="400ms ease-in",
         colors=graph_colors,
+        # pygal's own default font stack ("Consolas, Liberation Mono, Menlo, Courier,
+        # monospace") has no match in our chart-rendering image (only fonts-dejavu-core is
+        # installed there), and resvg does exact font-family matching with no fontconfig-style
+        # generic-family fallback - so with the default, resvg silently drops every
+        # title/axis/legend text element while still drawing the plotted lines. "DejaVu Sans
+        # Mono" is the font we know that package provides. Setting it here propagates to every
+        # *_font_family Style attribute (title/legend/label/tooltip/...), since pygal's
+        # Style.__init__ defaults each of those to font_family when unset.
+        font_family="DejaVu Sans Mono",
     )
 
 
@@ -50,15 +59,15 @@ class PlotCustomCSS:
                   {{ id }}.title {
                     fill: #11383A;
                   }
-    
+
                   {{ id }}.legends .legend text {
                     fill: #3f3f3f;
                   }
-              
+
                   {{ id }}.axis.y text {
                     fill: #3f3f3f;
                   }
-    
+
                   {{ id }}.axis.x text {
                     fill: #3f3f3f;
                   }


### PR DESCRIPTION
## Summary
- PromQL/resource charts rendered by Holmes and sent to Slack (and other chat sinks) were missing all text - title, axis labels, and legend - while the plotted lines/dots still rendered fine.
- Root cause: pygal's default font stack (`Consolas, "Liberation Mono", Menlo, Courier, monospace`) has no match in the runner image, which only installs `fonts-dejavu-core`. `resvg` (the SVG->PNG rasterizer used for chat-sink images) does exact font-family matching with no fontconfig-style generic-family fallback, so it silently drops every `<text>` element when none of the requested font names are installed - no exception, no log, nothing to catch.
- This was a latent regression from #2136 (CairoSVG -> resvg-py swap): CairoSVG/Pango did fontconfig-based generic-family substitution, so `fonts-dejavu-core` worked fine under the old rasterizer; resvg does not do that substitution, so the same font package stopped being enough once the rasterizer changed.
- Fix: pin `charts_style()`'s `font_family` to `"DejaVu Sans Mono"`, the font `fonts-dejavu-core` actually provides. pygal's `Style.__init__` defaults every other `*_font_family` attribute (title/legend/axis label/tooltip/...) to `font_family` when unset, so this one line fixes text rendering everywhere pygal draws it.

## Root cause verification
Reproduced in a container matching the runner image's exact font install (`fonts-dejavu-core` only, no `fontconfig` package), running the real chart pipeline (`build_chart_from_prometheus_result` -> `convert_svg_to_png`):
- Before the fix: title, axis labels, and legend text are all absent; only the line/dots/legend swatch render.
- After the fix: all text renders correctly.

Also confirmed adding the `fontconfig` package alone does **not** fix it - resvg's font matching isn't fontconfig-driven, it needs a literal family-name match, which is why the fix targets the font name pygal requests rather than the Dockerfile.

## Test plan
- [x] Rebuilt a container replicating the runner's exact font install and ran the real (patched) `custom_rendering.py` through the real `pygal` -> `resvg_py` pipeline; confirmed text renders correctly.
- [x] Confirmed the same setup without the fix reproduces the reported bug (title/axis/legend text missing, lines still render).
- [x] CI (pytest / pre-commit)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>