### PR TITLE
helm: configurable liveness, readiness and startup probes + named container ports

### DIFF
--- a/docs/setup-robusta/health-probes.rst
+++ b/docs/setup-robusta/health-probes.rst
@@ -9,15 +9,13 @@ Nothing is rendered unless you set it, so the default install is unaffected.
 Available Endpoints
 -------------------------------------
 
-The runner serves HTTP on port ``5000``:
+The runner serves HTTP on port ``5000``, named ``http``:
 
 * ``/metrics`` - available as soon as the web server starts, independent of any external service.
 * ``/healthz`` - ``200`` only when every configured sink reports healthy, ``500`` otherwise.
 
-The forwarder serves ``/metrics`` on port ``2112``. It has no ``/healthz``; any other path returns ``404``.
-The port is bound at process start, before the watch loop syncs.
-
-Neither container declares named ports, so probe ports must be numeric.
+The forwarder serves ``/metrics`` on port ``2112``, named ``metrics``. It has no ``/healthz``; any other path
+returns ``404``. The port is bound at process start, before the watch loop syncs.
 
 Recommended Configuration
 -------------------------------------
@@ -28,30 +26,25 @@ Recommended Configuration
       startupProbe:
         httpGet:
           path: /metrics
-          port: 5000
+          port: http
         failureThreshold: 30
         periodSeconds: 10
       livenessProbe:
         httpGet:
           path: /metrics
-          port: 5000
+          port: http
         periodSeconds: 30
       readinessProbe:
         httpGet:
           path: /healthz
-          port: 5000
+          port: http
         periodSeconds: 15
 
     kubewatch:
       livenessProbe:
         httpGet:
           path: /metrics
-          port: 2112
-        periodSeconds: 30
-      readinessProbe:
-        httpGet:
-          path: /metrics
-          port: 2112
+          port: metrics
         periodSeconds: 15
 
 Any probe field Kubernetes accepts can be used, including ``tcpSocket`` and ``exec``.
@@ -71,3 +64,28 @@ Service and blocks a rollout from proceeding, without restarting anything.
 Note that probes are not how you detect a misconfigured install. A runner that cannot reach the Kubernetes API,
 or a forwarder without a usable kubeconfig, exits at startup and lands in ``CrashLoopBackOff``, which Kubernetes
 already reports on its own.
+
+Why Reference Ports By Name
+-------------------------------------
+
+Both containers declare their port with a name, and the examples above use the name rather than ``5000`` or
+``2112``. Prefer the name in anything you write yourself:
+
+* **The number stops being repeated.** A probe that says ``port: http`` keeps working if the listen port
+  changes. A probe hardcoding ``5000`` has to be found and updated, and silently probes the wrong port until
+  someone notices.
+* **It says what the port is for.** ``port: http`` is readable in a review; ``port: 5000`` needs a lookup.
+* **Other Kubernetes objects resolve names too.** NetworkPolicy rules and Prometheus Operator scrape configs
+  accept a container port name and resolve it per pod, so one rename does not have to be chased across objects.
+* **A typo says so.** A probe naming a port no container declares reports
+  ``port "..." not found``. A probe with the wrong number reports a generic connection refused, which looks
+  the same as an application that is genuinely down.
+
+Port names are more constrained than Service port names: at most 15 characters, lowercase alphanumeric and
+dashes, and unique within the pod.
+
+One place to keep using the number is a Service ``targetPort``, which is why both Services still say
+``targetPort: 5000`` and ``targetPort: 2112``. A numeric ``targetPort`` resolves whether or not the pod
+declares the name, while a named one resolves per pod - so during an upgrade from a chart version whose pods
+had no named port, pods stay ``Ready`` but their endpoints are published with no port at all, and the Service
+black-holes traffic until the rollout finishes.

--- a/docs/setup-robusta/health-probes.rst
+++ b/docs/setup-robusta/health-probes.rst
@@ -1,0 +1,73 @@
+Health Probes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Robusta ships without Kubernetes health probes. If your platform requires them - for example a policy that
+rejects containers with no ``livenessProbe`` - you can define them yourself on the runner and the forwarder.
+
+Nothing is rendered unless you set it, so the default install is unaffected.
+
+Available Endpoints
+-------------------------------------
+
+The runner serves HTTP on port ``5000``:
+
+* ``/metrics`` - available as soon as the web server starts, independent of any external service.
+* ``/healthz`` - ``200`` only when every configured sink reports healthy, ``500`` otherwise.
+
+The forwarder serves ``/metrics`` on port ``2112``. It has no ``/healthz``; any other path returns ``404``.
+The port is bound at process start, before the watch loop syncs.
+
+Neither container declares named ports, so probe ports must be numeric.
+
+Recommended Configuration
+-------------------------------------
+
+.. code-block:: yaml
+
+    runner:
+      startupProbe:
+        httpGet:
+          path: /metrics
+          port: 5000
+        failureThreshold: 30
+        periodSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /metrics
+          port: 5000
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 5000
+        periodSeconds: 15
+
+    kubewatch:
+      livenessProbe:
+        httpGet:
+          path: /metrics
+          port: 2112
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          path: /metrics
+          port: 2112
+        periodSeconds: 15
+
+Any probe field Kubernetes accepts can be used, including ``tcpSocket`` and ``exec``.
+
+Choosing an Endpoint
+-------------------------------------
+
+Use ``/metrics`` for liveness. It restarts the pod only when the process is genuinely wedged.
+
+Avoid ``/healthz`` for liveness. Because it tracks sink health, a transient outage at Slack or another sink
+would restart the runner repeatedly while nothing is wrong with the runner itself. Robusta shipped a liveness
+probe on ``/healthz`` in early 2023 and removed it again for this reason.
+
+``/healthz`` is a reasonable readiness endpoint if you want a sink-aware signal - it takes the pod out of the
+Service and blocks a rollout from proceeding, without restarting anything.
+
+Note that probes are not how you detect a misconfigured install. A runner that cannot reach the Kubernetes API,
+or a forwarder without a usable kubeconfig, exits at startup and lands in ``CrashLoopBackOff``, which Kubernetes
+already reports on its own.

--- a/docs/setup-robusta/index.rst
+++ b/docs/setup-robusta/index.rst
@@ -22,6 +22,7 @@
    read-only-service-account
    rbac-namespace-scoping
    node-selector
+   health-probes
    proxies
    privacy-and-security
    installation-faq

--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -49,6 +49,10 @@ spec:
         image: {{ .Values.image.registry }}/{{ .Values.kubewatch.imageName }}
         {{- end }}
         imagePullPolicy: {{ .Values.kubewatch.imagePullPolicy }}
+        ports:
+          - name: metrics
+            containerPort: 2112
+            protocol: TCP
         env:
           - name: KW_CONFIG
             value: /config

--- a/helm/robusta/templates/forwarder.yaml
+++ b/helm/robusta/templates/forwarder.yaml
@@ -67,6 +67,18 @@ spec:
         securityContext:
         {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.kubewatch.startupProbe }}
+        startupProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kubewatch.livenessProbe }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kubewatch.readinessProbe }}
+        readinessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
           requests:
             cpu: {{ .Values.kubewatch.resources.requests.cpu }}

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -197,6 +197,18 @@ spec:
           {{- with .Values.runner.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- with .Values.runner.startupProbe }}
+        startupProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.runner.livenessProbe }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.runner.readinessProbe }}
+        readinessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:

--- a/helm/robusta/templates/runner.yaml
+++ b/helm/robusta/templates/runner.yaml
@@ -104,6 +104,10 @@ spec:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- end }}
+        ports:
+          - name: http
+            containerPort: 5000
+            protocol: TCP
         env:
           - name: PLAYBOOKS_CONFIG_FILE_PATH
             value: /etc/robusta/config/active_playbooks.yaml

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -651,6 +651,17 @@ kubewatch:
       memory: 512Mi
     limits:
       cpu: ~
+  # health probes, rendered only when set. ports must be numeric - the container declares no named ports
+  # /metrics is served as soon as the process is up, before the watch loop syncs
+  # e.g.
+  # livenessProbe:
+  #   httpGet:
+  #     path: /metrics
+  #     port: 2112
+  #   periodSeconds: 30
+  startupProbe: {}
+  livenessProbe: {}
+  readinessProbe: {}
   additional_env_vars:
   - name: ADVANCED_FILTERS
     value: "true"
@@ -741,6 +752,18 @@ runner:
       memory: 1024Mi
     limits:
       cpu: ~
+  # health probes, rendered only when set. ports must be numeric - the container declares no named ports
+  # /metrics is up whenever the web server is; /healthz additionally reflects sink health, so it
+  # suits readiness but will restart the pod on a transient sink outage if used for liveness
+  # e.g.
+  # livenessProbe:
+  #   httpGet:
+  #     path: /metrics
+  #     port: 5000
+  #   periodSeconds: 30
+  startupProbe: {}
+  livenessProbe: {}
+  readinessProbe: {}
   additional_env_vars: []
   additional_env_froms: []
   customCRD: []

--- a/helm/robusta/values.yaml
+++ b/helm/robusta/values.yaml
@@ -651,13 +651,13 @@ kubewatch:
       memory: 512Mi
     limits:
       cpu: ~
-  # health probes, rendered only when set. ports must be numeric - the container declares no named ports
+  # health probes, rendered only when set. reference the container port by name
   # /metrics is served as soon as the process is up, before the watch loop syncs
   # e.g.
   # livenessProbe:
   #   httpGet:
   #     path: /metrics
-  #     port: 2112
+  #     port: metrics
   #   periodSeconds: 30
   startupProbe: {}
   livenessProbe: {}
@@ -752,14 +752,14 @@ runner:
       memory: 1024Mi
     limits:
       cpu: ~
-  # health probes, rendered only when set. ports must be numeric - the container declares no named ports
+  # health probes, rendered only when set. reference the container port by name
   # /metrics is up whenever the web server is; /healthz additionally reflects sink health, so it
   # suits readiness but will restart the pod on a transient sink outage if used for liveness
   # e.g.
   # livenessProbe:
   #   httpGet:
   #     path: /metrics
-  #     port: 5000
+  #     port: http
   #   periodSeconds: 30
   startupProbe: {}
   livenessProbe: {}


### PR DESCRIPTION
## What

Adds `livenessProbe`, `readinessProbe` and `startupProbe` values for the runner and the forwarder, rendered only when set, and names the container ports so probes can reference them by name (`http`/5000 on the runner, `metrics`/2112 on the forwarder).

New docs page at `docs/setup-robusta/health-probes.rst` covering which endpoints each component actually serves, which to point probes at, and why to reference ports by name.

The only change to a default render is the two `ports:` blocks, so existing installs get one pod restart on upgrade and no other behavior change.

## Why

Follows the endpoint/history writeup and proposal in #1158, which @adamantal 👍'd.

- `/healthz` reflects sink health, so a liveness probe on it restarts the runner whenever a sink flaps — nothing is wrong with the runner. That is what the 2023 probes did (#825, #845) before `2b2292c5` reverted them, and #1960 stalled after re-adding pod probes. Liveness on `/metrics` restarts only a genuinely wedged process; `/healthz` is documented as a readiness option for anyone who wants the sink-aware signal.
- Forwarder has no `/healthz` — only `/metrics` on `:2112` — so that is what the docs point at.
- Default-off keeps this out of the way of anyone who doesn't want probes, while unblocking platforms that require them.
- Named ports mean a probe reads `port: http` instead of repeating `5000`, survives a listen-port change, and resolves in NetworkPolicy and Prometheus Operator configs too. A name that no container declares also fails with an explicit `port "..." not found` rather than a generic connection refused.

Service `targetPort` deliberately stays numeric. A named `targetPort` resolves per pod, so upgrading from a chart version whose pods had no named port leaves the old pod `Ready` with its endpoint published with no port at all — I checked on kind and the EndpointSlice comes back `ports: null` — and the Service black-holes traffic until the rollout finishes. Numeric resolves either way. It can move to the name in a later version once no supported upgrade path starts from unnamed pods.

Note on the original report: `automountServiceAccountToken: false` no longer produces a running-but-unready pod. On 0.49.0 the runner exits on its first API call and the forwarder exits `fatal` on the missing kubeconfig, so both land in `CrashLoopBackOff` — Kubernetes already reports that. Probes here are for wedged processes, slow starts, and rollout/Service gating; the docs say so rather than implying they detect misconfiguration.

## Testing

Installed on kind twice — once with numeric probe ports, once with all probes referencing the names (`port: http`, `port: metrics`). Both pods reached `1/1 Ready` with 0 restarts, and EndpointSlices kept real ports. Confirmed `helm template` is byte-identical to master apart from the two `ports:` blocks, and rendered clean with `runner.hardenedFs=true` and `grafanaRenderer.enableContainer=true`.
